### PR TITLE
LESSPlugin: change filename path from relative to absolute

### DIFF
--- a/src/plugins/stylesheet/LESSPlugin.ts
+++ b/src/plugins/stylesheet/LESSPlugin.ts
@@ -43,7 +43,7 @@ export class LESSPluginClass implements Plugin {
             less = require("less");
         }
 
-        options.filename = file.info.fuseBoxPath;
+        options.filename = file.info.absDir;
 
         if ("sourceMapConfig" in context) {
             options.sourceMap = { ...sourceMapDef, ...options.sourceMap || {} };

--- a/src/plugins/stylesheet/LESSPlugin.ts
+++ b/src/plugins/stylesheet/LESSPlugin.ts
@@ -43,7 +43,7 @@ export class LESSPluginClass implements Plugin {
             less = require("less");
         }
 
-        options.filename = file.info.absPath;
+        options.filename = options.filename || file.info.fuseBoxPath;
 
         if ("sourceMapConfig" in context) {
             options.sourceMap = { ...sourceMapDef, ...options.sourceMap || {} };

--- a/src/plugins/stylesheet/LESSPlugin.ts
+++ b/src/plugins/stylesheet/LESSPlugin.ts
@@ -43,7 +43,7 @@ export class LESSPluginClass implements Plugin {
             less = require("less");
         }
 
-        options.filename = file.info.absDir;
+        options.filename = file.info.absPath;
 
         if ("sourceMapConfig" in context) {
             options.sourceMap = { ...sourceMapDef, ...options.sourceMap || {} };


### PR DESCRIPTION
This patch fix `@import` resolving inside the less file, if main less file isn't in root directory.