### PR TITLE
Fix infinite requests caused by server's 200OK

### DIFF
--- a/modules/fuse-box-loader-api/fusebox.js
+++ b/modules/fuse-box-loader-api/fusebox.js
@@ -174,8 +174,12 @@ function $getRef(name, o) {
     };
 }
 ;
-function $async(file, cb) {
+function $async(file, cb, o) {
+    if (o === void 0) { o = {}; }
     if ($isBrowser) {
+        if (o && o.ajaxed === file) {
+            return console.error(file, 'does not provide a module');
+        }
         var xmlhttp = new XMLHttpRequest();
         xmlhttp.onreadystatechange = function () {
             if (xmlhttp.readyState == 4) {
@@ -192,7 +196,7 @@ function $async(file, cb) {
                     }
                     var normalized = $pathJoin("./", file);
                     FuseBox.dynamic(normalized, content);
-                    cb(FuseBox.import(file, {}));
+                    cb(FuseBox.import(file, { ajaxed: file }));
                 }
                 else {
                     console.error(file, 'not found on request');
@@ -256,7 +260,7 @@ function $import(name, o) {
         if (processStopped === false) {
             return;
         }
-        return $async(name, function (result) { return asyncMode_1 ? o(result) : null; });
+        return $async(name, function (result) { return asyncMode_1 ? o(result) : null; }, o);
     }
     var pkg = ref.pkgName;
     if (file.locals && file.locals.module)

--- a/src/loader/LoaderAPI.ts
+++ b/src/loader/LoaderAPI.ts
@@ -331,8 +331,11 @@ function $getRef(name: string, o: RefOpts): IReference {
  * Async request
  * Makes it possible to request files asynchronously
  */
-function $async(file: string, cb: (imported?: any) => any) {
+function $async(file: string, cb: (imported?: any) => any, o: any = {}) {
     if ($isBrowser) {
+        if(o && o.ajaxed === file) {
+            return console.error(file, 'does not provide a module');
+        }
         var xmlhttp: XMLHttpRequest = new XMLHttpRequest();
         xmlhttp.onreadystatechange = function () {
             if (xmlhttp.readyState == 4) {
@@ -348,7 +351,7 @@ function $async(file: string, cb: (imported?: any) => any) {
                     }
                     let normalized = $pathJoin("./", file);
                     FuseBox.dynamic(normalized, content);
-                    cb(FuseBox.import(file, {}));
+                    cb(FuseBox.import(file, {ajaxed: file}));
                 } else {
                     console.error(file, 'not found on request');
                     cb(undefined);
@@ -435,7 +438,7 @@ function $import(name: string, o: any = {}) {
         if (processStopped === false) {
             return;
         }
-        return $async(name, (result) => asyncMode ? o(result) : null);
+        return $async(name, (result) => asyncMode ? o(result) : null, o);
         // throw `File not found ${ref.validPath}`;
     }
 


### PR DESCRIPTION
Solving: https://github.com/fuse-box/fuse-box/issues/518

When a module is not found or badly loaded in the browser, if there were no server errors (status: 200), FuseBox will use the response (and fail to register the module badly given) then import the module again ... as the module was not properly registered, the import will lead to an ajax request, and this will repeat indefinitely.

The correction brought here is simple (the infinite recursion is short) : The import will pass the option `ajaxed` to specify the file that was required to lead to that import. The function `$async` will, before creating an XHR object, check if by chance the request is not the one just done - and if yes, signal an error instead of repeating it.