### PR TITLE
Add options to watch() and src() with 'base' param

### DIFF
--- a/src/sparky/SparkFlow.ts
+++ b/src/sparky/SparkFlow.ts
@@ -7,10 +7,6 @@ import { log } from "./Sparky";
 import { parse, SparkyFilePatternOptions } from "./SparkyFilePattern";
 import * as  chokidar from "chokidar";
 
-export interface SparkFlowWatchOptions {
-    base? : string;
-}
-
 export class SparkFlow {
     private activities = [];
     private watcher: any;

--- a/src/sparky/Sparky.ts
+++ b/src/sparky/Sparky.ts
@@ -1,5 +1,6 @@
 import { SparkTask } from "./SparkTask";
 import { SparkFlow } from "./SparkFlow";
+import { SparkyFilePatternOptions } from "./SparkyFilePattern";
 import { each } from "realm-utils";
 import { WorkFlowContext } from "../core/WorkflowContext";
 import { Log } from "../Log";
@@ -37,12 +38,12 @@ export class Sparky {
         return this;
     }
 
-    public static src(str: string): SparkFlow {
+    public static src(str: string, opts?: SparkyFilePatternOptions): SparkFlow {
         const flow = new SparkFlow();
-        return flow.glob(str);
+        return flow.glob(str, opts);
     }
 
-    public static watch(glob: string, opts?: any) {
+    public static watch(glob: string, opts?: SparkyFilePatternOptions) {
         const flow = new SparkFlow();
         return flow.watch(glob, opts);
     }

--- a/src/sparky/SparkyFilePattern.ts
+++ b/src/sparky/SparkyFilePattern.ts
@@ -26,7 +26,7 @@ export function parse(str: string, opts?: SparkyFilePatternOptions): SparkyFileP
             glob = str;
         } else {
             glob = path.join(Config.PROJECT_ROOT, base, str);
-            root = path.join(Config.PROJECT_ROOT. base);
+            root = path.join(Config.PROJECT_ROOT, base);
         }
     }
 

--- a/src/sparky/SparkyFilePattern.ts
+++ b/src/sparky/SparkyFilePattern.ts
@@ -6,23 +6,27 @@ export interface SparkyFilePattern {
     root: string;
     glob: string;
     filepath: string;
-
 }
-export function parse(str: string): SparkyFilePattern {
 
+export interface SparkyFilePatternOptions {
+    base?: string; // Will be ignored when parsing absolute paths
+}
+
+export function parse(str: string, opts?: SparkyFilePatternOptions): SparkyFilePattern {
+    const base = opts ? (opts.base || '') : '';
     const isGlob = /[*{}}]/.test(str);
     const isAbsolutePath = path.isAbsolute(str);
     let root, filepath, glob;
     if (!isGlob) {
-        root = isAbsolutePath ? path.dirname(str) : Config.PROJECT_ROOT;
-        filepath = isAbsolutePath ? str : path.join(Config.PROJECT_ROOT, str);
+        root = isAbsolutePath ? path.dirname(str) : path.join(Config.PROJECT_ROOT, base);
+        filepath = isAbsolutePath ? str : path.join(Config.PROJECT_ROOT, base, str);
     } else {
         if (isAbsolutePath) {
             root = str.split("*")[0]
             glob = str;
         } else {
-            glob = path.join(Config.PROJECT_ROOT, str);
-            root = Config.PROJECT_ROOT;
+            glob = path.join(Config.PROJECT_ROOT, base, str);
+            root = path.join(Config.PROJECT_ROOT. base);
         }
     }
 


### PR DESCRIPTION
Created a new interface called `SparkyFilePatternOptions` which is like this:

```typescript
export interface SparkyFilePatternOptions {
    base?: string; // Will be ignored when parsing absolute paths
}
```
Added the interface as optional params to src() and watch() methods, and is actually used in parse method inside SparkyFilePattern.ts.

Now something like this would work:
```js
Sparky.task('copyAssets', () => {
    return Sparky.watch('./assets', { base: './src' })
        .dest('./dist')
})
```
And should fix #493 