### PR TITLE
Fix declarations for noImplicitAny

### DIFF
--- a/src/core/FuseBox.ts
+++ b/src/core/FuseBox.ts
@@ -206,7 +206,7 @@ export class FuseBox {
 
 
     /** Starts the dev server and returns it */
-    public dev(opts?: ServerOptions, fn?: { (server: Server) }) {
+    public dev(opts?: ServerOptions, fn?: { (server: Server): void }) {
         opts = opts || {};
         opts.port = opts.port || 4444;
         this.producer.devServerOptions = opts;

--- a/src/quantum/plugin/ComputerStatementRule.ts
+++ b/src/quantum/plugin/ComputerStatementRule.ts
@@ -2,7 +2,7 @@ import { RequireStatement } from "../core/nodes/RequireStatement";
 import { QuantumCore } from "./QuantumCore";
 
 export class ComputedStatementRule {
-    constructor(public path: string, public rules: { mapping: string, fn: { (statement: RequireStatement, core: QuantumCore) } }) {
+    constructor(public path: string, public rules: { mapping: string, fn: { (statement: RequireStatement, core: QuantumCore): void; } }) {
 
     }
 }

--- a/src/quantum/plugin/QuantumCore.ts
+++ b/src/quantum/plugin/QuantumCore.ts
@@ -56,7 +56,7 @@ export class QuantumCore {
         this.context = this.producer.fuse.context;
     }
 
-    public solveComputed(path: string, rules: { mapping: string, fn: { (statement: RequireStatement, core: QuantumCore) } }) {
+    public solveComputed(path: string, rules: { mapping: string, fn: { (statement: RequireStatement, core: QuantumCore): void } }) {
         this.customStatementSolutions.add(string2RegExp(path));
         this.requiredMappings.add(string2RegExp(rules.mapping));
         this.computedStatementRules.set(path, new ComputedStatementRule(path, rules));


### PR DESCRIPTION
Omitting the return type of fn causes compile errors in consuming projects that import fuse-box with noImplicitAny compiler option.

```log
node_modules/fuse-box/dist/typings/core/FuseBox.d.ts(63,9): error TS7020: Call signature, which lacks return-type annotation, implicitly has an 'any' return type.
node_modules/fuse-box/dist/typings/quantum/plugin/ComputerStatementRule.d.ts(8,13): error TS7020: Call signature, which lacks return-type annotation, implicitly has an 'any' return type.
node_modules/fuse-box/dist/typings/quantum/plugin/ComputerStatementRule.d.ts(14,13): error TS7020: Call signature, which lacks return-type annotation, implicitly has an 'any' return type.
node_modules/fuse-box/dist/typings/quantum/plugin/QuantumCore.d.ts(30,13): error TS7020: Call signature, which lacks return-type annotation, implicitly has an 'any' return type.
```