### PR TITLE
Add charset/description/keywords/author metas to WebIndexPlugin config

### DIFF
--- a/src/plugins/WebIndexPlugin.ts
+++ b/src/plugins/WebIndexPlugin.ts
@@ -6,6 +6,10 @@ import { ensureAbsolutePath, joinFuseBoxPath } from "../Utils";
 
 export interface IndexPluginOptions {
     title?: string;
+    charset?: string;
+    description?: string;
+    keywords?: string;
+    author?: string;
     bundles?: string[];
     path?: string;
     target?: string;
@@ -43,11 +47,15 @@ export class WebIndexPluginClass implements Plugin {
         let html = `<!DOCTYPE html>
 <html>
 <head>
-    <title>$title</title>
+    $title
+    $charset
+    $description
+    $keywords
+    $author
 </head>
 <body>
+    $bundles
 </body>
-$bundles
 </html>`;
         if (this.opts.template) {
             let filePath = ensureAbsolutePath(this.opts.template);
@@ -59,7 +67,11 @@ $bundles
         ).join("\n");
 
         let macro = {
-            title: this.opts.title ? this.opts.title : "",
+            title: this.opts.title ? `<title>${this.opts.title}</title>` : "",
+            charset: this.opts.charset ? `<meta charset="${this.opts.charset}">` : "",
+            description: this.opts.description ? `<meta name="description" content="${this.opts.description}">` : "",
+            keywords: this.opts.keywords ? `<meta name="keywords" content="${this.opts.keywords}">` : "",
+            author: this.opts.author ? `<meta name="author" content="${this.opts.author}">` : "",
             bundles: jsTags
         }
         for (let key in macro) {

--- a/src/plugins/WebIndexPlugin.ts
+++ b/src/plugins/WebIndexPlugin.ts
@@ -47,7 +47,7 @@ export class WebIndexPluginClass implements Plugin {
         let html = `<!DOCTYPE html>
 <html>
 <head>
-    $title
+    <title>$title</title>
     $charset
     $description
     $keywords
@@ -67,7 +67,7 @@ export class WebIndexPluginClass implements Plugin {
         ).join("\n");
 
         let macro = {
-            title: this.opts.title ? `<title>${this.opts.title}</title>` : "",
+            title: this.opts.title ? this.opts.title : "",
             charset: this.opts.charset ? `<meta charset="${this.opts.charset}">` : "",
             description: this.opts.description ? `<meta name="description" content="${this.opts.description}">` : "",
             keywords: this.opts.keywords ? `<meta name="keywords" content="${this.opts.keywords}">` : "",


### PR DESCRIPTION
Add optional config props for common html metas.

```
WebIndexPlugin({
  charset: 'utf-8',
  title: 'Document Title',
  description: 'A description of the web app',
  keywords: 'keywords, that, represent, your, app',
  author: 'Guy <guy@author.com>'
})
```

I also slightly modified the $title template variable to wrap the `<title>` tag for you, instead of having to include it in the template yourself.

I also fixed a bug in the default html template where the `$bundles` var is outside of the `<body>` tag.