### PR TITLE
Update Sparky tests and fix a test for Windows

### DIFF
--- a/src/sparky/SparkyFile.ts
+++ b/src/sparky/SparkyFile.ts
@@ -11,11 +11,14 @@ export class SparkyFile {
     public contents: Buffer | string;
     public extension: string;
     public filepath: string;
+    public root: string;
     private savingRequired = false;
 
-    constructor(filepath: string, public root: string) {
+    constructor(filepath: string, root: string) {
         this.filepath = path.normalize(filepath);
-        let hp = this.filepath.split(root)[1];
+        this.root = path.normalize(root);
+
+        let hp = path.relative(this.root, this.filepath);
         this.homePath = path.isAbsolute(hp) ? hp.slice(1) : hp;
         this.name = path.basename(this.filepath);
     }

--- a/src/sparky/SparkyFilePattern.ts
+++ b/src/sparky/SparkyFilePattern.ts
@@ -19,11 +19,11 @@ export function parse(str: string, opts?: SparkyFilePatternOptions): SparkyFileP
     let root, filepath, glob;
     if (!isGlob) {
         root = isAbsolutePath ? path.dirname(str) : path.join(Config.PROJECT_ROOT, base);
-        filepath = isAbsolutePath ? str : path.join(Config.PROJECT_ROOT, base, str);
+        filepath = isAbsolutePath ? path.normalize(str) : path.join(Config.PROJECT_ROOT, base, str);
     } else {
         if (isAbsolutePath) {
-            root = str.split("*")[0]
-            glob = str;
+            root = path.normalize(str.split("*")[0])
+            glob = path.normalize(str);
         } else {
             glob = path.join(Config.PROJECT_ROOT, base, str);
             root = path.join(Config.PROJECT_ROOT, base);

--- a/src/tests/sparky/SparkyFilePattern.test.ts
+++ b/src/tests/sparky/SparkyFilePattern.test.ts
@@ -39,4 +39,10 @@ export class SparkyFilePatternTest {
         should(result.glob).equal(path.normalize("/a/b/**/**.js"));
         should(result.root).equal(path.normalize("/a/b/"));
     }
+
+    "Should understand 'base' option"() {
+        const result = parse("./b/file.js", { base: "./a" });
+        should(result.filepath).equal(path.join(Config.PROJECT_ROOT, "./a/b/file.js"))
+        should(result.root).equal(path.join(Config.PROJECT_ROOT, "./a"))
+    }
 }


### PR DESCRIPTION
Updated Sparky tests adding a test for `base` option.

Fixed an edge case in Windows in `SparkyFile.ts` constructor, it just needed to `path.normalize()` the root path. This made the test fail in Windows.

Also:
```js
let hp = this.filepath.split(root)[1]; // Removed this
let hp = path.relative(this.root, this.filepath); // And did this instead
```
Which does the intended use and is a safer way to work with paths.