### PR TITLE
Fix relative paths resolution by SassPlugin

### DIFF
--- a/src/plugins/SassPlugin.ts
+++ b/src/plugins/SassPlugin.ts
@@ -33,8 +33,10 @@ export class SassPluginClass implements Plugin {
             sourceMap: true,
             outFile: file.info.fuseBoxPath,
             sourceMapContents: true,
-            includePaths: [file.info.absDir],
+            includePaths: [],
         }, this.options);
+
+        options.includePaths.push(file.info.absDir);
 
         return new Promise((res, rej) => {
             return sass.render(options, (err, result) => {


### PR DESCRIPTION
Related to #57 
Abandoned a check whether `options.includePaths` is an `Array` before pushing to it as `node-sass` docs require the user to pass an array.