### PR TITLE
Rename PostCSS to PostCSSPlugin

### DIFF
--- a/src/plugins/PostCSSPlugin.ts
+++ b/src/plugins/PostCSSPlugin.ts
@@ -56,6 +56,6 @@ export class PostCSSPluginClass implements Plugin {
     }
 }
 
-export const PostCSS = (processors?: any, opts?: any) => {
+export const PostCSSPlugin = (processors?: any, opts?: any) => {
     return new PostCSSPluginClass(processors, opts);
 }


### PR DESCRIPTION
So that it's consistent with other plugins. Docs also use the name PostCSSPlugin.