### PR TITLE
Report the new size and time taken for UglifyJS

### DIFF
--- a/src/FuseBox.ts
+++ b/src/FuseBox.ts
@@ -222,7 +222,7 @@ export class FuseBox {
                 }
 
             }).then(result => {
-                self.context.log.end();
+                self.context.log.end('FuseBox Bundle');
                 this.triggerEnd();
                 self.context.source.finalize(bundleData);
                 this.triggerPost();

--- a/src/FuseBox.ts
+++ b/src/FuseBox.ts
@@ -222,7 +222,7 @@ export class FuseBox {
                 }
 
             }).then(result => {
-                self.context.log.end('FuseBox Bundle');
+                self.context.log.end();
                 this.triggerEnd();
                 self.context.source.finalize(bundleData);
                 this.triggerPost();

--- a/src/Log.ts
+++ b/src/Log.ts
@@ -68,9 +68,9 @@ export class Log {
             .write("\n").reset();
     }
 
-    public end(header: string) {
+    public end(header?: string) {
         let took = process.hrtime(this.timeStart) as [number, number];
-        this.echoBundleStats(header, this.totalSize, took);
+        this.echoBundleStats(header || 'Bundle', this.totalSize, took);
     }
 
     public echoBundleStats (header: string, size: number, took: [number, number]) {

--- a/src/Log.ts
+++ b/src/Log.ts
@@ -69,16 +69,20 @@ export class Log {
     }
 
     public end() {
-        if (!this.printLog) {
-            return;
-        }
         let took = process.hrtime(this.timeStart)
-        cursor.write("\n")
-            .reset().write(`    --------------\n`)
-            .yellow().write(`    Size: ${prettysize(this.totalSize)} \n`)
-            .yellow().write(`    Time: ${prettyTime(took, "ms")}`)
-            .write("\n")
-            .reset().write(`    --------------\n`)
-            .write("\n").reset();
+        this.echoBundleStats(this.totalSize, took)
+    }
+
+    public echoBundleStats (size, took) {
+      if (!this.printLog) {
+          return;
+      }
+      cursor.write("\n")
+          .reset().write(`    --------------\n`)
+          .yellow().write(`    Size: ${prettysize(size)} \n`)
+          .yellow().write(`    Time: ${prettyTime(took, "ms")}`)
+          .write("\n")
+          .reset().write(`    --------------\n`)
+          .write("\n").reset();
     }
 }

--- a/src/Log.ts
+++ b/src/Log.ts
@@ -68,16 +68,17 @@ export class Log {
             .write("\n").reset();
     }
 
-    public end() {
-        let took = process.hrtime(this.timeStart)
-        this.echoBundleStats(this.totalSize, took)
+    public end(header: string) {
+        let took = process.hrtime(this.timeStart) as [number, number];
+        this.echoBundleStats(header, this.totalSize, took);
     }
 
-    public echoBundleStats (size, took) {
+    public echoBundleStats (header: string, size: number, took: [number, number]) {
       if (!this.printLog) {
           return;
       }
       cursor.write("\n")
+          .green().write(`    ${header}\n`)
           .reset().write(`    --------------\n`)
           .yellow().write(`    Size: ${prettysize(size)} \n`)
           .yellow().write(`    Time: ${prettyTime(took, "ms")}`)

--- a/src/Log.ts
+++ b/src/Log.ts
@@ -79,11 +79,8 @@ export class Log {
       }
       cursor.write("\n")
           .green().write(`    ${header}\n`)
-          .reset().write(`    --------------\n`)
           .yellow().write(`    Size: ${prettysize(size)} \n`)
           .yellow().write(`    Time: ${prettyTime(took, "ms")}`)
-          .write("\n")
-          .reset().write(`    --------------\n`)
           .write("\n").reset();
     }
 }

--- a/src/plugins/UglifyJSPlugin.ts
+++ b/src/plugins/UglifyJSPlugin.ts
@@ -1,8 +1,6 @@
 import { Plugin } from "../WorkflowContext";
 import { BundleSource } from '../BundleSource';
 
-
-
 /**
  * @export
  * @class UglifyJSPluginClass
@@ -42,10 +40,17 @@ export class UglifyJSPluginClass implements Plugin {
 			}
 		}
 
+		let timeStart = process.hrtime();
+
 		const result = UglifyJs.minify(source, {
 			...this.options,
 			...mainOptions
 		});
+
+		let took = process.hrtime(timeStart)
+		let bytes = Buffer.byteLength(result.code, "utf8")
+
+		context.log.echoBundleStats(bytes, took)
 
 		newConcat.add(null, result.code, result.map || sourceMap);
 	}

--- a/src/plugins/UglifyJSPlugin.ts
+++ b/src/plugins/UglifyJSPlugin.ts
@@ -50,7 +50,7 @@ export class UglifyJSPluginClass implements Plugin {
 		let took = process.hrtime(timeStart)
 		let bytes = Buffer.byteLength(result.code, "utf8")
 
-		context.log.echoBundleStats('UglifyJS Bundle', bytes, took)
+		context.log.echoBundleStats('Bundle (Uglified)', bytes, took)
 
 		newConcat.add(null, result.code, result.map || sourceMap);
 	}

--- a/src/plugins/UglifyJSPlugin.ts
+++ b/src/plugins/UglifyJSPlugin.ts
@@ -50,7 +50,7 @@ export class UglifyJSPluginClass implements Plugin {
 		let took = process.hrtime(timeStart)
 		let bytes = Buffer.byteLength(result.code, "utf8")
 
-		context.log.echoBundleStats(bytes, took)
+		context.log.echoBundleStats('UglifyJS Bundle', bytes, took)
 
 		newConcat.add(null, result.code, result.map || sourceMap);
 	}


### PR DESCRIPTION
This is for #167, but it is not ready. I want to start a discussion.

This is what the report looks like currently
![image](https://cloud.githubusercontent.com/assets/1187432/23035608/90b4e3d4-f434-11e6-86f0-a8c456937d84.png)

Obviously the lack of a label on the second report is one issue. I'm a little confused on how @nchanged wants to organize things. Things seem sort of abstracted around the `context` object, but the `Log` modules on `context` seems pretty specific to logging `ModuleCollection`, and their isn't another logging module. 

* Do you want a new logging module to abstract logging?
* Do you want `cursor` use directly in the `UglifyJSPluginClass`
* ... something else?
