### PR TITLE
should fix PostCSS plugin from not resolving the transform/task

### DIFF
--- a/src/plugins/PostCSSPlugin.ts
+++ b/src/plugins/PostCSSPlugin.ts
@@ -47,12 +47,12 @@ export class PostCSSPluginClass implements Plugin {
         if (!postcss) {
             postcss = require("postcss");
         }
-        return new Promise((resolve, reject) => {
-            return postcss(this.processors).process(file.contents).then(result => {
-                file.contents = result.css;
-            });
-        });
-
+        return postcss(this.processors)
+        	.process(file.contents)
+        	.then(result => {
+            	file.contents = result.css;
+            	return result.css;
+	        });
     }
 }
 


### PR DESCRIPTION
So I was using the PostCSS plugin and found that the CSS plugin was not receiving any contents - the Promise from the `transform()` was not resolving and just timing out. Turns out there was just a small fix: the promise being returned by the PostCSS's `transform()` was never resolving :) fortunately I just had to unwrap the inner call to `postcss.process()` and return that Promise.