### PR TITLE
Adding support for alternative file extensions with BabelPlugin

### DIFF
--- a/docs/plugins/transpilers/BabelPlugin.md
+++ b/docs/plugins/transpilers/BabelPlugin.md
@@ -17,7 +17,8 @@ npm install babel-core babel-preset-es2015 babel-plugin-transform-react-jsx --sa
 | ---- | ---- | ----------- | -------- |
 | config | `Object`  | when using other fuse-box only properties, babel config is passed in as .config |  |
 | limit2project | `boolean`  | to use this plugin across an entire project (including other modules like npm) | `true` |
-| test | `Regex`  | files to match | <code>/\.(j&#124;t)s(x)?$/</code> |
+| extensions | `Array<string>`  | file extensions to allow with fuse-box | `[".jsx"]`
+| test | `Regex`  | files to match | <code>/\\.(j&#124;t)s(x)?$/</code> |
 
 
 

--- a/src/tests/plugins/BabelPlugin.test.ts
+++ b/src/tests/plugins/BabelPlugin.test.ts
@@ -1,0 +1,21 @@
+import { createEnv } from "./../stubs/TestEnvironment";
+import { should } from "fuse-test-runner";
+import { BabelPlugin } from "../../plugins/js-transpilers/BabelPlugin";
+
+export class BabelPluginTest {
+    "Should bundle wxyz with Babel using extensions"() {
+        return createEnv({
+            project: {
+                files: {
+                    "index.wxyz": `export {default as canada} from './moose/eh/igloo.wxyz'`,
+                    "moose/eh/igloo.wxyz": "export default { result: 'igloo'}",
+                },
+                instructions: "index.wxyz",
+                plugins: [BabelPlugin({ extensions: [".wxyz"], config: { "presets": ["latest"] } })],
+            },
+        }).then((result) => {
+          const out = result.project.FuseBox.import("./index.wxyz");
+          should(out).deepEqual({ canada: { result: "igloo" } });
+        });
+    }
+}


### PR DESCRIPTION
This PR enables extensions other than `".jsx"` to be registered with `WorkFlowContext::allowExtension(ext)`, thereby allowing use of custom extensions. 

I use the '.jsy' custom extension for [offside indented JavaScript dialect](https://github.com/shanewholloway/babel-plugin-offside-js). Think CoffeeScript, Python, or [Wisp](http://dustycloud.org/blog/wisp-lisp-alternative/). Being able to use the custom extension makes happy syntax highlighters much easier…