### PR TITLE
Extended tty definition to support for debug.js

### DIFF
--- a/assets/libs/tty/index.js
+++ b/assets/libs/tty/index.js
@@ -1,5 +1,7 @@
 if (FuseBox.isServer) {
     module.exports = global.require("tty");
 } else {
-    module.exports = {}
+    module.exports = {
+        isatty() { return false; } 
+    }
 }


### PR DESCRIPTION
debug.js is a package used by many libraries out there and it depends on tty library. Following is a stub implementation of the only tty call needed by debug.js.