### PR TITLE
sourceMaps shouldn't throw an error if outFile is not set

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,6 +172,38 @@ sourceMaps: { project: true, vendor: true }
 Sourcemaps currently work with [typescript](#typescript) and [BabelPlugin](#babel-plugin)
 [see the SourceMapPlainJsPlugin](#sourcemapplainjsplugin)
 
+Single bundle :
+```js
+// will generate 2 files : index.js and index.js.map
+
+FuseBox.init({
+    cache: false,
+    sourceMaps: { project: true, vendor: true },
+    plugins: [
+        SourceMapPlainJsPlugin(),
+    ],
+    outFile: 'index.js',
+})
+.bundle('>index.ts');
+```
+
+Multiple bundle :
+```js
+// will generate 4 files : index.js, index.js.map, main.js, and main.js.map
+
+FuseBox.init({
+    cache: false,
+    sourceMaps: { project: true, vendor: true },
+    plugins: [
+        SourceMapPlainJsPlugin(),
+    ],
+})
+.bundle({
+  'index.js': '>index.ts +**.ts',
+  'main.js': '>main.ts +**.ts',
+});
+```
+
 ## Standalone
 
 By default FuseBox injects API in every bundle. That can be overridden by setting:
@@ -398,7 +430,7 @@ Don't run that bundle in a traditional browser.
 An example using the available config options might look similar to:
 ```js
 // remember, unless you transpile your fuse.js, es6 will not work in your fuse.js
-// so using `require` is the easiest. 
+// so using `require` is the easiest.
 // destructuring with `require` is supported with the current node version.
 //
 // importing can also be done with the syntax:

--- a/src/core/FuseBox.ts
+++ b/src/core/FuseBox.ts
@@ -194,13 +194,18 @@ export class FuseBox {
                     vendorSourceMaps = true;
                 }
             }
-            const mapsName = path.basename(this.context.outFile) + ".map";
-            const mapsOutFile =
-                path.join(path.dirname(this.context.outFile), mapsName);
-            if (projectSourcMaps) {
-                sourceMapOptions.outFile = mapsOutFile;
-                sourceMapOptions.bundleReference = mapsName;
+
+            if (this.context.outFile) {
+                const mapsName = path.basename(this.context.outFile) + ".map";
+                const mapsOutFile =
+                   path.join(path.dirname(this.context.outFile), mapsName);
+
+                if (projectSourcMaps) {
+                    sourceMapOptions.outFile = mapsOutFile;
+                    sourceMapOptions.bundleReference = mapsName;
+                }
             }
+
             sourceMapOptions.vendor = vendorSourceMaps;
             this.context.sourceMapConfig = sourceMapOptions;
         }

--- a/test/sourcemap_plainjs_plugin.js
+++ b/test/sourcemap_plainjs_plugin.js
@@ -9,9 +9,8 @@ module.exports = 'file2';
 `;
 
 const defConf = {
-    sourceMap: {
-        bundleReference: "sourcemaps.js.map",
-    },
+    sourceMaps: true,
+    outFile: 'sourcemaps.js',
     plugins: [build.SourceMapPlainJsPlugin()],
 };
 
@@ -24,7 +23,7 @@ describe("SourceMapPlainJsPlugin", function() {
             "file2.js": file2,
         }, ">index.js", defConf, true).then(concat => {
 
-            concat.sourceMap.should.be.okay;
+            concat._sourceMap.should.be.okay;
             (concat.content.toString().match(/\/\/#\ssourceMappingURL=sourcemaps\.js\.map$/) !== null).should.equal(true);
 
             return true;
@@ -42,7 +41,7 @@ describe("SourceMapPlainJsPlugin", function() {
                 build.SourceMapPlainJsPlugin(),
             ],
         }), true).then(concat => {
-            concat.sourceMap.should.be.okay;
+            concat._sourceMap.should.be.okay;
             (concat.content.toString().match(/\/\/#\ssourceMappingURL=sourcemaps\.js\.map$/) !== null).should.equal(true);
 
             return true;


### PR DESCRIPTION
Today, ```init({sourceMap: {}})``` has been deprecated in favor of ```init({sourceMaps: true})```

But this prevent us to generate source-map when using multiple bundles at once

In order to support multiple bundles, the name of the source-map should be generated only if an outFile is mentionned. So it has to support an init object without outFile.