### PR TITLE
docs, easier deps

### DIFF
--- a/docs/builtin-plugins.md
+++ b/docs/builtin-plugins.md
@@ -1,16 +1,19 @@
 # Built-in plugins
 
-Fusebox contains premade plugins, that should help you to get started.
+Fusebox contains premade plugins that should help you to get started.
 
 ## CSS Plugin
 CSSPlugin should be always at the end of any CSS processor chain, as it handles everything that is relating to bundling, reloading and grouping.
 
 
+[see the mastering css with fusebox example](https://github.com/fuse-box/mastering-css)
+
+
 ### Inline CSS
 
-```
-plugins : [
-  CSSPlugin()
+```js
+plugins: [
+  CSSPlugin(),
 ]
 ```
 That configuration gets all `.css` on they way, and inlines them in your bundle.
@@ -20,10 +23,11 @@ That configuration gets all `.css` on they way, and inlines them in your bundle.
 You can write files to the file system as well.
 
 ```js
-plugins : [
+let tmp = './tmp'
+plugins: [
     CSSPlugin({
-        outFile: (file) => `${tmp}/${file}`
-    })
+        outFile: (file) => `${tmp}/${file}`,
+    }),
 ]
 ```
 
@@ -35,27 +39,27 @@ FuseBox will automatically inject your files into the HEAD once required
 
 ### Head injection
 
-CSSPlugin automatically appends your script into the HEAD by default. You can override it by setting `{inject : false}`
+CSSPlugin automatically appends your script into the HEAD by default. You can override it by setting `{inject: false}`
 
 ```js
-plugins : [
+plugins: [
     CSSPlugin({
         outFile: (file) => `${tmp}/${file}`,
-        inject : false
-    })
+        inject: false,
+    }),
 ]
 ```
 Now you can manually append your css file!
 
-If you want to keep the magic but configure the injection yourself, you can provide a callback to the `inject` 
+If you want to keep the magic but configure the injection yourself, you can provide a callback to the `inject`
 parameter to customise your css file resolver in the browser
 
 ```js
-plugins : [
+plugins: [
     CSSPlugin({
         outFile: (file) => `${tmp}/${file}`,
-        inject: (file) => `custom/${file}`
-    })
+        inject: (file) => `custom/${file}`,
+    }),
 ]
 ```
 Will result in:
@@ -63,37 +67,36 @@ Will result in:
 ```html
 <link rel="stylesheet" type="text/css" href="custom/main.css">
 ```
- 
+
 
 ### Grouping files
 
-You can group many css files into a one file. 
+You can group many css files into a one file.
 
 
 ```js
-plugins : [
-    CSSPlugin({group : "bundle.css"})
+plugins: [
+    CSSPlugin({group: "bundle.css"}),
 ]
 ```
 
-the `group` option should not contain any relative or absolute paths. This is a virtual file in the dependency tree. You can use 
+the `group` option should not contain any relative or absolute paths. This is a virtual file in the dependency tree. You can use
 all paramters described above to customise the behaviour. For example
 
 ```js
  plugins: [CSSPlugin({ group: "app.css", outFile: `${tmp}/app.css` })],
-
 ```
 
 > NOTE! outFile should be a string when used with `group` option.
 
-Check the tests [here](https://github.com/fuse-box/fuse-box/blob/master/test/css_plugin.js) 
+Check the tests [here](https://github.com/fuse-box/fuse-box/blob/master/test/css_plugin.js)
 
 ## CSSResourcePlugin
 
 Imagine a situation where you import a css file from an npm library.
 Let's try  make [jstree](https://github.com/vakata/jstree) library work
 
-```
+```js
 import "jstree/dist/jstree.js";
 import "jstree/dist/themes/default/style.css";
 ```
@@ -104,13 +107,13 @@ It re-writes URL and copies files to a destination specified by user,
 
 ### Copy files
 
-```
-plugins : [
+```js
+plugins: [
    [/node_modules.*\.css$/,
-      build.CSSResourcePlugin({
-          dist : "build/resources",
-          resolve : (f) => `/resources/${f}`
-      }), build.CSSPlugin()]
+      fsbx.CSSResourcePlugin({
+          dist: "build/resources",
+          resolve: (f) => `/resources/${f}`
+      }), fsbx.CSSPlugin()]
 ]
 ```
 
@@ -120,12 +123,12 @@ plugins : [
 ### Inline
 You can inline images as well
 
-```
-plugins : [
+```js
+plugins: [
    [/node_modules.*\.css$/,
-      build.CSSResourcePlugin({
-            inline : true
-      }), build.CSSPlugin()]
+    fsbx.CSSResourcePlugin({
+      inline: true,
+    }), fsbx.CSSPlugin()],
 ]
 ```
 
@@ -141,7 +144,7 @@ Less plugin should be chained along the with the CSSPlugin
 
 ```js
 plugins:[
-  [fsbx.LESSPlugin(), fsbx.CSSPlugin()]
+  [fsbx.LESSPlugin(), fsbx.CSSPlugin()],
 ],
 ```
 
@@ -161,7 +164,6 @@ PostCSS should be chained along the with the CSSPlugin
 ```js
 const precss = require("precss");
 const POST_CSS_PLUGINS = [precss()];
-
 
 plugins:[
   [fsbx.PostCSS(POST_CSS_PLUGINS), fsbx.CSSPlugin()],
@@ -183,7 +185,7 @@ Make files export text data
 
 ```js
 plugins:[
- [/\.raw$/, RawPlugin({extensions: ['.raw']})]
+ [/\.raw$/, RawPlugin({extensions: ['.raw']})],
 ],
 ```
 
@@ -196,23 +198,32 @@ npm install node-sass
 Usage:
 ```js
 plugins:[
-  [fsbx.SassPlugin({ /* options */ })]
+  [fsbx.SassPlugin({ /* options */ })],
 ],
 ```
 
 ## HTML Plugin
 ```js
 plugins: [
-  fsbx.HTMLPlugin({ useDefault: false })
+  fsbx.HTMLPlugin({ useDefault: false }),
 ]
 ```
 
 Toggle `useDefault` to make HTML files export strings as `default` property.
-For example with `useDefault: true` you will be able to import HTML files like so :
+For example with `useDefault: true` you will be able to import HTML files like so:
 
 ```js
 import tpl from "~/views/file.html"
 ```
+
+With `useDefault: true`, is as if the html file contains this:
+```jsx
+export default `
+  <!DOCTYPE html>
+  <title>eh</title>
+`
+```
+
 
 ## ImageBase64Plugin
 Works greatly if you want to have images bundled
@@ -220,9 +231,9 @@ Works greatly if you want to have images bundled
 ```bash
 npm install base64-img --save-dev
 ```
-```
+```js
 plugins: [
-    fsbx.ImageBase64Plugin()
+    fsbx.ImageBase64Plugin(),
 ]
 ```
 
@@ -249,16 +260,16 @@ For example. to transpile JSX, you can use this configuration.
             sourceMaps: true,
             presets: ["es2015"],
             plugins: [
-                ["transform-react-jsx"]
-            ]
-        }
+                ["transform-react-jsx"],
+            ],
+        },
     })
 ]
 ```
 
-`limit2project` set to true, to use this plugin across an entire project (including other modules like npm)
+`limit2project` is default true, to use this plugin across an entire project (including other modules like npm)
 
-Note, that if you want to have sourcemaps in place, set `sourceMaps` to true. Read sourcemaps section for better understanding how sourcemaps are defined.
+Note, that if you want to have sourceMaps in place, set `sourceMaps` to true. [Read sourceMaps section](#sourcemaps) for better understanding how sourceMaps are defined.
 
 
 ## JSON plugin
@@ -266,7 +277,7 @@ Of course, it can't be all shiny without a JSON plugin, can it? (Allows `.json` 
 
 ```js
 plugins: [
-    fsbx.JSONPlugin()
+    fsbx.JSONPlugin(),
 ]
 ```
 
@@ -275,7 +286,7 @@ React lovers, [here it is](https://github.com/fuse-box/react-example/blob/master
 
 ```js
 plugins: [
-    fsbx.SVGPlugin()
+    fsbx.SVGPlugin(),
 ]
 ```
 
@@ -284,7 +295,7 @@ Add anything at the top of your bundle.
 ```js
 plugins: [
     // Add a banner to bundle output
-    fsbx.BannerPlugin('// Hey this is my banner! Copyright 2016!')
+    fsbx.BannerPlugin('// Hey this is my banner! Copyright 2016!'),
 ]
 ```
 
@@ -293,7 +304,7 @@ Compresses your code by [UglifyJS2](https://github.com/mishoo/UglifyJS2)
 ```js
 plugins: [
     // [options] - UglifyJS2 options
-    fsbx.UglifyJSPlugin(options)
+    fsbx.UglifyJSPlugin(options),
 ]
 ```
 
@@ -307,29 +318,29 @@ sourceMap: {
   outFile: "sourcemaps.js.map",
 },
 plugins: [
-    fsbx.SourceMapPlainJsPlugin();
-]
+    fsbx.SourceMapPlainJsPlugin(),
+],
 ```
 
 ## EnvPlugin
 Writes environment variables to both client and server at build time.
 
 ```js
-plugins : [
-   fsbx.EnvPlugin({ NODE_ENV: "production" })
-]
+plugins: [
+   fsbx.EnvPlugin({ NODE_ENV: "production" }),
+],
 ```
 
 Access it like you used to:
 
-```
-console.log( process.env.NODE_ENV )
+```js
+console.log(process.env.NODE_ENV)
 ```
 
 The order of plugins is important: environment variables created with this plugin will only be available to plugins further down the chain.
 
-```
-plugins : [
+```js
+plugins: [
    fsbx.BabelPlugin({ /* settings /*}), // <-- won't have NODE_ENV set
    fsbx.EnvPlugin({ NODE_ENV: "production" }),
    fsbx.BabelPlugin({ /* settings /*}), // <-- will have NODE_ENV set
@@ -341,11 +352,11 @@ plugins : [
 Handle [CoffeeScript](http://coffeescript.org) compilation of .coffee files
 
 ```js
-plugins : [
+plugins: [
    fsbx.CoffeePlugin({
        // Options passed to the coffeescript compiler
-   })
-]
+   }),
+],
 ```
 
 ## Typescript helpers
@@ -373,10 +384,10 @@ Simply add TypeScriptHelpers to your plugin list. No further configuration requi
 
 ```js
 const fsbx = require("fuse-box");
-let fuseBox = fsbx.FuseBox.init({
+let fuse = fsbx.FuseBox.init({
     homeDir: "test/fixtures/cases/ts",
     outFile: "./out.js",
-    plugins: [fsbx.TypeScriptHelpers()]
+    plugins: [fsbx.TypeScriptHelpers()],
 });
 
 ```

--- a/docs/bundle.md
+++ b/docs/bundle.md
@@ -14,19 +14,19 @@ fuse.bundle(">index.js");
 ```
 
 * If you want a bundle to be executed on load, add `>` in front of your entry file. In case your bundle serves as an individual library, you would not want to make an automatic execution.
-* Make sure to keep the extension as you can point to a typescript file. 
+* Make sure to keep the extension as you can point to a typescript file.
 * All *inputs* are relative to `homeDir`
 
 With arithmetic instructions, you can explicitly define which files go to the bundle, which files skip external dependencies e.g.
 
 ```js
-fuseBox.bundle(">index.ts [lib/**/*.ts]");
+fuse.bundle(">index.ts [lib/**/*.ts]");
 ```
 
-In this case, you will get everything that is required in the index, as well as everything that lies under `lib/` folder with one condition - any external libraries will be ignored. 
+In this case, you will get everything that is required in the index, as well as everything that lies under `lib/` folder with one condition - any external libraries will be ignored.
 
 ### Examples for better understanding
-`> index.js [**/*.js]` - Bundle everything without dependencies, and execute `index.js`
+`> index.js [**/*.js]` - Bundle everything without dependencies, and execute `index.js`.
 
 `[lib/*.js] +path +fs` - Bundle all files in lib folder, ignore node modules except for `path` and `fs`
 
@@ -37,27 +37,27 @@ In this case, you will get everything that is required in the index, as well as 
 `**/*.js -path` - Bundle everything with dependencies except for module `path`
 
 ## Making many bundles at once
-You can specify many `{ outFile : bundleStr }`. Your config (excluding `outFile`) will be copied for every single process.
+You can specify many `{ outFile: bundleStr }`. Your config (excluding `outFile`) will be copied for every single process.
 
 For example:
 
 ```js
-fuseBox.bundle({
+fuse.bundle({
     "_build/test_vendor.js": "+path",
     "_build/app.js": ">[index.ts]"
 });
 ```
 
 ## Bundle in a bundle
-Super powers of FuseBox allow doing that without code redundancy. An API of a second bundle will be removed, and 2 bundles will be fused together, keeping only one shared Fusebox API.
+The super powers of FuseBox allow merging bundles inside of bundles without code redundancy. The API of a second bundle will be removed, and 2 bundles will be fused together, keeping only one shared Fusebox API.
 
 Only one thing you need to consider before that - packaging.
 
-Your current project is called "default" This is by design. All dynamic modules will register themselves into it automatically. 
+Your current project is called "default" This is by design. All dynamic modules will register themselves into it automatically.
 
-If you want to require a bundle it must have a different namespace. Unless you want to keep it shared. Read up on [package naming](#package-name) for better understanding
+If you want to require a bundle it must have a different namespace. Unless you want to keep it shared. Read up on [package naming](#package-name) for better understanding.
 
-Bundle your first package, then make sure you master bundle does not have the same name (otherwise they will share filename scopes) and require it like any other file
+Bundle your first package, then make sure your master/main bundle does not have the same package name (otherwise they will [share filename scopes](#scoping-fused)) and require it like any other file.
 
 ```js
 import * as myLib from "./bundles/myLib.js"
@@ -69,17 +69,17 @@ FuseBox sniffs its own creations and restructures the code accordingly.
 you can import using the fusebox api wrapper that is built into the bundle
 ```js
 const bundled = require("./magic/yourOutFile.js")
-const exports = bundle.FuseBox.import("./yourBundle.js");
+const exports = bundled.FuseBox.import("./yourBundle.js");
 ```
 
 or you can import the file directly using FuseBox
 ```
-const fusebox = require("fuse-box")
-const FuseBox = fusebox.FuseBox
+const fsbx = require("fuse-box")
+const FuseBox = fsbx.FuseBox
 
 const bundled = require("./magic/yourOutFile.js")
 const bundled = FuseBox.import("./yourBundle.js")
 ```
 
 ## Scoping / Fused
-If you have more than one bundle and require them, they will be `fused` behind the scenes. That is to say, they will be able to import from each other. This is possible because FuseBox is not just a bundler, but a full featured virtual environment! [See an example using fusing](https://github.com/fuse-box/fuse-box-scopes-example). 
+If you have more than one bundle and require them, they will be `fused` behind the scenes. That is to say, they will be able to import from each other. This is possible because FuseBox is not just a bundler, but a full featured virtual environment! [See an example using fusing](https://github.com/fuse-box/fuse-box-scopes-example).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -430,11 +430,13 @@ let vendors = [
   'flipbox',
   'path',
   'fs',
-].map(vendor => ' -' + vendor).join('')
+]
+const vendorInst = "[async-registry.js]" + vendors.map(vendor => ' +' + vendor).join('')
+const appInst = ">[index.ts]" + vendors.map(vendor => ' -' + vendor).join('')
 
 const multipleBundles = {
-    "./build/vendorBundle.js": "[async-registry.js]" + vendors,
-    "./build/appBundle.js": ">[index.ts]",
+    "./build/vendorBundle.js": vendorInst,
+    "./build/appBundle.js": appInst,
 }
 
 const singleBundle = `

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,7 +18,7 @@ That's your _source_ folder. It can be an absolute path, Or relative to [appRoot
 
 ```js
 FuseBox.init({
-  homeDir: "./src"
+  homeDir: "./src",
 })
 ```
 
@@ -37,7 +37,7 @@ That's your _bundle_ file. It can be an absolute path, Or relative to [appRootPa
 ```js
 FuseBox.init({
   homeDir: "./src",
-  outFile: "./build/bundle.js"
+  outFile: "./build/bundle.js",
 })
 ```
 
@@ -52,9 +52,21 @@ You can turn off caching if you like. By default caching is on. FuseBox will cre
 FuseBox.init({
   homeDir: "./src",
   outFile: "./build/bundle.js",
-  cache: true
+  cache: true,
 })
 ```
+
+## Debug and Log
+Additional logging and debugging can be enabled, but keep in mind they can reduce performance.
+```js
+FuseBox.init({
+  homeDir: "./src",
+  outFile: "./build/bundle.js",
+  log: true,
+  debug: true,
+})
+```
+
 
 ## Custom modules folder
 
@@ -62,7 +74,7 @@ You probably would want to test a package some day, or just have an abstraction 
 
 ```js
 FuseBox.init({
-    modulesFolder: "src/modules"
+    modulesFolder: "src/modules",
 })
 ```
 
@@ -80,7 +92,7 @@ It's imperative having a __unique name__ (matching an npm package) when publishi
 
 ```js
 FuseBox.init({
-    package: "mySuperLib"
+    package: "mySuperLib",
 })
 ```
 If you want to have an entry point (main) file, define it like so:
@@ -88,9 +100,9 @@ If you want to have an entry point (main) file, define it like so:
 ```js
 FuseBox.init({
     package:{
-        name :  "mySuperLib",
-        main : "index.ts"
-    }
+        name: "mySuperLib",
+        main: "index.ts",
+    },
 })
 ```
 If you don't want to you have your package execute on load, make sure your instruction does not have `>` in it.
@@ -100,7 +112,7 @@ Here is an example how make a package:
 FuseBox.init({
     package: {
         name: "super-name",
-        entry: "index.ts"
+        entry: "index.ts",
     },
     homeDir: `/src-package`,
     outFile: `build/packages/super-name.js`,
@@ -153,6 +165,8 @@ sourceMap: {
 * `outFile` is where the sourcemap is written to disk. It can be an absolute path, Or relative to `appRootPath`.
 
 Sourcemaps currently work with [typescript](#typescript) and [BabelPlugin](#babel-plugin)
+[see the SourceMapPlainJsPlugin][#SourceMapPlainJsPlugin]
+
 
 ## List of plugins
 
@@ -160,10 +174,10 @@ Sourcemaps currently work with [typescript](#typescript) and [BabelPlugin](#babe
 ```js
 FuseBox.init({
     plugins:[
-        build.TypeScriptHelpers(),
-        build.JSONPlugin(),
-        [build.LESSPlugin(), build.CSSPlugin()],
-    ]
+        fsbx.TypeScriptHelpers(),
+        fsbx.JSONPlugin(),
+        [fsbx.LESSPlugin(), fsbx.CSSPlugin()],
+    ],
 })
 ```
 
@@ -174,8 +188,8 @@ If you are into black magic, this API is for you.
 ```js
 FuseBox.init({
     autoImport: {
-        Inferno: "inferno"
-    }
+        Inferno: "inferno",
+    },
 })
 ```
 Whereas the key `Inferno` (uppercase) is a variable name, and `inferno` (lowercase) is a require statement.
@@ -201,14 +215,14 @@ However `var Inferno = {};` will do nothing.
 ## Alias
 If you are coming from WebPack this feature might be helpful.
 
-> Alias is an experimental feature; the API might change in the feature. 
+> Alias is an experimental feature; the API might change in the feature.
 > using Alias breaks sourcemaps of a file where it's being used as it is required to re-generated the source code (this will be fixed soon)
 
 ```js
 FuseBox.init({
-    alias : {
+    alias: {
         "faraway": "~/somewhere/far/away/",
-    }
+    },
 })
 ```
 
@@ -219,9 +233,9 @@ You can also alias npm packages:
 
 ```js
 FuseBox.init({
-    alias : {
-        "babel-utils": "babel/dist/something/here/utils"
-    }
+    alias: {
+        "babel-utils": "babel/dist/something/here/utils",
+    },
 })
 ```
 
@@ -251,8 +265,8 @@ FuseBox.init({
    shim: {
         jquery: {
             source: "node_modules/jquery/dist/jquery.js",
-            exports: "$"
-        }
+            exports: "$",
+        },
    }
 });
 ```
@@ -269,13 +283,13 @@ The key `jquery` in our case is used to define package name: for example, you ca
 
 Example shim config:
 ```js
-shim : {
-   "react-native-web": { exports : "require('react-native')"}
+shim: {
+   "react-native-web": { exports: "require('react-native')"},
 }
 ```
 Now you can reference it like  `window.ReactNative`, and require function is at your convenience.
 
-Important to note, shims will not be analyzed, which means they should be transpiled before importing, or imported into an environment that does not need them to be transpiled. Shimming works similar to [requirejs](http://requirejs.org/) and [jspm](http://jspm.io/). 
+Important to note, shims will not be analyzed, which means they should be transpiled before importing, or imported into an environment that does not need them to be transpiled. Shimming works similar to [requirejs](http://requirejs.org/) and [jspm](http://jspm.io/).
 
 For an example, see [shimming in the fuse config](https://github.com/fuse-box/shimming-and-css-example/blob/master/fuse.js#L7) and [how it can be accessed in your code](https://github.com/fuse-box/shimming-and-css-example/blob/master/src/index.ts#L4)
 
@@ -288,9 +302,150 @@ you might want to make fuse think that it is running on server.
 
 ```js
 FuseBox.init({
-    serverBundle: true
+    serverBundle: true,
 })
 ```
 > Use it ONLY for electron environment. This is a very special case that allows FuseBox to be run in browser but behave as if it's running on server.
 
 Don't run that bundle in a traditional browser.
+
+
+
+
+## Full Config
+An example using the available config options might look similar to:
+```js
+import fsbx from "fuse-box"
+const FuseBox = fsbx.FuseBox
+
+const config = {
+  homeDir: "./src",
+  outFile: "./build/bundle.js",
+  log: true,
+  debug: true,
+  plugins:[
+    fsbx.BabelPlugin({
+      // test is optional
+      // this would make it only parse `.jsx` files
+      // it defaults to `js` and `jsx`
+      test: /\.jsx$/,
+
+      // if no config is passed in,
+      // it will use the .babelrc closest to homeDir
+      config: {
+        "sourceMaps": true,
+        "presets": ["latest"],
+        "plugins": [
+          "transform-react-jsx",
+          "transform-object-rest-spread",
+          "transform-decorators-legacy",
+          "transform-class-properties",
+          "add-module-exports",
+        ],
+      },
+
+      // this is default `true`
+      // setting this to false
+      // means babel will parse _all imported node modules_
+      limit2project: true,
+    }),
+
+    fsbx.TypeScriptHelpers(),
+    fsbx.JSONPlugin(),
+    fsbx.HTMLPlugin({ useDefault: false })
+
+    // these css plugins are chained
+    [
+      fsbx.LESSPlugin(),
+      fsbx.CSSPlugin({
+        // file is the file.info.absPath
+        // more info on that in the `Plugin API` section
+        outFile: (file) => `./tmp/${file}`
+      })
+    ],
+
+    fsbx.SourceMapPlainJsPlugin(),
+  ],
+
+  shim: {
+    "react-native-web": {
+      exports: `require("react-native")`,
+    },
+  },
+
+  alias: {
+    // node modules
+    "babel-utils": "babel/dist/something/here/utils",
+
+    // homeDir
+    "faraway": "~/somewhere/far/away/",
+  },
+
+  // this works in a similar way to how things such as `process.env`
+  // are automatically added for the browser
+  autoImport: {
+    // used any time we do `Inferno.anything` in the source code
+    Inferno: "inferno",
+  },
+
+  // is for the package `canadaEh`
+  // will export everything that your entry point
+  // think of it as `entry point exports`
+  // and it also adds the exports to `global` or `window`
+  globals: { "canadaEh": "*" },
+
+  // package can just be a string naming your package
+  package: {
+    // name must be unique
+    name: "canadaEh",
+    // main is optional, it is used as an optional entry point
+    main: "index.ts",
+  },
+
+  sourceMap: {
+    bundleReference: "sourcemaps.js.map",
+    outFile: "sourcemaps.js.map",
+  },
+}
+
+if (process.env.NODE_ENV === 'production') {
+  // [options] - UglifyJS2 options
+  const prodPlugins = [
+    fsbx.UglifyJSPlugin(options),
+    fsbx.EnvPlugin({ NODE_ENV: "production" }),
+  ]
+  config.plugins = config.plugins.concat(prodPlugins)
+}
+
+// this is the same as
+// const fuse = new FuseBox(config)
+const fuse = FuseBox.init(config)
+
+// --- bundling
+
+let frontEndDev = true
+let vendors = [
+  'commander',
+  'tosource',
+  'flipbox',
+  'path',
+  'fs',
+].map(vendor => ' -' + vendor).join('')
+
+const multipleBundles = {
+    "./build/vendorBundle.js": "[async-registry.js]" + vendors,
+    "./build/appBundle.js": ">[index.ts]",
+}
+
+const singleBundle = `
+    > [index.ts]
+    + [**/*.html]
+    + [**/*.js]
+    + [**/*.ts]
+    + [**/*.css]
+`
+
+if (frontEndDev) bundle.devServer(singleBundle)
+else bundle.bundle(multipleBundles)
+
+```

--- a/docs/devserver.md
+++ b/docs/devserver.md
@@ -2,7 +2,7 @@
 
 To run a development server all you need is to change `bundle` to `devServer`
 
-## Launch express and socket 
+## Launch express and socket
 ```js
 FuseBox.init({
     homeDir: "src",
@@ -12,13 +12,13 @@ FuseBox.init({
 the `devServer` function takes an *optional* options parameter as a second argument.
 
 ### Changing the served folder
-FuseBox will automatically serve your `build` folder e.g. with `outFile : "build/out.js"` it will serve the folder `build/`.
+FuseBox will automatically serve your `build` folder e.g. with `outFile: "build/out.js"` it will serve the folder `build/`.
 
-You can change it by passing in a string value to the `root` option (It can be an absolute path, Or relative to `appRootPath`): 
+You can change it by passing in a string value to the `root` option (It can be an absolute path, Or relative to `appRootPath`):
 
 ```js
 devServer(">index.ts", {
-   root: 'public/build'
+   root: 'public/build',
 });
 ```
 
@@ -27,7 +27,7 @@ By default you will get `express` application running and a `socket` server boun
 
 ```js
 devServer(">index.ts", {
-   port: 8081
+   port: 8081,
 });
 ```
 
@@ -37,7 +37,7 @@ If you not into Hot Reload, you can disable it:
 
 ```js
 devServer(">index.ts", {
-   hmr : false
+   hmr: false,
 });
 ```
 
@@ -46,7 +46,7 @@ You can customize the URI if required.
 
 ```js
 devServer(">index.ts", {
-   socketURI : "wss://localhost:3333" 
+   socketURI: "wss://localhost:3333",
 });
 ```
 
@@ -54,7 +54,7 @@ devServer(">index.ts", {
 Access express application like so:
 ```js
 const self = devServer(">index.ts", {
-   port: 8081
+   port: 8081,
 });
 self.httpServer.app.use(/* your middleware */);
 ```
@@ -64,7 +64,7 @@ You can set `root` to false if you want to manually configure the root path
 ```js
 const self = devServer(">index.ts", {
    port: 8081,
-   root: false
+   root: false,
 });
 self.httpServer.serveStatic("*", "build/static");
 ```
@@ -77,9 +77,9 @@ this.app.use(userPath, express.static(ensureUserPath(userFolder)));
 
 You can also create an SPA server which fallbacks to index.html
 ```js
-var express = require('express');
-var path = require('path')
-var server = devServer('>index.js', {
+import express import 'express'
+import path import 'path'
+const server = devServer('>index.js', {
     port: 8081,
 });
 server.httpServer.app.use(express.static(path.join('build','static')));
@@ -93,7 +93,7 @@ server.httpServer.app.get('*', function(req, res) {
 You can manually sent events on file change like so:
 
 ```js
-fuseBox.devServer(">index.ts", {
+fuse.devServer(">index.ts", {
     emitter: (self, fileInfo) => {
         self.socketServer.send("source-changed", fileInfo);
     }
@@ -105,10 +105,10 @@ fuseBox.devServer(">index.ts", {
 If you have an existing http application (java, python, nodejs - it does not matter), you can easily integrate fusebox with it.
 ```js
 fuse.devServer(">app.tsx", {
-    port: 8080, 
-    httpServer: false
+    port: 8080,
+    httpServer: false,
 });
 ```
-In this configuration `port: 8080` corresponds to a socket server port, having `httpServer:false` makes it work only in `socket` mode.  Once you page it loaded, `FuseBox API` will try to connect to `:8080` port an start listening to events.
+In this configuration `port: 8080` corresponds to a socket server port, having `httpServer: false` makes it work only in `socket` mode.  Once you page it loaded, `FuseBox API` will try to connect to `:8080` port an start listening to events.
 
 See the [fuse-box-express-example](https://github.com/fuse-box/fuse-box-express-seed) for a more detailed setup.

--- a/docs/format.md
+++ b/docs/format.md
@@ -1,0 +1,16 @@
+# format for examples
+- examples must have trailing commas, this allows copy pasting without added work
+- when all docs follow a format, changing the format is quite easy since things can be search-and-replaced
+- to keep consistency across the docs:
+  - import from `fuse-box` is `fsbx`
+    - `import fsbx from "fuse-box"`
+    - `fsbx.TypeScriptHelpers()`
+  - `.FuseBox` from `fsbx` (`fsbx.FuseBox`) is `FuseBox`:
+    - `const FuseBox = fsbx.FuseBox`
+  - instantiation of `FuseBox` is `fuse`
+    - `const fuse = FuseBox.init(config)`
+  - use `.init` and not `new` except when explaining the ability to use `new`
+  - all objects have no spacing between property and value
+    - good: `{port: 8080}`
+    - bad  : `{port : 8080}`
+    - bad:`{port:8080}`

--- a/docs/internal-process.md
+++ b/docs/internal-process.md
@@ -1,0 +1,37 @@
+### internal steps
+
+#### bundle step (1)
+- bundle(config) is called
+  - if config is an object, internally it instantiate a new FuseBox instance for each property.
+  - if it is a string, it will instantiate one FuseBox instance.
+  - each instance's constructor will
+    - initiate a cache for a context
+    -
+- [workflow context][src-workflow-context] is reset
+- [preBundle](#preBundle) is triggered
+- [shims][#shimming] are added
+- [bundleStart](#bundleStart) is triggered
+- [Arithmetics][src-arithmetic] are parsed
+
+#### process step (2)
+- [modules are collected (moduleCollection)][src-module-collection-collectmodules]
+- [paths are resolved][src-path-master]
+- [.collectBundle (bundleCollection)][src-module-collection-collectbundle]
+  - [plugins init is called][#init]
+  - [the collections are logged][src-log] (you will see this in the console as `└──`)
+  - bundleCollection.transformGroups is called
+    - fileGroups are looped
+      - nested dependencies all grouped into one promise array to flatten
+      - if they are cached & cache is enabled, the cache is used
+      - otherwise resolveNodeModule is called: .resolveNodeModule -> resolve()
+        - checks whether they should be bundled, or excluded
+        - checks for any conflictingVersions
+
+[src-module-collection-collectmodules]: (https://github.com/fuse-box/fuse-box/tree/master/src/ModuleCollection.ts)
+[src-module-collection-collectbundle]: (https://github.com/fuse-box/fuse-box/tree/master/src/ModuleCollection.ts)
+
+[src-log]: https://github.com/fuse-box/fuse-box/blob/master/src/Log.ts
+[src-file]: https://github.com/fuse-box/fuse-box/blob/master/src/File.ts
+[src-path-master]: (https://github.com/fuse-box/fuse-box/tree/master/src/PathMaster.ts)
+[src-workflow-context]: (https://github.com/fuse-box/fuse-box/tree/master/src/WorkFlowContext.ts)
+[src-arithmetic]: (https://github.com/fuse-box/fuse-box/tree/master/src/WorkFlowContext.ts)

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -5,11 +5,11 @@
 
 [![NPM](https://nodei.co/npm/fuse-box.png?downloads=true)](https://nodei.co/npm/fuse-box/)
 
-FuseBox is a bundler/module loader that combines the power of webpack, JSPM and SystemJS. 
+FuseBox is a bundler/module loader that combines the power of webpack, JSPM and SystemJS.
 
 It is blazing fast (it takes 50-100ms to re-bundle) which makes it extremely convenient for developers. It requires zero configuration to bundle such monsters like `babel-core`.
 
-FuseBox loves __typescript__, and does not require any additional configuration. It will compile and bundle your code within a fraction of a second, yet offering a comprehensive loader API. 
+FuseBox loves __typescript__, and does not require any additional configuration. It will compile and bundle your code within a fraction of a second, yet offering a comprehensive loader API.
 
 It is packed with features, and unfolds limitless possibilities of extending the API.
 
@@ -37,9 +37,9 @@ Learn how [easy it](https://github.com/fuse-box/angular2-example) is to fuse ang
 ## Effortless bundling
 You have an npm library in mind? You can bundle it without any extra configuration. babel-core with all plugins? No problem, fusebox will take care of everything you need.
 
-__Typescript__! Oh! We love typescript. You know what you need to do, to start transpiling and bundling typescript at the same time? `Change .js to .ts` [Are you ready?](https://github.com/fuse-box/angular2-example) 
+__Typescript__! Oh! We love typescript. You know what you need to do, to start transpiling and bundling typescript at the same time? `Change .js to .ts` [Are you ready?](https://github.com/fuse-box/angular2-example)
 
-FuseBox will take care of __ALL__ nodejs dependencies. We offer a comprehensive list of nodejs modules for browser out of the box. No worries, no matter what are you trying to bundle. It will work. 
+FuseBox will take care of __ALL__ nodejs dependencies. We offer a comprehensive list of nodejs modules for browser out of the box. No worries, no matter what are you trying to bundle. It will work.
 
 There is nothing that cannot be fused. Create a 3 liner config and bundle some heavy project! Do conventional import statements, use shared bundles, hack API, create crazy plugins!
 
@@ -54,7 +54,7 @@ Check this [benchmark](https://github.com/fuse-box/benchmark):
 1200 files to bundle
 
 |         |            |
-| ------------- |:-------------:| 
+| ------------- |:-------------:|
 | FuseBox      | 0.234s |
 | Webpack      | 1.376s |
 
@@ -62,7 +62,7 @@ Check this [benchmark](https://github.com/fuse-box/benchmark):
 1000 files to bundle / 10 times
 
 |         |            |
-| ------------- |:-------------:| 
+| ------------- |:-------------:|
 | FuseBox      | 2.257s |
 | Webpack      | 13.591s |
 
@@ -72,14 +72,13 @@ Check this [benchmark](https://github.com/fuse-box/benchmark):
 FuseBox is written in typescript, so I could not just proceed without a seamless typescript integration. In fact, you don't need to configure anything! Just point it to a typescript file, and FuseBox will do the rest.
 
 ```js
-fuseBox.bundle(">index.ts");
+fuse.bundle(">index.ts");
 ```
 
 ## Comprehensive Loader API
 
 Whatever you tempted mind would want - you can get it all here. Apply hacks, intercept require statements, use an amazing dynamic module loading, and many many other neat features!
- 
+
 ## Extensive plugins
 
 Have an idea in mind? Just develop a plugin, it's extremely easy to make one. Besides, we have [a few plugins](#built-in-plugins), that will help you get started. Want to develop one? Read up [here](#plugin-api)
-

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -9,56 +9,90 @@ Let's take a look a plugin's interface first
 ```typescript
 interface Plugin {
     test?: RegExp;
-    dependencies?: string[];
-    init: { (context: WorkFlowContext) };
-    transform: { (file: File) };
+    opts?: any;
+    init?: { (context: WorkFlowContext) };
+
+    transform: { (file: File, ast?: any) };
+    transformGroup?(file: File): any;
     onTypescriptTransform?: { (file: File) };
+
+    dependencies?: string[];
+
+    preBundle?(context: WorkFlowContext);
     bundleStart?(context: WorkFlowContext);
     bundleEnd?(context: WorkFlowContext);
+    postBundle?(context: WorkFlowContext);
+
+    // available, but not implemented yet
+    preBuild?(context: WorkFlowContext);
+    postBuild?(context: WorkFlowContext);
 }
+
 ```
 ## Spec
 
 ### test [RegExp]
 
 Defining `test` will filter files into your plugin. For example `\.js$`
-If specified you plugin's `transform` will get  triggered upon transformation. It's optional.
+If specified you plugin's `transform` will get triggered upon transformation. It's optional.
 
 ### dependencies
 
-`dependencies` a list of npm dependencies your plugin might require.  For example [this case](https://github.com/fuse-box/fuse-box/blob/master/src/plugins/CSSplugin.ts#L23)
+`dependencies` a list of npm dependencies your plugin might require. If provided, then the dependencies are loaded on the client before the plugin is invoked. For example [this case](https://github.com/fuse-box/fuse-box/blob/master/src/plugins/CSSplugin.ts#L23)
 
 ### init
 
-Happens when a plugin is initialized. Good places, to reset your states.
+Happens when a plugin is initialized. It is common practice to reset your plugin state in this method.
 
 ### transform
 
-`transform` if your plugin has a `test` property, fusebox will trigger transform method sending [file](https://github.com/fuse-box/fuse-box/blob/master/src/File.ts) as a first argument.
+`transform` if your plugin has a `test` property, fusebox will trigger transform method sending [file][src-file] as a first argument.
 
-### bundleStart
+### triggers
+
+#### bundleStart
 Happens on bundle start. A good place to inject your custom code here. For example [here](https://github.com/fuse-box/fuse-box/blob/master/src/plugins/CSSplugin.ts#L50)
 
-### bundleEnd
-All files are bundled.
+#### bundleEnd
+All files are bundled. But it has not been finalized and written to a file.
 
-Please be patient! __Documentation is in progress__. 
+#### preBundle
+Triggered after adding shims.
+
+#### postBundle
+Triggered after the bundle source has been finalized, but before it is written to file.
+[UglifyPlugin](#UglifyJSPlugin) uses this trigger.
+
+[see the source code that triggers these plugin methods](https://github.com/fuse-box/fuse-box/blob/master/src/FuseBox.ts#L179)
+
 
 ## Alternative content
 
-If for some reason we want to preserve file contents for a later reuse and override the output, we can use 
+If for some reason we want to preserve file contents for a later reuse and override the output, we can use
 `file.alternativeContent` which affects directly bundling process over [here](https://github.com/fuse-box/fuse-box/blob/96b646a632f886f296a533ccf4c45f436cf443f3/src/BundleSource.ts#L133)
 
 It can be use for the [concat](#concat-files) technique for example
 
+If an array of plugins is passed, those plugins will be chained
+
+```js
+FuseBox.init({
+    plugins: [
+        fsbx.JSONPlugin(),
+        [fsbx.LESSPlugin(), fsbx.CSSPlugin()],
+    ],
+})
+```
 
 ## Transform
 
 ### Helpers
-- `file.contents`: can rewrite the output of a particular chunk, it is a simple string
-- `file.analysis.dependencies`: can clear/flush dependencies of a file by setting it to an empty array.
-- `file.info`: information about the file, such as `file.info.absPath` and `file.info.fuseBoxPath`
 
+#### File
+- `file.contents`: can rewrite the output of a particular chunk, it is a simple string
+- `file.info`: information about the file, such as `file.info.absPath` and `file.info.fuseBoxPath`
+- `file.analysis.dependencies`: can clear/flush dependencies of a file by setting it to an empty array.
+- [read the File source for more](https://github.com/fuse-box/fuse-box/blob/master/src/FileAnalysis.ts#L33)
 
 ### AST
 To use the AST, you need to know if the AST has been loaded already. You can do this by checking whether `file.analysis.ast` is not `undefined`.
@@ -70,36 +104,38 @@ file.analysis.parseUsingAcorn()
 file.analysis.analyze()
 ```
 
-If babel plugin has been used, the AST will be loaded using [babel babylon](https://github.com/babel/babylon).
+If the babel plugin has been used, the AST will be loaded using [babel babylon](https://github.com/babel/babylon).
 
 You can load any ast parser you'd like by
 ```js
 if (!file.analysis.ast) {
   const result = YourAST(file.contents)
-  file.analysis.loadAst(result.ast);
+  file.analysis.loadAst(result.ast)
   file.analysis.analyze()
 }
 ```
+
+[read the FileAnalysis source for more](https://github.com/fuse-box/fuse-box/blob/master/src/File.ts)
 
 
 ## Transforming typescript
 
 You can tranform typescript code before it actually gets to transpiling
 
-```
+```js
 const MySuperTranformation = {
     onTypescriptTransform: (file) => {
         file.contents += "\n console.log('I am here')";
     }
 }
 FuseBox.init({
-    plugins : [MySuperTranformation]
+    plugins: [MySuperTranformation],
 })
 ```
 
 ## Concat files
 
-It is possible to concat files into one using the plugin API. There is [ConcatPlugin](https://github.com/fuse-box/fuse-box/blob/master/src/plugins/ConcatPlugin.ts#L51) which serves as an example for the subject. 
+It is possible to concat files into one using the plugin API. There is [ConcatPlugin](https://github.com/fuse-box/fuse-box/blob/master/src/plugins/ConcatPlugin.ts#L51) which serves as an example for the subject.
 
 In order to understand how it works imagine a plugin chain:
 
@@ -115,21 +151,21 @@ public transform(file: File) {
     file.loadContents();
 
     let context = file.context;
-    
+
     // create a file group in the context with name which is set in the plugin configuration
     // let's say "txtBundle.txt"
     let fileGroup = context.getFileGroup(this.bundleName);
     if (!fileGroup) {
         fileGroup = context.createFileGroup(this.bundleName);
     }
-    // Adding current file (say a.txt) as a subFile 
+    // Adding current file (say a.txt) as a subFile
     fileGroup.addSubFile(file);
 
     // making sure the current file refers to an object at runtime that calls our bundle
     file.alternativeContent = `module.exports = require("./${this.bundleName}")`;
 }
  ```
- 
+
 When we register a new file group `context.createFileGroup("txtBundle.txt")` FuseBox creates a __fake__ or a virtual file which is added to the dependency tree. This file has a special mode, called `groupMode`.
 
 We need to alter the output as well using [alternative content](#alternative-content). Original contents will be ignored by the Source bundler.
@@ -149,11 +185,11 @@ public transformGroup(group: File) {
     group.contents = `module.exports = ${JSON.stringify(text)}`;
 }
  ```
- 
+
 Now our bundle has a virtual file which looks like this:
 
 ```js
-___scope___.file("textBundle.txt", function(exports, require, module, __filename, __dirname){ 
+___scope___.file("textBundle.txt", function(exports, require, module, __filename, __dirname){
     module.exports = "hello\nworld"
 });
 ```

--- a/docs/third-party-plugins.md
+++ b/docs/third-party-plugins.md
@@ -6,3 +6,17 @@
 | ESLinter         | ESlint plugin for fuse-box               | [DoumanAsh/fuse-box-eslint-plugin](https://github.com/DoumanAsh/fuse-box-eslint-plugin)   |
 | Closure Compiler | Fusebox Google Closure Compiler Plugin   | [matthiasak/fusebox-closure-plugin](https://github.com/matthiasak/fusebox-closure-plugin) |
 | proxying / stubbing imports | Fusebox proxying / stubbing imports  Plugin| [tomitrescak/proxyrequire](https://github.com/tomitrescak/proxyrequire) |
+
+
+# examples
+- https://github.com/fuse-box/development-playground/tree/master/src
+- https://github.com/fuse-box/mastering-css
+- https://github.com/fuse-box/shimming-and-css-example
+- https://github.com/fuse-box/fuse-box-aurelia-seed
+- https://github.com/fuse-box/angular2-example
+- https://github.com/fuse-box/fuse-box-ionic2-seed
+- https://github.com/fuse-box/fuse-box-scopes-example/tree/master/shared
+- https://github.com/fuse-box/fuse-box-ts-react-reflux-seed
+- https://github.com/fuse-box/react-example
+- https://github.com/fuse-box/fuse-box-production-test-project
+- https://github.com/fuse-box/fuse-box-production-test-package

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -4,10 +4,10 @@ Below are some tips that will improve your experience and help you  avoiding got
 
 ## General tips
 
-* Don't import **FuseBox** in your code, 
-it will cause issues, it is already added to your bundle and 
-available globally and you can access it anywhere in your code like  when you access `window`  on client or ` global` in `Node.js`. 
-for example to import a file  just use  `FuseBox.import('./myfile')`
+* Don't import **FuseBox** in your code,
+it will cause issues, it is already added to your bundle and
+available globally and you can access it anywhere in your code like when you access `window` on client or `global` in `Node.js`.
+for example to import a file just use `FuseBox.import('./myfile')`
 * Use the [EnvPlugin](#envplugin) to pass Environmental variables on both client and server, you can even use packages like [safe-env](https://www.npmjs.com/package/safe-env) with it.
 * **FuseBox** `API` has neat `isServer` and `isBrowser` methods, use them to check the environment the code is running in. for example `FuseBox.isServer` will return `true` if you are running your code in `Node.js`
 
@@ -27,8 +27,8 @@ To make this setup work with **FuseBox**, you'll need to **add** these two optio
 {
   serverBundle: true,
   shim: {
-    electron: { exports: "global.require('electron')" }
-  }
+    electron: { exports: "global.require('electron')" },
+  },
 }
 ```
 
@@ -39,4 +39,3 @@ The `shim` acts as a pass through instructing **FuseBox** to trust us that `elec
 No need to include or exclude `+electron` from your bundles. Just these few lines will do the job.
 
 Happy Electron-ing!
-

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -15,7 +15,7 @@ FuseBox.init({
          bundleReference: "./sourcemaps.js.map",
          outFile: "sourcemaps.js.map",
     },
-    outFile: "./out.js"
+    outFile: "./out.js",
 }).bundle(">index.ts");
 ```
 
@@ -27,13 +27,13 @@ FuseBox automatically switches to typescript mode by detecting the extension `.t
 
 FuseBox comes with default ts options so you don't *need* a tsconfig.
 
-If you have a tsconfig file in your `homeDir` or any directory up the file tree (e.g. `appRootPath`), it will be picked up automatically. 
+If you have a tsconfig file in your `homeDir` or any directory up the file tree (e.g. `appRootPath`), it will be picked up automatically.
 
 Alternatively you can use the tsconfig option to customize the path to tsconfig.json (It can be an absolute path, Or relative to `appRootPath`).
 
 ```js
 FuseBox.init({
-    tsConfig : "tsconfig.json"
+    tsConfig: "tsconfig.json",
 })
 ```
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -153,3 +153,24 @@ gulp.task('watch', ['dist'], function() {
         runSequence('dist-main');
     });
 });
+
+gulp.task('installDevDeps', function(done) {
+  var deps = [
+    'babel-core',
+    'babel-generator',
+    'babylon',
+    'cheerio',
+    '@angular/core',
+    'stylus',
+    'less',
+    'postcss',
+    'node-sass',
+    'uglify-js',
+    'source-map',
+    'coffee-script',
+    '@types/node',
+  ]
+  var installDeps = spawn('npm', ['install'].concat(deps), {
+      stdio: 'inherit'
+  })
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     },
     "scripts": {
         "test": "TRAVIS=true ./node_modules/mocha/bin/mocha",
-        "start": "gulp watch"
+        "start": "gulp watch",
+        "devDeps": "gulp installDevDeps"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
docs:
+ add missing types to plugin api
+ expand upon some of the fns in plugin api
+ expanding on  in babel plugin
+ extended html plugin example
+ add debug and logs docs
++ add full config
++ unify instance names in bundle
++ adding standards file for consistancy in doc
++ adding internal process doc
+ adding all examples to third party plugins doc
+ some minor grammar fixes

iteration ability:
+ add gulp command to gulpfile and package json to install devdep
+ add missing nodetypes for tsconfig to resolve not-real errors in linting