### PR TITLE
Peer dependencies & extended CSSPlugin

### DIFF
--- a/_playground/_build/index.html
+++ b/_playground/_build/index.html
@@ -7,11 +7,17 @@
 
 <body>
     <div id="root"></div>
-    <script type="text/javascript" charset="utf-8" src="out.js?1"></script>
     <h1>Welcome to <span class="fuse-box">FuseBox!</span></h1>
-    <section>
-        The simplest and fastest bundler around! 
-    </section>
+    <p>
+        The simplest and fastest bundler around!
+    </p>
+    <p class="raw-styling">
+        Raw style string output using CSSPlugin option "raw". This is useful for Angular2 who want inlined styles in their <a href="https://angular.io/docs/ts/latest/api/core/index/Component-decorator.html" target="_blank">components</a>:
+        <div class="style-example">
+        </div>
+    </p>
+
+    <script type="text/javascript" charset="utf-8" src="out.js?1"></script>
 </body>
 
 </html>

--- a/_playground/bundle.js
+++ b/_playground/bundle.js
@@ -22,14 +22,16 @@ const fuseBox = FuseBox.init({
         build.TypeScriptHelpers(),
         build.JSONPlugin(),
 
-        [build.LESSPlugin(), build.CSSPlugin()],
-        [build.PostCSS(POST_CSS_PLUGINS), build.CSSPlugin()],
+        // Only process none "raw" less files
+        [/^(?!.*raw).*\.less$/, build.LESSPlugin(), build.CSSPlugin()],
 
+        // Only process "raw" less files
+        [/\.raw.less$/, build.LESSPlugin(), build.CSSPlugin({
+            raw: true
+        })],
 
-        //build.ChainPlugin(/.less$/, [build.LESSPlugin(), build.CSSPlugin()]),
-        // build.ChainPlugin(/.css$/, [build.PostCSS(POST_CSS_PLUGINS), build.CSSPlugin({
-        //     minify: true
-        // })])
+        // All other CSS files
+        [build.PostCSS(POST_CSS_PLUGINS), build.CSSPlugin()]
     ]
 });
 

--- a/_playground/ts/index.ts
+++ b/_playground/ts/index.ts
@@ -1,3 +1,5 @@
 import "./styles.css"
 import "./less/styles.less";
-console.log(1);
+import * as rawStyles from "./less/styles.raw.less";
+
+document.querySelector('.style-example').innerHTML += rawStyles.default;

--- a/_playground/ts/less/styles.less
+++ b/_playground/ts/less/styles.less
@@ -8,4 +8,10 @@ html, body {
     .fuse-box {
         color: blue;
     }
+
+    .style-example {
+        background: #000;
+        color: #FFF;
+        padding:  10px;
+    }
 }

--- a/_playground/ts/less/styles.raw.less
+++ b/_playground/ts/less/styles.raw.less
@@ -1,0 +1,3 @@
+.raw-style {
+    color: pink;
+}

--- a/package.json
+++ b/package.json
@@ -61,5 +61,10 @@
         "realm-utils": "^1.0.6",
         "request": "^2.79.0",
         "watch": "^1.0.1"
+    },
+    "peerDependencies": {
+        "less": "*",
+        "babel-core": "*",
+        "postcss": "*"
     }
 }


### PR DESCRIPTION
### Changes
- Use peer dependencies so users get prompted to install whichever version they like for plugin usages.
- Adds `raw` option to CSSPlugin, useful for Angular2 devs that wish to do:

```js
@Component({
   selector: 'foo',
   template: '<div class="foo">Foo</div>',
   styles: require('./component.less/css/sass/etc.')
})
class Foo { }
```