### PR TITLE
change brightBlack to reset get neutral color on dark themes

### DIFF
--- a/src/Log.ts
+++ b/src/Log.ts
@@ -41,14 +41,14 @@ export class Log {
         let bytes = Buffer.byteLength(contents, "utf8");
         let size = prettysize(bytes);
         this.totalSize += bytes;
-        cursor.brightBlack().write(`└──`)
+        cursor.reset().write(`└──`)
             .green().write(` ${collection.cachedName || collection.name}`)
             .yellow().write(` (${collection.dependencies.size} files,  ${size})`)
 
         cursor.write("\n")
         collection.dependencies.forEach(file => {
             if (!file.info.isRemoteFile) {
-                cursor.brightBlack().write(`      ${file.info.fuseBoxPath}`).write("\n")
+                cursor.reset().write(`      ${file.info.fuseBoxPath}`).write("\n")
             }
         });
         cursor.reset();
@@ -61,9 +61,9 @@ export class Log {
         let bytes = Buffer.byteLength(contents, "utf8");
         let size = prettysize(bytes);
         this.totalSize += bytes;
-        cursor.brightBlack().write(`└──`)
+        cursor.reset().write(`└──`)
             .green().write(` ${collection.cachedName || collection.name}`)
-            .brightBlack().write(` (${collection.dependencies.size} files)`)
+            .reset().write(` (${collection.dependencies.size} files)`)
             .yellow().write(` ${size}`)
             .write("\n").reset();
     }
@@ -74,11 +74,11 @@ export class Log {
         }
         let took = process.hrtime(this.timeStart)
         cursor.write("\n")
-            .brightBlack().write(`    --------------\n`)
+            .reset().write(`    --------------\n`)
             .yellow().write(`    Size: ${prettysize(this.totalSize)} \n`)
             .yellow().write(`    Time: ${prettyTime(took, "ms")}`)
             .write("\n")
-            .brightBlack().write(`    --------------\n`)
+            .reset().write(`    --------------\n`)
             .write("\n").reset();
     }
 }

--- a/src/PrettyError.ts
+++ b/src/PrettyError.ts
@@ -2,25 +2,25 @@ import { File } from "./File";
 const ansi = require("ansi");
 const cursor = ansi(process.stdout);
 /**
- * 
- * 
+ *
+ *
  * @export
  * @class PrettyTrace
  */
 export class PrettyError {
     /**
-     * Prints a pretty error 
+     * Prints a pretty error
      * Based on Acorn Exception
-     * 
+     *
      * It order for it work an exception must have err.loc with (line)
      * For example:
-     * 
+     *
      * Position { line: 1, column: 5 }
-     * 
+     *
      * @static
      * @param {*} position
      * @param {string} contents
-     * 
+     *
      * @memberOf PrettyTrace
      */
     public static errorWithContents(error: any, file: File) {
@@ -47,7 +47,7 @@ export class PrettyError {
                     l.white().bg.red().write(`${index + 1}  ${line}`);
                     l.bg.reset();
                 } else {
-                    l.brightBlack().write(`${index + 1} `).red().write(` ${line}`)
+                    l.reset().write(`${index + 1} `).red().write(` ${line}`)
                 }
                 l.write("\n").reset();
             }


### PR DESCRIPTION
To fix #173.

Grey colors do not show up on solarized dark (and a few others). But the neutral color is already grey.

Here is solarized dark before the change (with some highlighing to show the invisible text)
![image](https://cloud.githubusercontent.com/assets/1187432/23032463/4a68ceb4-f429-11e6-8ff2-e76ace449d65.png)


Here is solarized dark after the change
![image](https://cloud.githubusercontent.com/assets/1187432/23032448/429480a2-f429-11e6-9348-fac9c416ce71.png)

For extra comparison here is Solarized light before and after
![image](https://cloud.githubusercontent.com/assets/1187432/23032524/738bf2d0-f429-11e6-9e66-20e9cca4bb98.png)

![image](https://cloud.githubusercontent.com/assets/1187432/23032531/79d87f82-f429-11e6-993c-48f474e8151b.png)

I tested several other themes just to be sure, but since this uses `reset()` it should be safe everywhere.
