### PR TITLE
ChainPlugin Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Will result in:
 
 Whereas `a.js` and  `b.js` are files in folder `batch`
 
-You can requires all JSON files for example:
+You can require all JSON files for example:
 
 ```
 FuseBox.import("./batch/*.json")

--- a/_playground/_build/index.html
+++ b/_playground/_build/index.html
@@ -2,23 +2,16 @@
 <html>
 
 <head>
-    <title></title>
+    <title>Welcome to FuseBox</title>
 </head>
-
 
 <body>
     <div id="root"></div>
     <script type="text/javascript" charset="utf-8" src="out.js?1"></script>
-    <h1>Hello</h1>
-    <script>
-        FuseBox.dynamic("custom/foo.js", 'module.exports = {stuff : "hello"}');
-
-        // var s = document.createElement("style");
-        // s.innerHTML = "body { background-color:red !important; }";
-        // document.getElementsByTagName("head")[0].appendChild(s);
-    </script>
-
-
+    <h1>Welcome to <span class="fuse-box">FuseBox!</span></h1>
+    <section>
+        The simplest and fastest bundler around! 
+    </section>
 </body>
 
 </html>

--- a/_playground/bundle.js
+++ b/_playground/bundle.js
@@ -19,12 +19,13 @@ let fuseBox = FuseBox.init({
     modulesFolder: "_playground/npm",
     //plugins: [new build.TypeScriptHelpers(), build.JSONPlugin, new build.CSSPlugin({ minify: true })]
     plugins: [
+        FuseBox.chain('.less').forTest(/\.less$/).add(build.LESSPlugin({})).add(build.CSSPlugin({})),
         build.TypeScriptHelpers(),
         build.JSONPlugin(),
-        build.CSSPlugin({
-            minify: true
-                // serve: path => `./${path}`
-        })
+        // build.CSSPlugin({
+        //     minify: true
+        //         // serve: path => `./${path}`
+        // })
     ]
 });
 

--- a/_playground/bundle.js
+++ b/_playground/bundle.js
@@ -1,11 +1,12 @@
-const build = require("./../build/commonjs/index.js");
-const watch = require("watch");
-
-//global.Promise = require('bluebird')
-const FuseBox = build.FuseBox;
 const fs = require("fs");
+const watch = require("watch");
+const precss = require("precss");
+const build = require("./../build/commonjs/index.js");
+const FuseBox = build.FuseBox;
+const POST_CSS_PLUGINS = [precss()];
 
-let fuseBox = FuseBox.init({
+const fuseBox = FuseBox.init({
+    extensions: ['.less'],
     homeDir: "_playground/ts",
     // sourceMap: {
     //     bundleReference: "./sourcemaps.js.map",
@@ -17,15 +18,14 @@ let fuseBox = FuseBox.init({
     //package: "myLib",
     //globals: { myLib: "myLib" },
     modulesFolder: "_playground/npm",
-    //plugins: [new build.TypeScriptHelpers(), build.JSONPlugin, new build.CSSPlugin({ minify: true })]
     plugins: [
-        FuseBox.chain('.less').forTest(/\.less$/).add(build.LESSPlugin({})).add(build.CSSPlugin({})),
         build.TypeScriptHelpers(),
         build.JSONPlugin(),
-        // build.CSSPlugin({
-        //     minify: true
-        //         // serve: path => `./${path}`
-        // })
+        build.ChainPlugin(/.less$/, [build.LESSPlugin(), build.CSSPlugin()]),
+        build.ChainPlugin(/.css$/, [build.PostCSSPlugin(POST_CSS_PLUGINS), build.CSSPlugin({
+            minify: true,
+            serve: path => `./${path}`
+        })])
     ]
 });
 

--- a/_playground/ts/index.ts
+++ b/_playground/ts/index.ts
@@ -1,5 +1,5 @@
-
 import "./hello.js"
+import "./less/styles.less";
 declare const FuseBox: any;
 
 let results = FuseBox.import("./batch/*")

--- a/_playground/ts/less/styles.less
+++ b/_playground/ts/less/styles.less
@@ -1,0 +1,10 @@
+@import "ts/less/vars";
+
+.something {
+    background-color: @background-colour;
+    color: @colour;
+
+    .foo {
+        width: 200px;
+    }
+}

--- a/_playground/ts/less/styles.less
+++ b/_playground/ts/less/styles.less
@@ -1,10 +1,11 @@
 @import "ts/less/vars";
 
-.something {
+html, body {
     background-color: @background-colour;
     color: @colour;
+    font-family: Tahoma;
 
-    .foo {
-        width: 200px;
+    .fuse-box {
+        color: red;
     }
 }

--- a/_playground/ts/less/vars.less
+++ b/_playground/ts/less/vars.less
@@ -1,2 +1,2 @@
-@background-colour: green;
-@colour: purple;
+@background-colour: #EEE;
+@colour: #333;

--- a/_playground/ts/less/vars.less
+++ b/_playground/ts/less/vars.less
@@ -1,0 +1,2 @@
+@background-colour: green;
+@colour: purple;

--- a/dist/typings/WorkflowContext.d.ts
+++ b/dist/typings/WorkflowContext.d.ts
@@ -38,7 +38,6 @@ export declare class WorkFlowContext {
     log: Log;
     initCache(): void;
     reset(): void;
-    allowExtension(ext: string): void;
     setHomeDir(dir: string): void;
     setLibInfo(name: string, version: string, info: IPackageInformation): Map<string, IPackageInformation>;
     convert2typescript(name: string): string;

--- a/package.json
+++ b/package.json
@@ -1,65 +1,66 @@
 {
-    "name": "fuse-box",
-    "version": "1.3.17",
-    "description": "Fuse-Box a bundler just does it right",
-    "typings": "./dist/typings/index.d.ts",
-    "main": "dist/commonjs/index.js",
-    "directories": {
-        "test": "test"
-    },
-    "scripts": {
-        "test": "TRAVIS=true ./node_modules/mocha/bin/mocha"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/fuse-box/fuse-box.git"
-    },
-    "author": "",
-    "license": "ISC",
-    "bugs": {
-        "url": "https://github.com/fuse-box/fuse-box/issues"
-    },
-    "homepage": "https://github.com/fuse-box/fuse-box#readme",
-    "devDependencies": {
-        "@types/node": "^6.0.41",
-        "cheerio": "0.22.0",
-        "fuse-box-test-using-old-version": "^1.0.0",
-        "fuse-box-testcase1": "^1.0.0",
-        "fuse-box-testcase3": "^1.0.3",
-        "gulp": "^3.9.1",
-        "gulp-bump": "^2.4.0",
-        "gulp-concat": "^2.6.0",
-        "gulp-rename": "^1.2.2",
-        "gulp-replace": "^0.5.4",
-        "gulp-sourcemaps": "^1.6.0",
-        "gulp-typescript": "^3.0.1",
-        "gulp-uglify": "^2.0.0",
-        "gulp-wrap": "^0.13.0",
-        "mocha": "^3.1.0",
-        "reflect-metadata": "^0.1.8",
-        "rollup": "^0.36.3",
-        "run-sequence": "^1.2.2",
-        "should": "^11.1.0",
-        "typescript": "^2.1.1",
-        "watch": "^1.0.1",
-        "wires-reactive": "^1.1.1"
-    },
-    "dependencies": {
-        "acorn": "^4.0.3",
-        "acorn-es7": "^0.1.0",
-        "acorn-jsx": "^3.0.1",
-        "ansi": "^0.3.1",
-        "app-root-path": "^2.0.1",
-        "ast-traverse": "^0.1.1",
-        "buffer": "^5.0.0",
-        "concat-with-sourcemaps": "^1.0.4",
-        "escodegen": "^1.8.1",
-        "glob": "^7.1.1",
-        "mkdirp": "^0.5.1",
-        "pretty-time": "^0.2.0",
-        "prettysize": "0.0.3",
-        "realm-utils": "^1.0.6",
-        "request": "^2.79.0",
-        "watch": "^1.0.1"
-    }
+  "name": "fuse-box",
+  "version": "1.3.17",
+  "description": "Fuse-Box a bundler just does it right",
+  "typings": "./dist/typings/index.d.ts",
+  "main": "dist/commonjs/index.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "TRAVIS=true ./node_modules/mocha/bin/mocha"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fuse-box/fuse-box.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/fuse-box/fuse-box/issues"
+  },
+  "homepage": "https://github.com/fuse-box/fuse-box#readme",
+  "devDependencies": {
+    "@types/node": "^6.0.41",
+    "cheerio": "0.22.0",
+    "fuse-box-test-using-old-version": "^1.0.0",
+    "fuse-box-testcase1": "^1.0.0",
+    "fuse-box-testcase3": "^1.0.3",
+    "gulp": "^3.9.1",
+    "gulp-bump": "^2.4.0",
+    "gulp-concat": "^2.6.0",
+    "gulp-rename": "^1.2.2",
+    "gulp-replace": "^0.5.4",
+    "gulp-sourcemaps": "^1.6.0",
+    "gulp-typescript": "^3.0.1",
+    "gulp-uglify": "^2.0.0",
+    "gulp-wrap": "^0.13.0",
+    "mocha": "^3.1.0",
+    "reflect-metadata": "^0.1.8",
+    "rollup": "^0.36.3",
+    "run-sequence": "^1.2.2",
+    "should": "^11.1.0",
+    "typescript": "^2.1.1",
+    "watch": "^1.0.1",
+    "wires-reactive": "^1.1.1"
+  },
+  "dependencies": {
+    "acorn": "^4.0.3",
+    "acorn-es7": "^0.1.0",
+    "acorn-jsx": "^3.0.1",
+    "ansi": "^0.3.1",
+    "app-root-path": "^2.0.1",
+    "ast-traverse": "^0.1.1",
+    "buffer": "^5.0.0",
+    "concat-with-sourcemaps": "^1.0.4",
+    "escodegen": "^1.8.1",
+    "glob": "^7.1.1",
+    "less": "^2.7.1",
+    "mkdirp": "^0.5.1",
+    "pretty-time": "^0.2.0",
+    "prettysize": "0.0.3",
+    "realm-utils": "^1.0.6",
+    "request": "^2.79.0",
+    "watch": "^1.0.1"
+  }
 }

--- a/src-frontend/tsconfig.json
+++ b/src-frontend/tsconfig.json
@@ -12,7 +12,7 @@
         "noImplicitUseStrict": false,
         "removeComments": true,
         "noLib": false,
-        "ourDir": "build/",
+        "outDir": "build/",
         "preserveConstEnums": true,
         "suppressImplicitAnyIndexErrors": true
     },

--- a/src/BundleSource.ts
+++ b/src/BundleSource.ts
@@ -1,3 +1,4 @@
+import * as console from 'console';
 
 import { BundleData } from './Arithmetic';
 import { ModuleCollection } from "./ModuleCollection";

--- a/src/BundleSource.ts
+++ b/src/BundleSource.ts
@@ -1,5 +1,3 @@
-import * as console from 'console';
-
 import { BundleData } from './Arithmetic';
 import { ModuleCollection } from "./ModuleCollection";
 import { WorkFlowContext } from "./WorkFlowContext";

--- a/src/File.ts
+++ b/src/File.ts
@@ -1,3 +1,5 @@
+import * as console from 'console';
+import { PluginChain } from './FuseBox';
 import { ModuleCollection } from "./ModuleCollection";
 import { FileAnalysis } from "./FileAnalysis";
 import { WorkFlowContext, Plugin } from "./WorkflowContext";
@@ -140,6 +142,8 @@ export class File {
                 let plugin = this.context.plugins[index];
                 if (plugin.test && plugin.test.test(this.absPath)) {
                     target = plugin;
+
+                    console.log(target.test, target['name']);
                 }
                 index++;
             }
@@ -177,7 +181,10 @@ export class File {
      * @memberOf File
      */
     public loadContents() {
-        this.contents = fs.readFileSync(this.info.absPath).toString();
+        if (!this.contents) {
+            this.contents = fs.readFileSync(this.info.absPath).toString();
+        }
+        
         this.isLoaded = true;
     }
 

--- a/src/FuseBox.ts
+++ b/src/FuseBox.ts
@@ -8,7 +8,6 @@ import * as path from "path";
 import { each, utils, chain, Chainable } from "realm-utils";
 const appRoot = require("app-root-path");
 const watch = require("watch");
-const DEFAULT_EXTENSIONS = ['.ts', '.js', '.jsx', '.html', '.xml', '.json', '.css'];
 
 /**
  *

--- a/src/FuseBox.ts
+++ b/src/FuseBox.ts
@@ -1,6 +1,6 @@
 import { JSONPlugin } from "./plugins/JSONplugin";
 import { PathMaster } from "./PathMaster";
-import { Plugin, WorkFlowContext } from './WorkflowContext';
+import { WorkFlowContext } from './WorkflowContext';
 import { CollectionSource } from "./CollectionSource";
 import { Arithmetic, BundleData } from "./Arithmetic";
 import { ModuleCollection } from "./ModuleCollection";

--- a/src/PathMaster.ts
+++ b/src/PathMaster.ts
@@ -1,3 +1,4 @@
+import * as console from 'console';
 
 import { IPackageInformation, IPathInformation } from './PathMaster';
 import { WorkFlowContext } from "./WorkflowContext";
@@ -171,6 +172,7 @@ export class PathMaster {
             name = "." + name.slice(1, name.length);
             name = path.join(this.rootPackagePath, name);
         }
+
         if (!AllowedExtenstions.has(ext)) {
             if (/\/$/.test(name)) {
                 return `${name}index${fileExt}`;

--- a/src/PathMaster.ts
+++ b/src/PathMaster.ts
@@ -1,5 +1,3 @@
-import * as console from 'console';
-
 import { IPackageInformation, IPathInformation } from './PathMaster';
 import { WorkFlowContext } from "./WorkflowContext";
 import * as path from "path";

--- a/src/WorkflowContext.ts
+++ b/src/WorkflowContext.ts
@@ -38,7 +38,7 @@ export interface Plugin {
      * @type {{ (context: WorkFlowContext) }}
      * @memberOf Plugin
      */
-    init: { (context: WorkFlowContext) };
+    init?: { (context: WorkFlowContext) };
     /**
      * 
      * 
@@ -211,11 +211,10 @@ export class WorkFlowContext {
      */
     public log: Log;
 
-
-
     public initCache() {
         this.cache = new ModuleCache(this);
     }
+
     /**
      * 
      * 
@@ -230,15 +229,16 @@ export class WorkFlowContext {
     }
 
     /**
-     * 
-     * 
-     * @param {string} ext
-     * 
-     * @memberOf WorkFlowContext
-     */
-    public allowExtension(ext: string) {
-        AllowedExtenstions.add(ext);
+         * 
+         * 
+         * @param {string} ext
+         * 
+         * @memberOf WorkFlowContext
+         */
+    public setAllowExtensions(extensions: Array<string>) {
+        extensions.forEach(extension => AllowedExtenstions.add(extension));
     }
+
     /**
      * 
      * 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,9 @@
-import { LESSPlugin } from './plugins/LESSPlugin';
-export { PostCSS } from "./plugins/PostCSSPlugin";
+export { PostCSSPlugin } from "./plugins/PostCSSPlugin";
 export { TypeScriptHelpers } from "./plugins/TypeScriptHelpers";
 export { SVGPlugin } from "./plugins/SVGPlugin";
 export { BabelPlugin } from "./plugins/BabelPlugin";
 
-
+export { ChainPlugin } from "./plugins/ChainPlugin";
 export { LESSPlugin } from "./plugins/LESSPlugin";
 export { CSSPlugin } from "./plugins/CSSplugin";
 export { HTMLPlugin } from "./plugins/HTMLplugin";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
+import { LESSPlugin } from './plugins/LESSPlugin';
 export { TypeScriptHelpers } from "./plugins/TypeScriptHelpers";
 export { SVGPlugin } from "./plugins/SVGPlugin";
 export { BabelPlugin } from "./plugins/BabelPlugin";
 
+export { LESSPlugin } from "./plugins/LESSPlugin";
 export { CSSPlugin } from "./plugins/CSSplugin";
 export { HTMLPlugin } from "./plugins/HTMLplugin";
 export { JSONPlugin } from "./plugins/JSONplugin";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@ export { PostCSSPlugin } from "./plugins/PostCSSPlugin";
 export { TypeScriptHelpers } from "./plugins/TypeScriptHelpers";
 export { SVGPlugin } from "./plugins/SVGPlugin";
 export { BabelPlugin } from "./plugins/BabelPlugin";
-
 export { ChainPlugin } from "./plugins/ChainPlugin";
 export { LESSPlugin } from "./plugins/LESSPlugin";
 export { CSSPlugin } from "./plugins/CSSplugin";

--- a/src/plugins/BabelPlugin.ts
+++ b/src/plugins/BabelPlugin.ts
@@ -51,7 +51,6 @@ export class BabelPluginClass implements Plugin {
      */
     public init(context: WorkFlowContext) {
         this.context = context;
-        context.allowExtension(".jsx");
     }
 
 

--- a/src/plugins/CSSplugin.ts
+++ b/src/plugins/CSSplugin.ts
@@ -36,39 +36,14 @@ export class CSSPluginClass implements Plugin {
         }
 
     }
-    /**
-     *
-     *
-     * @param {WorkFlowContext} context
-     *
-     * @memberOf FuseBoxCSSPlugin
-     */
-    public init(context: WorkFlowContext) {
-        context.allowExtension(".css");
-    }
 
     public bundleStart(context: WorkFlowContext) {
         let lib = path.join(Config.LOCAL_LIBS, "fsbx-default-css-plugin", "index.js")
         context.source.addContent(fs.readFileSync(lib).toString());
     }
 
-    public onStyleChain(chain: PluginChain) {
-        this.modify(chain.file);
-    }
-
-    /**
-     *
-     *
-     * @param {File} file
-     *
-     * @memberOf FuseBoxCSSPlugin
-     */
     public transform(file: File) {
         file.loadContents();
-        this.modify(file);
-    }
-
-    private modify(file: File) {
         let contents = "";
         let filePath = file.info.fuseBoxPath;
         let serve = false;

--- a/src/plugins/CSSplugin.ts
+++ b/src/plugins/CSSplugin.ts
@@ -60,6 +60,9 @@ export class CSSPluginClass implements Plugin {
      */
     public transform(file: File) {
         file.loadContents();
+
+        console.log('CSS', file.contents);
+
         let contents = "";
         let filePath = file.info.fuseBoxPath;
         let serve = false;

--- a/src/plugins/ChainPlugin.ts
+++ b/src/plugins/ChainPlugin.ts
@@ -1,0 +1,59 @@
+import { WorkFlowContext, Plugin } from '../WorkflowContext';
+import { utils } from "realm-utils";
+
+export class ChainPluginClass {
+    private test: RegExp;
+    private plugins: Array<Plugin>;
+
+    constructor(test: RegExp, plugins: Array<Plugin>) {
+        this.test = test;
+        this.plugins = plugins;
+    }
+    
+    add(plugin: Plugin) {
+        this.plugins.push(plugin);
+        return this;
+    }
+
+    bundleStart(context: WorkFlowContext) {
+        // Get the first plugin that has a bundleStart - this should take priority
+        let length = this.plugins.length;
+
+        while (length--) {
+            let plugin = this.plugins[length];
+
+            if (utils.isFunction(plugin.bundleStart)) {
+                plugin.bundleStart(context);
+                break;
+            }
+        }
+    }
+
+    transform(file, ast?): Promise<void> {
+        return this.plugins.reduce((chain: Promise<void>, plugin) => {
+            if (!utils.isFunction(plugin.transform)) {
+                return Promise.resolve();
+            }
+
+            return chain.then(() => plugin.transform.apply(plugin, [file, ast]));
+        }, Promise.resolve());
+    }
+
+    bundleEnd(context: WorkFlowContext) {
+        // Get the first plugin that has a bundleEnd - this should take priority
+        let length = this.plugins.length;
+
+        while (length--) {
+            let plugin = this.plugins[length];
+
+            if (utils.isFunction(plugin.bundleEnd)) {
+                plugin.bundleEnd(context);
+                break;
+            }
+        }
+    }
+}
+
+export const ChainPlugin = (test: RegExp, plugins: Array<Plugin>) => {
+    return new ChainPluginClass(test, plugins);
+}

--- a/src/plugins/ChainPlugin.ts
+++ b/src/plugins/ChainPlugin.ts
@@ -9,7 +9,7 @@ export class ChainPluginClass {
         this.test = test;
         this.plugins = plugins;
     }
-    
+
     add(plugin: Plugin) {
         this.plugins.push(plugin);
         return this;
@@ -17,15 +17,10 @@ export class ChainPluginClass {
 
     bundleStart(context: WorkFlowContext) {
         // Get the first plugin that has a bundleStart - this should take priority
-        let length = this.plugins.length;
+        let plugin = this.plugins.find(plugin => utils.isFunction(plugin.bundleStart));
 
-        while (length--) {
-            let plugin = this.plugins[length];
-
-            if (utils.isFunction(plugin.bundleStart)) {
-                plugin.bundleStart(context);
-                break;
-            }
+        if (plugin) {
+            plugin.bundleStart(context);
         }
     }
 
@@ -41,15 +36,10 @@ export class ChainPluginClass {
 
     bundleEnd(context: WorkFlowContext) {
         // Get the first plugin that has a bundleEnd - this should take priority
-        let length = this.plugins.length;
+        let plugin = this.plugins.find(plugin => utils.isFunction(plugin.bundleEnd));
 
-        while (length--) {
-            let plugin = this.plugins[length];
-
-            if (utils.isFunction(plugin.bundleEnd)) {
-                plugin.bundleEnd(context);
-                break;
-            }
+        if (plugin) {
+            plugin.bundleEnd(context);
         }
     }
 }

--- a/src/plugins/HTMLplugin.ts
+++ b/src/plugins/HTMLplugin.ts
@@ -23,17 +23,7 @@ export class FuseBoxHTMLPlugin implements Plugin {
      * @memberOf FuseBoxHTMLPlugin
      */
     public test: RegExp = /\.html$/;
-
-    /**
-     * 
-     * 
-     * @param {WorkFlowContext} context
-     * 
-     * @memberOf FuseBoxHTMLPlugin
-     */
-    public init(context: WorkFlowContext) {
-        context.allowExtension(".html");
-    }
+    
     /**
      * 
      * 

--- a/src/plugins/JSONplugin.ts
+++ b/src/plugins/JSONplugin.ts
@@ -20,16 +20,6 @@ export class FuseBoxJSONPlugin implements Plugin {
     /**
      * 
      * 
-     * @param {WorkFlowContext} context
-     * 
-     * @memberOf FuseBoxHTMLPlugin
-     */
-    public init(context: WorkFlowContext) {
-        context.allowExtension(".json");
-    }
-    /**
-     * 
-     * 
      * @param {File} file
      * 
      * @memberOf FuseBoxHTMLPlugin

--- a/src/plugins/LESSPlugin.ts
+++ b/src/plugins/LESSPlugin.ts
@@ -1,0 +1,61 @@
+import * as console from 'console';
+import { File } from "../File";
+import { WorkFlowContext } from "./../WorkflowContext";
+import { Plugin } from "../WorkflowContext";
+
+// Do we want to do this? Or do we want them to pass LESS in?
+// Letting users pass it in seems to defeat the purpose of wrapping the plugin up TBH
+const less = require('less');
+/**
+ *
+ *
+ * @export
+ * @class LESSPluginClass
+ * @implements {Plugin}
+ */
+export class LESSPluginClass implements Plugin {
+    /**
+     *
+     *
+     * @type {RegExp}
+     * @memberOf LESSPluginClass
+     */
+    public test: RegExp = /\.less$/;
+    public options: any;
+    private minify = false;
+    private serve: any;
+
+    constructor(options: any) {
+        this.options = options || {};
+    }
+    /**
+     *
+     *
+     * @param {WorkFlowContext} context
+     *
+     * @memberOf LESSPluginClass
+     */
+    public init(context: WorkFlowContext) {
+        context.allowExtension(".less");
+    }
+
+    /**
+     *
+     *
+     * @param {File} file
+     *
+     * @memberOf LESSPluginClass
+     */
+    public transform(file: File) {
+        file.loadContents();
+
+        return less.render(file.contents, this.options).then(output => {
+            file.contents = output.css;
+            console.log('LESS', file.contents);
+        });
+    }
+}
+
+export const LESSPlugin = (opts: any) => {
+    return new LESSPluginClass(opts)
+}

--- a/src/plugins/LESSPlugin.ts
+++ b/src/plugins/LESSPlugin.ts
@@ -1,49 +1,27 @@
-import * as console from 'console';
 import { File } from "../File";
 import { WorkFlowContext } from "./../WorkflowContext";
 import { Plugin } from "../WorkflowContext";
+import * as less from "less";
 
-// Do we want to do this? Or do we want them to pass LESS in?
-// Letting users pass it in seems to defeat the purpose of wrapping the plugin up TBH
-const less = require('less');
 /**
- *
- *
  * @export
  * @class LESSPluginClass
  * @implements {Plugin}
  */
 export class LESSPluginClass implements Plugin {
     /**
-     *
-     *
      * @type {RegExp}
      * @memberOf LESSPluginClass
      */
     public test: RegExp = /\.less$/;
     public options: any;
-    private minify = false;
-    private serve: any;
 
     constructor(options: any) {
         this.options = options || {};
     }
-    /**
-     *
-     *
-     * @param {WorkFlowContext} context
-     *
-     * @memberOf LESSPluginClass
-     */
-    public init(context: WorkFlowContext) {
-        context.allowExtension(".less");
-    }
 
     /**
-     *
-     *
      * @param {File} file
-     *
      * @memberOf LESSPluginClass
      */
     public transform(file: File) {
@@ -51,7 +29,6 @@ export class LESSPluginClass implements Plugin {
 
         return less.render(file.contents, this.options).then(output => {
             file.contents = output.css;
-            console.log('LESS', file.contents);
         });
     }
 }

--- a/src/plugins/PostCSSPlugin.ts
+++ b/src/plugins/PostCSSPlugin.ts
@@ -1,4 +1,3 @@
-import * as console from 'console';
 import { PluginChain } from '../PluginChain';
 import { File } from "../File";
 import { WorkFlowContext } from "./../WorkflowContext";

--- a/src/plugins/PostCSSPlugin.ts
+++ b/src/plugins/PostCSSPlugin.ts
@@ -1,3 +1,4 @@
+import * as console from 'console';
 import { PluginChain } from '../PluginChain';
 import { File } from "../File";
 import { WorkFlowContext } from "./../WorkflowContext";
@@ -21,19 +22,10 @@ export class PostCSSPluginClass implements Plugin {
      */
     public test: RegExp = /\.css$/;
     public dependencies = [];
+    
     constructor(public processors: any, public opts: any) {
         this.opts = this.opts || {};
         this.processors = this.processors || [];
-    }
-    /**
-     *
-     *
-     * @param {WorkFlowContext} context
-     *
-     * @memberOf FuseBoxCSSPlugin
-     */
-    public init(context: WorkFlowContext) {
-        context.allowExtension(".css");
     }
 
     /**
@@ -43,26 +35,19 @@ export class PostCSSPluginClass implements Plugin {
      *
      * @memberOf FuseBoxCSSPlugin
      */
-    public transform(file: File): Promise<PluginChain> {
+    public transform(file: File): Promise<void> {
         file.loadContents();
+
         if (!postcss) {
             postcss = require("postcss");
         }
-        return new Promise((resolve, reject) => {
-            return postcss(this.processors).process(file.contents).then(result => {
-                file.contents = result.css;
-                // what are we going to do with sourcemaps?
-                // What about caching?
 
-                // Resolve styling chain
-                // All plugins that have onStyleChain will get triggered
-                return resolve(file.createChain("style", file));
-            });
+        return postcss(this.processors).process(file.contents).then(result => {
+            file.contents = result.css;
         });
-
     }
 }
 
-export const PostCSS = (processors? : any, opts?: any) => {
+export const PostCSSPlugin = (processors?: any, opts?: any) => {
     return new PostCSSPluginClass(processors, opts);
 }

--- a/src/plugins/SVGPlugin.ts
+++ b/src/plugins/SVGPlugin.ts
@@ -20,16 +20,6 @@ export class SVGSimplePlugin implements Plugin {
     /**
      * 
      * 
-     * @param {WorkFlowContext} context
-     * 
-     * @memberOf FuseBoxHTMLPlugin
-     */
-    public init(context: WorkFlowContext) {
-        context.allowExtension(".svg");
-    }
-    /**
-     * 
-     * 
      * @param {File} file
      * 
      * @memberOf FuseBoxHTMLPlugin

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -12,7 +12,7 @@
         "noImplicitUseStrict": false,
         "removeComments": true,
         "noLib": false,
-        "ourDir": "build/",
+        "outDir": "build/",
         "preserveConstEnums": true,
         "suppressImplicitAnyIndexErrors": true
     },

--- a/test/fixtures/cases/ts/tsconfig.json
+++ b/test/fixtures/cases/ts/tsconfig.json
@@ -13,7 +13,7 @@
         "noImplicitUseStrict": false,
         "removeComments": true,
         "noLib": false,
-        "ourDir": "build/",
+        "outDir": "build/",
         "preserveConstEnums": true,
         "noEmitHelpers": true,
         "suppressImplicitAnyIndexErrors": true


### PR DESCRIPTION
***NOTE: I have added `less` as a dependency as it the only dependency for that plugin, unlike PostCss. Asking the user to import it and pass it in is overkill and makes the config bloated for no reason. I have an idea of how we can structure the plugins directory to make for a nice publish process and also make them self-contained***

## Changes

- New `ChainPlugin`
- Moved `allowedExtensions` into top level config (because it wasn't needed due to plugins having a `test` and also so we don't need to pass an `extension` into the `ChainPlugin`
- Makes `WorkflowContext.init()` optional when implementing a plugin. It is not needed to set the extension anymore (see above). It can still be implemented if the developer needs/wants it.
- `File.loadContents()` now caches the content if it has been set, this is not a problem as they get reset once bundled anyway. With this change the developer can be sure that `file.contents` is what the previous plugin in the chain set it to. 
- Removes the previous chaining implementation

## Housekeeping
- File name standardisation for plugins
- Fixed some typos in `tsconfig` files (`ourDir` --> `outDir`)
- Updates to the `_playground` to show chaining in action for LESS and PostCSS