### PR TITLE
proc.require()

### DIFF
--- a/src/FuseProcess.ts
+++ b/src/FuseProcess.ts
@@ -52,7 +52,12 @@ export class FuseProcess {
 				if(!(closePromise instanceof Promise))
 					closePromise = Promise.resolve(true);
 				closePromise.then(
-					()=> resolve(getMainExport(require(this.filePath))),
+					() => {
+						var exps = false;
+						try { exps = getMainExport(require(this.filePath)); }
+						catch(x) { reject(x); }
+						if(exps) resolve(exps);
+					},
 					x=> reject(x)
 				);
 			});

--- a/src/FuseProcess.ts
+++ b/src/FuseProcess.ts
@@ -41,7 +41,7 @@ export class FuseProcess {
 									cached.default.close() : //if a `close` function is exported by the default export
 								console.warn(`Bundle ${this.bundle.name} doesn't export a close() function and no close was given`);
 						} catch(x) {
-							console.error(`Exception while closeping bundle ${this.bundle.name}.`);
+							console.error(`Exception while closing bundle ${this.bundle.name}.`);
 							reject(x);
 						}
 					} else if(close) {

--- a/src/FuseProcess.ts
+++ b/src/FuseProcess.ts
@@ -1,5 +1,6 @@
 import { Bundle } from "./core/Bundle";
 import { ChildProcess, spawn } from "child_process";
+declare function require(name:string);
 
 export class FuseProcess {
     public node: ChildProcess;
@@ -22,6 +23,40 @@ export class FuseProcess {
         return this;
     }
 
+		require(close?: ((exports: any) => void)|(() => void)) {
+			function getMainExport(mdl) {
+				return mdl && mdl.FuseBox && mdl.FuseBox.mainFile ?
+						mdl.FuseBox.import(mdl.FuseBox.mainFile) :
+						mdl;
+			}
+			return new Promise((resolve, reject)=> {
+				var cache = (<any>require).cache, cached = cache[this.filePath], closePromise;
+				if(cached) {
+					cached = getMainExport(cached.exports);
+					if(cached) {
+						try {
+							closePromise = close ? (<(exps: any) => void>close)(cached) :	//if a close function is given in parameter
+								cached.close ? cached.close() : //if a `close` function is exported by the bundle
+								cached.default && cached.default.close ?
+									cached.default.close() : //if a `close` function is exported by the default export
+								console.warn(`Bundle ${this.bundle.name} doesn't export a close() function and no close was given`);
+						} catch(x) {
+							console.error(`Exception while closeping bundle ${this.bundle.name}.`);
+							reject(x);
+						}
+					} else if(close) {
+						closePromise = (<() => void>close)();
+					}
+					delete cache[this.filePath];
+				}
+				if(!(closePromise instanceof Promise))
+					closePromise = Promise.resolve(true);
+				closePromise.then(
+					()=> resolve(getMainExport(require(this.filePath))),
+					x=> reject(x)
+				);
+			});
+		}
     /** Spawns another proces */
     public exec(): FuseProcess {
         const node = spawn("node", [this.filePath], {


### PR DESCRIPTION
Alternative to .completed(proc=> proc.start()) that runs the script in the node instance used by fuse (debugging if fuse is debugged)
```
.completed(proc=> {
	proc.require().then(exps=> {
		// exps is the main module' exports
	});
});
```
There are several ways to express how to close the deprecated instance once the bundle has been re-transpiled, when it is started again, depending on the AEFL (Automatically Executed File on Load)
If the bundle has NO AEFL, a close function taking no argument can be given as argument of `require`
```
proc.require(function() {
	console.log('unloaded');
});
```
If the bundle HAS an AEFL, the first of these choice that exists/is defined will be used :

A- Give a close function to the `require` call, who takes an argument containing the exports of the AEFL
```
proc.require(exps => exps.kill())
```

B- export a close function in the AEFL that takes no argument

```
// server.js
[ ... ]
export function close() {
	myResources.$destroy();
}
[ ... ]
```

C- Export directly in exports or in default an object that hase a close function (without parameters)


```
// server.js
[ ... ]
export default app.listen(config.port);
[ ... ]
```
OR

```
// server.js
[ ... ]
export = app.listen(config.port);
[ ... ]
```

PROMISES:
If the `close` function that is called returns a Promise, the module will be re-started on that promise' resolution.
```
proc.require(function() {
	return Promise((resolve, reject)=> setTimeout(()=> resolve(true), 60000));
});
```
This will wait a minute before re-requireing the module.
note: This promise' resolution value is ignored
OBVIOUS NOTE:
The `close` function is not called the first time the module is launched. It is called just after re-transpilation and before re-launching the module.
RETURN VALUE:
The function `require` returns a Promise that resolves to the exports of the AEFL