### PR TITLE
quickfix

### DIFF
--- a/src/analysis/plugins/OwnBundle.ts
+++ b/src/analysis/plugins/OwnBundle.ts
@@ -20,7 +20,7 @@ export class OwnBundle {
 
     public static onNode(file: File, node: any, parent: any) {
         const analysis = file.analysis;
-        if (node.type === "MemberExpression") {
+        if (file.collection.entryFile && node.type === "MemberExpression") {
             if (parent.type === "CallExpression") {
                 if (node.object && node.object.type === "Identifier" &&
                     node.object.name === analysis.fuseBoxVariable) {


### PR DESCRIPTION
```
Exception has occurred: Error
TypeError: Cannot read property 'info' of undefined
    at Function.onNode (...\fuse-box\dist\commonjs\analysis\plugins\OwnBundle.js:24:66)
```
A case of absent entry-point is not taken into account and let an `undefined.info` occur
