### PR TITLE
http.createRequest was removed in Node 7

### DIFF
--- a/test/node_exports.js
+++ b/test/node_exports.js
@@ -74,7 +74,7 @@ describe("Node modules and exports", (done) => {
                 "index.js": `module.exports = require("http")`
             }
         }, "> index.js").then(data => {
-            data.myLib.createClient.should.be.ok;
+            data.myLib.request.should.be.ok;
             done();
         }).catch(done);
     });


### PR DESCRIPTION
Fixed failing test: http.createClient was deprecated earlier and now removed in Node 7