### PR TITLE
fixes #610 with uuid style browser overrides

### DIFF
--- a/src/analysis/plugins/ImportDeclaration.ts
+++ b/src/analysis/plugins/ImportDeclaration.ts
@@ -70,8 +70,10 @@ export class ImportDeclaration {
         if (file.collection && file.collection.info && file.collection.info.browserOverrides) {
             const overrides = file.collection.info.browserOverrides;
             if (overrides) {
-                if (overrides[requireStatement]) {
-                    requireStatement = overrides[requireStatement];
+                //require statement without file ext and override with ext
+                let requireStatementWithExt = requireStatement + '.js';
+                if (overrides[requireStatement] || overrides[requireStatementWithExt]) {
+                    requireStatement = overrides[requireStatement] || overrides[requireStatementWithExt];
                     file.analysis.requiresRegeneration = true;
                 }
             }

--- a/src/core/PathMaster.ts
+++ b/src/core/PathMaster.ts
@@ -354,9 +354,11 @@ export class PathMaster {
                 let entryRoot;
                 let browserOverrides;
                 if (this.context.isBrowserTarget() && json.browser) {
-                    if (typeof json.browser === "object" && json.browser[json.main]) {
+                    if (typeof json.browser === "object") {
                         browserOverrides = json.browser;
-                        entryFile = json.browser[json.main];
+                        if(json.browser[json.main]){
+                            entryFile = json.browser[json.main];
+                        }
                     }
                     if (typeof json.browser === "string") {
                         entryFile = json.browser;


### PR DESCRIPTION
These changes enable browser target even when main entry point is not included in the browser overrides,
fixes also issue, when require statement is without file extension like in uuid `var rng = require('./lib/rng');` and package.json browser is with file extensions `  "browser": {
    "./lib/rng.js": "./lib/rng-browser.js"
  },`


