### PR TITLE
change import path to match the file name.

### DIFF
--- a/src/BundleSource.ts
+++ b/src/BundleSource.ts
@@ -1,6 +1,6 @@
 import { BundleData } from './Arithmetic';
 import { ModuleCollection } from "./ModuleCollection";
-import { WorkFlowContext } from "./WorkFlowContext";
+import { WorkFlowContext } from "./WorkflowContext";
 import { Config } from "./Config";
 import { File } from "./File";
 import * as path from "path";

--- a/src/ModuleCollection.ts
+++ b/src/ModuleCollection.ts
@@ -1,6 +1,6 @@
 import { File } from "./File";
 import { PathMaster, IPackageInformation } from "./PathMaster";
-import { WorkFlowContext } from "./WorkFlowContext";
+import { WorkFlowContext } from "./WorkflowContext";
 import { each, utils } from "realm-utils";
 import { BundleData } from "./Arithmetic";
 


### PR DESCRIPTION
`WorkFlowContext` file name is `WorkflowContext` but imported as `import { WorkFlowContext } from "./WorkFlowContext";
`
