### PR TITLE
Unminified version of the API on debug

### DIFF
--- a/src/BundleSource.ts
+++ b/src/BundleSource.ts
@@ -213,7 +213,7 @@ ${file.headerContent ? file.headerContent.join("\n") : ""}`);
         this.concat.add(null, "})");
 
         if (context.standaloneBundle) {
-            let fuseboxLibFile = path.join(Config.FUSEBOX_MODULES, "fuse-box-loader-api", "fusebox.min.js");
+            let fuseboxLibFile = path.join(Config.FUSEBOX_MODULES, "fuse-box-loader-api", context.debugMode?"fusebox.js":"fusebox.min.js");
             if (this.context.customAPIFile) {
                 fuseboxLibFile = ensureUserPath(this.context.customAPIFile);
             }


### PR DESCRIPTION
When a `FuseBox` is initialised with `debug: true`, the loader is injected non-minified in order to follow what is happening in the core of FuseBox.
This can help coders (who use `debug: true` in fuse-box) to find out where they failed their configuration or find bugs.

Note: I personally use that