### PR TITLE
Fix issue not able to use hot reload over ssl

### DIFF
--- a/assets/libs/fusebox-websocket/index.js
+++ b/assets/libs/fusebox-websocket/index.js
@@ -1,6 +1,7 @@
 const events = require("events");
 
 const getSocketURL = (host) => {
+    
         const isBrowser = FuseBox.isBrowser
         if (host && /^ws(s):\/\//.test(host)) {
             return host;
@@ -8,10 +9,11 @@ const getSocketURL = (host) => {
         let protocol = "ws://";
         let port = isBrowser ? (!host &&
             window.location.port ? window.location.port : "") : "";
-        host = host ? host : (isBrowser ? window.location.host : "localhost");
+        host = host ? host : (isBrowser ? window.location.origin : "localhost");
         let portInHost = new RegExp(":\\d{1,}.*$");
         if (portInHost.test(host)) {
             port = "";
+            host = host.replace(port, "");
         }
         let http = new RegExp("^http(s)?://");
         if (http.test(host)) {

--- a/assets/libs/fusebox-websocket/index.js
+++ b/assets/libs/fusebox-websocket/index.js
@@ -13,7 +13,6 @@ const getSocketURL = (host) => {
         let portInHost = new RegExp(":\\d{1,}.*$");
         if (portInHost.test(host)) {
             port = "";
-            host = host.replace(port, "");
         }
         let http = new RegExp("^http(s)?://");
         if (http.test(host)) {


### PR DESCRIPTION
window.location.origin is used instead of window.location.host. This way protocol is included and matching will be done correctly and hot reload will also work over ssl connections.