### PR TITLE
Fix VuePlugin

### DIFF
--- a/src/plugins/VuePlugin.ts
+++ b/src/plugins/VuePlugin.ts
@@ -82,7 +82,7 @@ function toFunction (code) {
 
 function compileTemplateContent (context: any, engine: string, content: string) {
     return new Promise((resolve, reject) => {
-        if (!engine) { return content; }
+        if (!engine) { return resolve(content); }
         
         const cons = require('consolidate');
         if (!cons[engine]) { return content; }


### PR DESCRIPTION
Right now, the published version in NPM (2.0 beta 15 atm) breaks when the Vue template doesn't use any templating engine.

This fixes that, adding the missing `resolve()` call