### PR TITLE
Update VuePlugin and Sparky docs

### DIFF
--- a/docs/plugins/transpilers/VuePlugin.md
+++ b/docs/plugins/transpilers/VuePlugin.md
@@ -4,13 +4,13 @@
 The Vue plugin is used to transpile .vue files into Javascript.
 
 ## Install
-This package depends on the `vue-template-compiler` and `typescript` modules.
+This package depends on the `vue-template-compiler`, `vue-template-es2015-compiler` and `typescript` modules.
 
 Also, if you want to include Vue library into the bundle, remember to install `vue` module too.
 
 ```bash
-yarn add vue-template-compiler typescript vue --dev
-npm install vue-template-compiler typescript vue --save-dev
+yarn add vue-template-compiler vue-template-es2015-compiler typescript vue --dev
+npm install vue-template-compiler vue-template-es2015-compiler typescript vue --save-dev
 ```
 
 ## Example

--- a/docs/sparky.md
+++ b/docs/sparky.md
@@ -103,6 +103,22 @@ or you want to capture all images file formats
  Sparky.src("src/**/*.(jpg|png|gif))")
  ```
 
+Source method also accepts a second parameter to inject some options:
+
+### options.base
+
+Sets the base path from which the path names will be resolved.
+
+For example: If we have an `asset` folder, and inside that, a file called `logo.png`...
+
+```js
+Sparky.src("./src/assets/*.png").dest('./dist')
+// Result: dist/src/assets/logo.png
+
+Sparky.src("./assets/*.png", { base: './src' }).dest('./dist')
+// Result: dist/assets/logo.png
+```
+
 ## watch
 Same as `source` above, the only difference is that it is a daemon so it will always run whenever a file in the captured globing changes.
 ## Dest

--- a/src/sparky/SparkFlow.ts
+++ b/src/sparky/SparkFlow.ts
@@ -7,6 +7,10 @@ import { log } from "./Sparky";
 import { parse, SparkyFilePatternOptions } from "./SparkyFilePattern";
 import * as  chokidar from "chokidar";
 
+export interface SparkFlowWatchOptions {
+    base? : string;
+}
+
 export class SparkFlow {
     private activities = [];
     private watcher: any;

--- a/src/sparky/SparkFlow.ts
+++ b/src/sparky/SparkFlow.ts
@@ -7,10 +7,6 @@ import { log } from "./Sparky";
 import { parse, SparkyFilePatternOptions } from "./SparkyFilePattern";
 import * as  chokidar from "chokidar";
 
-export interface SparkFlowWatchOptions {
-    base? : string;
-}
-
 export class SparkFlow {
     private activities = [];
     private watcher: any;


### PR DESCRIPTION
Updated Sparky docs to add `options.base` #494 
Updated VuePlugin docs to include the new required module `vue-template-es2015-compiler` #485 