### PR TITLE
Fix declaration for noImplicitAny

### DIFF
--- a/src/core/WorkflowContext.ts
+++ b/src/core/WorkflowContext.ts
@@ -399,7 +399,7 @@ export class WorkFlowContext {
     /**
      * @param fn if provided, its called once the plugin method has been triggered
      */
-    public triggerPluginsMethodOnce(name: PluginMethodName, args: any, fn?: { (plugin: Plugin) }) {
+    public triggerPluginsMethodOnce(name: PluginMethodName, args: any, fn?: { (plugin: Plugin): void }) {
         this.plugins.forEach(plugin => {
             if (Array.isArray(plugin)) {
                 plugin.forEach(p => {


### PR DESCRIPTION
Omitting the return type of fn causes compile errors in consuming projects that import fuse-box with noImplicitAny compiler option.