### PR TITLE
Fix EPERM error on Windows

### DIFF
--- a/src/sparky/SparkFlow.ts
+++ b/src/sparky/SparkFlow.ts
@@ -38,6 +38,7 @@ export class SparkFlow {
 
             this.watcher = chokidar.watch(globs, chokidarOptions)
                 .on('all', (event, fp) => {
+                    if (event === 'addDir' || event === 'unlinkDir') return
                     if (this.initialWatch) {
                         this.files = [];
                         log.echoStatus(`Changed ${fp}`)


### PR DESCRIPTION
This error happened some times on windows when doing this:

```js
return Sparky.watch('./assets', { base: './src' })
        .dest('./dist')
```

`'./assets'` is passed to chokidar, which will emit `addDir` and `add` events, both will be handled and added to the files to copy, and then, make the copy.

The problem is that both folder AND files are being copied at the same time, and there's a race condition where a folder copy will happen before the file finished it's copy process. Resulting on 'No such file or directory' or EPERM errors.

This line prevents the copy of folders ignoring the addDir and unlinkDir events from chokidar. Because if a file is copied, it will already create the needed folders.