### PR TITLE
Fix files not bundled on windows OS when root starts with lower case  drive letter

### DIFF
--- a/src/PathMaster.ts
+++ b/src/PathMaster.ts
@@ -9,7 +9,7 @@ import { Config } from "./Config";
  * If a import url isn't relative
  * and only has ascii + @ in the name it is considered a node module
  */
-const NODE_MODULE = /^([a-z@].*)$/;
+const NODE_MODULE = /^[^:]([a-z@].*)$/;
 
 export interface INodeModuleRequire {
     name: string;


### PR DESCRIPTION
Fix files not bundled on windows OS when root starts with lower case  drive letter closes #189