### PR TITLE
Class properties (e.g. stage-2) do not have a callee

### DIFF
--- a/src/FileAnalysis.ts
+++ b/src/FileAnalysis.ts
@@ -145,7 +145,7 @@ export class FileAnalysis {
                         out.requires.push(node.source.value);
                     }
                 }
-                if (node.type === "CallExpression") {
+                if (node.type === "CallExpression" && node.callee) {
 
                     if (node.callee.type === "Identifier" && node.callee.name === "require") {
                         let arg1 = node.arguments[0];


### PR DESCRIPTION
Class properties do not have a callee, but they are handled (apparently) as CallExpression. E.g. this would fail with `stage-2` babel preset

```
class Foo extends React.Component {
  state = {
    foo: 'bar'
  }
}
```

Patched by checking explicitly that callee exists in the preflight check of the node