### PR TITLE
VuePlugin: relative includes requires filename option (pug)

### DIFF
--- a/src/plugins/VuePlugin.ts
+++ b/src/plugins/VuePlugin.ts
@@ -89,6 +89,7 @@ function compileTemplateContent (context: any, engine: string, content: string) 
         if (!cons[engine]) { return content; }
     
         cons[engine].render(content, {
+            filename: 'base',
             basedir: context.homeDir,
             includeDir: context.homeDir
         }, (err, html) => {


### PR DESCRIPTION
Fixed a bug where pug templates would not compile when using `include`. The `filename` parameter is required, even if set to something random.