### PR TITLE
Fixed build error and add process shim for server bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test:once": "gulp dist && TRAVIS=true ./node_modules/mocha/bin/mocha && node ./test.js",
     "start": "gulp watch",
     "devDeps": "gulp installDevDeps",
-    "dist": "gulp dist"
+    "dist": "gulp dist",
+    "prepublish": "gulp dist"
   },
   "engines": {
     "node": ">= 6.9.5",

--- a/src/core/ModuleCollection.ts
+++ b/src/core/ModuleCollection.ts
@@ -200,8 +200,7 @@ export class ModuleCollection {
             this.dependencies = new Map<string, File>();
         });
     }
-    public collectBundle(data: BundleData): Promise<ModuleCollection> {
-
+    public collectBundle(data: BundleData): Promise<void> {
         this.bundle = data;
         this.delayedResolve = true;
         this.initPlugins();

--- a/src/plugins/EnvPlugin.ts
+++ b/src/plugins/EnvPlugin.ts
@@ -1,6 +1,3 @@
-import * as fs from "fs";
-import * as path from "path";
-import { Config } from "./../Config"
 import { WorkFlowContext } from "../core/WorkflowContext";
 import { Plugin } from "../core/WorkflowContext";
 
@@ -17,10 +14,6 @@ export class EnvPluginClass implements Plugin {
     constructor(private env: EnvPluginOptions) { }
     public bundleStart(context: WorkFlowContext) {
         context.source.addContent(`var __process_env__ = ${JSON.stringify(this.env)};`);
-        if (context.serverBundle) {
-            let lib = path.join(Config.FUSEBOX_MODULES, "process", "index.js");
-            context.source.addContent(fs.readFileSync(lib).toString());
-        }
     }
 }
 

--- a/src/plugins/EnvPlugin.ts
+++ b/src/plugins/EnvPlugin.ts
@@ -1,3 +1,6 @@
+import * as fs from "fs";
+import * as path from "path";
+import { Config } from "./../Config"
 import { WorkFlowContext } from "../core/WorkflowContext";
 import { Plugin } from "../core/WorkflowContext";
 
@@ -14,6 +17,10 @@ export class EnvPluginClass implements Plugin {
     constructor(private env: EnvPluginOptions) { }
     public bundleStart(context: WorkFlowContext) {
         context.source.addContent(`var __process_env__ = ${JSON.stringify(this.env)};`);
+        if (context.serverBundle) {
+            let lib = path.join(Config.FUSEBOX_MODULES, "process", "index.js");
+            context.source.addContent(fs.readFileSync(lib).toString());
+        }
     }
 }
 


### PR DESCRIPTION
The collectBundle function is expecting a `Promise<ModuleCollection>` return, but gets a `Promise<void>`.

And when running a server bundle, environment variables don't get injected since the process shim isn't loaded.  But for browsers, people might wanna do vendor bundles that already includes the shim.