### PR TITLE
Fixes user-defined sass includePaths from being overwritten

### DIFF
--- a/src/plugins/SassPlugin.ts
+++ b/src/plugins/SassPlugin.ts
@@ -32,8 +32,12 @@ export class SassPluginClass implements Plugin {
             sourceMap: true,
             outFile: file.info.fuseBoxPath,
             sourceMapContents: true,
-            includePaths: [],
         }, this.options);
+
+        options.includePaths = [];
+        this.options.includePaths.forEach((path) => {
+            options.includePaths.push(path);
+        });
 
         options.includePaths.push(file.info.absDir);
 

--- a/src/plugins/SassPlugin.ts
+++ b/src/plugins/SassPlugin.ts
@@ -35,9 +35,11 @@ export class SassPluginClass implements Plugin {
         }, this.options);
 
         options.includePaths = [];
-        this.options.includePaths.forEach((path) => {
-            options.includePaths.push(path);
-        });
+        if (typeof this.options.includePaths !== "undefined"){
+            this.options.includePaths.forEach((path) => {
+                options.includePaths.push(path);
+            });
+        }
 
         options.includePaths.push(file.info.absDir);
 


### PR DESCRIPTION
Fixes https://github.com/fuse-box/fuse-box/issues/278