### PR TITLE
Verify that PathMaster exists before trying to use it

### DIFF
--- a/src/ModuleCollection.ts
+++ b/src/ModuleCollection.ts
@@ -250,7 +250,7 @@ export class ModuleCollection {
         // e.g require("lodash") - we require entry file
         // unlike require("requre/each") - points to an explicit file
         // So we might never resolve the entry (if only a partial require was mentioned)
-        return file.info.nodeModuleExplicitOriginal
+        return file.info.nodeModuleExplicitOriginal && collection.pm
             ? collection.resolve(new File(this.context, collection.pm.init(file.info.absPath)))
             : collection.resolveEntry();
     }


### PR DESCRIPTION
Attribute `pm` does not exist always and building crashes because it is missing when chaining several node modules. Here is a patch that passes the tests.