### PR TITLE
Add VuePlugin documentation

### DIFF
--- a/docs/_meta.json
+++ b/docs/_meta.json
@@ -41,7 +41,8 @@
         "group": "Transpilers",
         "files": [
             "plugins/transpilers/BabelPlugin.md",
-            "plugins/transpilers/CoffeePlugin.md"
+            "plugins/transpilers/CoffeePlugin.md",
+            "plugins/transpilers/VuePlugin.md"
         ]
     }, {
         "group": "Miscellaneous",

--- a/docs/plugins/transpilers/VuePlugin.md
+++ b/docs/plugins/transpilers/VuePlugin.md
@@ -1,0 +1,74 @@
+# VuePlugin
+
+## Description
+The Vue plugin is used to transpile .vue files into Javascript.
+
+## Install
+This package depends on the `vue-template-compiler` and `typescript` modules.
+
+Also, if you want to include Vue library into the bundle, remember to install `vue` module too.
+
+```bash
+yarn add vue-template-compiler typescript vue --dev
+npm install vue-template-compiler typescript vue --save-dev
+```
+
+## Example
+
+```js
+// fuse.js
+
+const { FuseBox, VuePlugin } = require('fuse-box')
+
+const fsbx = FuseBox.init({
+    homeDir: './src',
+    output: 'dist/app.js',
+    plugins: [
+        VuePlugin()
+    ]
+})
+
+fsbx.dev()
+
+fsbx.bundle('app.js')
+    .instructions('>index.ts')
+    .watch()
+
+fsbx.run()
+
+```
+
+```typescript
+// src/index.ts
+
+import * as Vue from 'vue/dist/vue.js'
+import * as App from './components/App.vue'
+
+new Vue({
+    el: '#app',
+    render: h => h(App)
+})
+
+```
+
+```html
+<!-- src/components/App.vue -->
+
+<template>
+    <div>
+        <p>{{ msg }}</p>
+        <input type="text" v-model="msg" />
+    </div>
+</template>
+
+<script>
+    export default {
+        name: 'app',
+        data () {
+            return {
+                msg: 'Welcome to Your Vue.js App'
+            }
+        }
+    }
+</script>
+```


### PR DESCRIPTION
@nchanged Would be nice to have a repository behind fuse-box organization for a Vue example, just like the Angular2 and React ones, so we can add it as a link in the documentation.