### PR TITLE
Don't use package browser field for non-browser targets

### DIFF
--- a/src/core/PathMaster.ts
+++ b/src/core/PathMaster.ts
@@ -353,10 +353,8 @@ export class PathMaster {
                 let entryFile;
                 let entryRoot;
                 let browserOverrides;
-                if (json.browser) {
-
-                    if (this.context.isBrowserTarget() &&
-                        typeof json.browser === "object" && json.browser[json.main]) {
+                if (this.context.isBrowserTarget() && json.browser) {
+                    if (typeof json.browser === "object" && json.browser[json.main]) {
                         browserOverrides = json.browser;
                         entryFile = json.browser[json.main];
                     }


### PR DESCRIPTION
Currently the code checks for isBrowserTarget for the overrides variant of the browser field in package.json, but does not check it for the main variant of the field.

This PR hoists the target check to the entire browser field handling.