### PR TITLE
little tweak for __generator.js for IE9/10/11

### DIFF
--- a/modules/fuse-typescript-helpers/__generator.js
+++ b/modules/fuse-typescript-helpers/__generator.js
@@ -1,5 +1,5 @@
 FuseBox.global("__generator", function(thisArg, body) {
-    var _ = { label: 0, sent() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] },
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] },
         f, y, t;
     return { next: verb(0), "throw": verb(1), "return": verb(2) };
 


### PR DESCRIPTION
`self(){ ... }` is throwing errors in IE 9, 10, and 11. This small tweak keeps it ES3 compatible.