### PR TITLE
fix `yarn add` command

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -38,6 +38,6 @@ You need NodeJs 6+. FuseBox will not run on an earlier version of node. If you h
 ## Installation
 
 ```bash
-yarn add fuse-box --save-dev
+yarn add fuse-box --dev
 npm install fuse-box --save-dev
 ```


### PR DESCRIPTION
The syntax for adding a package with `yarn` and saving it to `devDependencies` is `yarn add <name> --dev`.

It's a bit tricky to catch, though, because `yarn add <name> --save-dev` still works, and doesn't throw any warnings, but then actually saves the package to `dependencies` 😺.