### PR TITLE
Markdown plugin

### DIFF
--- a/docs/builtin-plugins.md
+++ b/docs/builtin-plugins.md
@@ -281,6 +281,34 @@ export default `
 ```
 
 
+## Markdown Plugin
+```js
+plugins: [
+  fsbx.MarkdownPlugin({
+    useDefault: false,
+    /* marked options */
+  }),
+]
+```
+
+Toggle `useDefault` to make Markdown files export strings as `default` property.
+For example with `useDefault: true` you will be able to import Markdown files like so:
+
+```js
+import tpl from "~/views/file.md"
+```
+
+With `useDefault: true`, is as if the html file contains this:
+```jsx
+export default `
+  <!DOCTYPE html>
+  <title>eh</title>
+`
+```
+
+For other options, see https://github.com/chjj/marked.
+
+
 ## ImageBase64Plugin
 Works greatly if you want to have images bundled
 

--- a/docs/builtin-plugins.md
+++ b/docs/builtin-plugins.md
@@ -282,6 +282,9 @@ export default `
 
 
 ## Markdown Plugin
+
+Markdown Plugin generates HTML from Markdown files.
+
 ```js
 plugins: [
   fsbx.MarkdownPlugin({
@@ -289,6 +292,12 @@ plugins: [
     /* marked options */
   }),
 ]
+```
+
+It depends on marked library, so it must be installed first :
+
+```bash
+npm install marked
 ```
 
 Toggle `useDefault` to make Markdown files export strings as `default` property.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -233,6 +233,7 @@ gulp.task("installDevDeps", function(done) {
         "stylus",
         "less",
         "postcss",
+        "marked",
         "node-sass",
         "uglify-js",
         "source-map",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
         "glob": "^7.1.1",
         "ieee754": "^1.1.8",
         "inquirer": "^3.0.6",
+        "marked": "^0.3.6",
         "postcss": "^5.2.11",
         "pretty-time": "^0.2.0",
         "prettysize": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
         "glob": "^7.1.1",
         "ieee754": "^1.1.8",
         "inquirer": "^3.0.6",
-        "marked": "^0.3.6",
         "postcss": "^5.2.11",
         "pretty-time": "^0.2.0",
         "prettysize": "0.0.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export { CoffeePlugin } from "./plugins/js-transpilers/CoffeePlugin";
 export { LESSPlugin } from "./plugins/stylesheet/LESSPlugin";
 export { CSSPlugin } from "./plugins/stylesheet/CSSplugin";
 export { HTMLPlugin } from "./plugins/HTMLplugin";
+export { MarkdownPlugin } from "./plugins/Markdownplugin";
 export { JSONPlugin } from "./plugins/JSONplugin";
 export { BannerPlugin } from "./plugins/BannerPlugin";
 export { SassPlugin } from "./plugins/stylesheet/SassPlugin";

--- a/src/plugins/Markdownplugin.ts
+++ b/src/plugins/Markdownplugin.ts
@@ -1,0 +1,92 @@
+import * as marked from 'marked';
+import { File } from "../core/File";
+import { WorkFlowContext } from "../core/WorkflowContext";
+import { Plugin } from "../core/WorkflowContext";
+
+/**
+ *
+ *
+ * @export
+ * @class FuseBoxMarkdownPlugin
+ * @implements {Plugin}
+ */
+export class FuseBoxMarkdownPlugin implements Plugin {
+    private useDefault = true;
+
+    private options = {
+        renderer: new marked.Renderer(),
+        gfm: true,
+        tables: true,
+        breaks: false,
+        pedantic: false,
+        sanitize: true,
+        smartLists: true,
+        smartypants: false
+    };
+
+    constructor(opts: any = {}) {
+        if (opts.useDefault !== undefined) {
+            this.useDefault = opts.useDefault;
+        }
+
+        this.options = Object.assign(this.options, opts);
+    }
+    /**
+     *
+     *
+     * @type {RegExp}
+     * @memberOf FuseBoxMarkdownPlugin
+     */
+    public test: RegExp = /\.md$/;
+
+    /**
+     *
+     *
+     * @param {WorkFlowContext} context
+     *
+     * @memberOf FuseBoxMarkdownPlugin
+     */
+    public init(context: WorkFlowContext) {
+        context.allowExtension(".md");
+    }
+    /**
+     *
+     *
+     * @param {File} file
+     *
+     * @memberOf FuseBoxMarkdownPlugin
+     */
+    public transform(file: File) {
+
+        let context = file.context;
+        if (context.useCache) {
+            let cached = context.cache.getStaticCache(file);
+            if (cached) {
+                file.isLoaded = true;
+                file.contents = cached.contents;
+                return;
+            }
+        }
+
+        file.loadContents();
+
+        // Transform the markdown using marked
+        marked.setOptions(this.options);
+        const html = marked(file.contents);
+
+        if (this.useDefault) {
+            file.contents = `module.exports.default =  ${JSON.stringify(html)}`;
+        } else {
+            file.contents = `module.exports =  ${JSON.stringify(html)}`;
+        }
+
+        if (context.useCache) {
+            context.emitJavascriptHotReload(file);
+            context.cache.writeStaticCache(file, file.sourceMap);
+        }
+    }
+};
+
+export const MarkdownPlugin = (opts?: any) => {
+    return new FuseBoxMarkdownPlugin(opts);
+};

--- a/src/plugins/Markdownplugin.ts
+++ b/src/plugins/Markdownplugin.ts
@@ -1,7 +1,8 @@
-import * as marked from 'marked';
 import { File } from "../core/File";
 import { WorkFlowContext } from "../core/WorkflowContext";
 import { Plugin } from "../core/WorkflowContext";
+
+let marked;
 
 /**
  *
@@ -13,8 +14,7 @@ import { Plugin } from "../core/WorkflowContext";
 export class FuseBoxMarkdownPlugin implements Plugin {
     private useDefault = true;
 
-    private options = {
-        renderer: new marked.Renderer(),
+    private options: any = {
         gfm: true,
         tables: true,
         breaks: false,
@@ -69,6 +69,14 @@ export class FuseBoxMarkdownPlugin implements Plugin {
         }
 
         file.loadContents();
+
+        if (!marked) {
+          marked = require("marked");
+        }
+
+        if (this.options.renderer) {
+          this.options.renderer = new marked.Renderer();
+        }
 
         // Transform the markdown using marked
         marked.setOptions(this.options);

--- a/src/tests/MarkdownPlugin.test.ts
+++ b/src/tests/MarkdownPlugin.test.ts
@@ -1,0 +1,72 @@
+import {createEnv} from "./stubs/TestEnvironment";
+import {should} from "fuse-test-runner";
+import {MarkdownPlugin} from "../plugins/Markdownplugin";
+
+export class MarkdownPluginTest {
+    "Should get Template with Default as export"() {
+        return createEnv({
+            project: {
+                files: {
+                    "index.ts": `const template= require('./index.md');`,
+                    "index.md": `# hello`,
+                },
+                plugins: [MarkdownPlugin()],
+                instructions: "> index.ts **/*.md",
+            },
+        }).then((result) => {
+            const contents = result.projectContents.toString();
+            should(contents).findString(`module.exports.default =  "<h1 id=\\"hello\\">hello</h1>\\n"`);
+        });
+    }
+
+    "Should get Template without Default as export"() {
+        return createEnv({
+            project: {
+                files: {
+                    "index.ts": `const template= require('./index.md');`,
+                    "index.md": `# hello`,
+                },
+                plugins: [MarkdownPlugin({useDefault: false})],
+                instructions: "> index.ts **/*.md",
+            },
+        }).then((result) => {
+            const contents = result.projectContents.toString();
+            should(contents).findString(`module.exports =  "<h1 id=\\"hello\\">hello</h1>\\n"`);
+        });
+    }
+
+    "Should import template with Default as export"() {
+        return createEnv({
+            project: {
+                files: {
+                    "index.ts": `const template= require('./index.md');`,
+                    "index.md": `# hello`,
+                },
+                plugins: [MarkdownPlugin()],
+                instructions: "> index.ts **/*.md",
+            },
+        }).then((result) => {
+            const out = result.project.FuseBox.import("./index.md");
+            should(out).deepEqual({
+                    "default": "<h1 id=\"hello\">hello</h1>\n"
+                }
+            );
+        });
+    }
+
+    "Should import template without Default as export"() {
+        return createEnv({
+            project: {
+                files: {
+                    "index.ts": `const template= require('./index.md');`,
+                    "index.md": `# hello`,
+                },
+                plugins: [MarkdownPlugin({useDefault: false})],
+                instructions: "> index.ts **/*.md",
+            },
+        }).then((result) => {
+            const out = result.project.FuseBox.import("./index.md");
+            should(out).equal("<h1 id=\"hello\">hello</h1>\n");
+        });
+    }
+}


### PR DESCRIPTION
A proposal based on the HTMLPlugin, to :
* support markdown files
* transform markdown files to HTML files

All of this is using marked library https://github.com/chjj/marked

The default marked options are the same than : https://github.com/peerigon/markdown-loader