### PR TITLE
Proposal: Pre/PostBundle() Plugin Lifecycle Hooks

### DIFF
--- a/_playground/bundle.js
+++ b/_playground/bundle.js
@@ -25,10 +25,11 @@ const fuseBox = FuseBox.init({
         // process them all ;-)
         [build.LESSPlugin(), build.CSSPlugin()],
 
-
-
         // All other CSS files
-        [build.PostCSS(POST_CSS_PLUGINS), build.CSSPlugin()]
+        [build.PostCSS(POST_CSS_PLUGINS), build.CSSPlugin()],
+
+        // Add a banner to bundle output
+        build.BannerPlugin('// Hey this is my banner! Copyright 2016!')
     ]
 });
 

--- a/dist/typings/WorkflowContext.d.ts
+++ b/dist/typings/WorkflowContext.d.ts
@@ -13,8 +13,10 @@ export interface Plugin {
     transform: {
         (file: File, ast?: any);
     };
+    preBundle?(context: WorkflowContext): any;
     bundleStart?(context: WorkFlowContext): any;
     bundleEnd?(context: WorkFlowContext): any;
+    postBundle?(context: WorkFlowContext): any;
 }
 export declare class WorkFlowContext {
     defaultPackageName: string;

--- a/src/BundleSource.ts
+++ b/src/BundleSource.ts
@@ -43,6 +43,14 @@ export class BundleSource {
      */
     constructor(public context: WorkFlowContext) {
         this.concat = new Concat(true, "", "\n");
+    }
+
+    /**
+     *
+     * 
+     * @memberOf BundleSource
+     */
+    public init() {
         this.concat.add(null, "(function(FuseBox){");
     }
 

--- a/src/FuseBox.ts
+++ b/src/FuseBox.ts
@@ -94,6 +94,10 @@ export class FuseBox {
         this.context.initCache();
     }
 
+     public triggerPre() {
+        this.context.triggerPluginsMethodOnce("preBundle", [this.context]);
+    }
+
     public triggerStart() {
         this.context.triggerPluginsMethodOnce("bundleStart", [this.context]);
     }
@@ -101,6 +105,11 @@ export class FuseBox {
     public triggerEnd() {
         this.context.triggerPluginsMethodOnce("bundleEnd", [this.context]);
     }
+
+    public triggerPost() {
+        this.context.triggerPluginsMethodOnce("postBundle", [this.context]);
+    }
+
 
 
     /**
@@ -173,6 +182,7 @@ export class FuseBox {
                 self.context.log.end();
                 this.triggerEnd();
                 self.context.source.finalize(bundleData);
+                this.triggerPost();
                 this.context.writeOutput();
                 return self.context.source.getResult();
             });
@@ -181,6 +191,8 @@ export class FuseBox {
 
     private initiateBundle(str: string) {
         this.context.reset();
+        this.triggerPre();
+        this.context.source.init();
         this.triggerStart();
         let parser = Arithmetic.parse(str);
         let bundle: BundleData;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export { LESSPlugin } from "./plugins/LESSPlugin";
 export { CSSPlugin } from "./plugins/CSSplugin";
 export { HTMLPlugin } from "./plugins/HTMLplugin";
 export { JSONPlugin } from "./plugins/JSONplugin";
+export { BannerPlugin } from "./plugins/BannerPlugin";
 
 export { WorkFlowContext } from "./WorkflowContext";
 export { PathMaster } from "./PathMaster";

--- a/src/plugins/BannerPlugin.ts
+++ b/src/plugins/BannerPlugin.ts
@@ -1,7 +1,6 @@
 import { File } from "../File";
 import { WorkFlowContext } from "./../WorkflowContext";
 import { Plugin } from "../WorkflowContext";
-let less;
 
 /**
  * @export
@@ -30,5 +29,5 @@ export class BannerPluginClass implements Plugin {
 }
 
 export const BannerPlugin = (banner: string) => {
-    return new BannerPluginClass(banner)
+    return new BannerPluginClass(banner);
 }

--- a/src/plugins/BannerPlugin.ts
+++ b/src/plugins/BannerPlugin.ts
@@ -1,0 +1,34 @@
+import { File } from "../File";
+import { WorkFlowContext } from "./../WorkflowContext";
+import { Plugin } from "../WorkflowContext";
+let less;
+
+/**
+ * @export
+ * @class BannerPluginClass
+ * @implements {Plugin}
+ */
+export class BannerPluginClass implements Plugin {
+    /**
+     * @type {RegExp}
+     * @memberOf BannerPluginClass
+     */
+    public test: RegExp = /\.js$/;
+    public banner: string;
+
+    constructor(banner: string) {
+        this.banner = banner || '';
+    }
+
+    public init(context: WorkFlowContext) {
+        context.allowExtension(".js");
+    }
+
+    public preBundle(context: WorkFlowContext) {
+        context.source.addContent(this.banner);
+    }
+}
+
+export const BannerPlugin = (banner: string) => {
+    return new BannerPluginClass(banner)
+}


### PR DESCRIPTION
Requested from issue #31 

### Changes
- Adds `preBundle()` and `postBundle()` plugin hooks
- Adds very basic `BannerPlugin`

### Notes
I'm not sure if `postBundle()`is very useful. Originally my hope was to maybe use this hook for minification of the entire bundle, but I don't think thats possible. Happy to remove if it adds no value - let me know.