### PR TITLE
Change log: Fix spelling in description of 1.3.108

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,7 @@
 | 1.3.111             | Fixing [modulesFolder](http://fuse-box.org/#custom-modules-folder) priority, Related [issue 124](https://github.com/fuse-box/fuse-box/issues/124)
 | 1.3.110             | Automatic tsconfig.json lookup
 | 1.3.109             | Clear Interval, avoiding frantic bundle call on fileChange
-| 1.3.108             | Preventing babel-plugin from transpling all npm deps. Issue [108](https://github.com/fuse-box/fuse-box/issues/108)
+| 1.3.108             | Preventing babel-plugin from transpiling all npm deps. Issue [108](https://github.com/fuse-box/fuse-box/issues/108)
 | 1.3.107             | Fixed broken tsConfig property
 | 1.3.106             | Added file.properties to the API. Removed buffer
 | 1.3.105             | Fixed errors related to Buffer. It is properly shimmed now, and fuse is serving a native "buffer" on server


### PR DESCRIPTION
Minor spelling fix in changelog: `transpling` -> `transpiling`