### PR TITLE
Pass the source file name to the transpiler

### DIFF
--- a/src/File.ts
+++ b/src/File.ts
@@ -334,8 +334,7 @@ export class File {
         this.loadContents();
         // Calling it before transpileModule on purpose
         this.tryTypescriptPlugins();
-        let result = ts.transpileModule(this.contents, this.context.getTypeScriptConfig());
-
+        let result = ts.transpileModule(this.contents, this.getTranspilationConfig());
 
         if (result.sourceMapText && this.context.sourceMapConfig) {
             let jsonSourceMaps = JSON.parse(result.sourceMapText);
@@ -364,5 +363,23 @@ export class File {
             });
             this.context.cache.writeStaticCache(this, this.sourceMap);
         }
+    }
+
+    /**
+     * Provides a file-specific transpilation config. This is needed so we can supply the filename to
+     * the TypeScript compiler.
+     * 
+     * @private
+     * @returns
+     * 
+     * @memberOf File
+     */
+    private getTranspilationConfig() {
+        return Object.assign({},
+            this.context.getTypeScriptConfig(),
+            {
+                fileName: this.info.absPath,
+            }
+        );
     }
 }


### PR DESCRIPTION
When transpiling files as modules, the filename is passed to TypeScript so it can interpret it properly. This is necessary to respect the behavior of the command line, especially when deciding whether files should be interpreted as jsx/tsx files, as per [the transpiler reference](https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API#transpiling-a-single-file).

See issue #213 for the original report.