### PR TITLE
SVG can be exported as default when using ImageBase64Plugin.

### DIFF
--- a/src/plugins/images/ImageBase64Plugin.ts
+++ b/src/plugins/images/ImageBase64Plugin.ts
@@ -55,17 +55,17 @@ export class ImageBase64PluginClass implements Plugin {
             file.isLoaded = true;
             file.contents = cached.contents;
         } else {
+            let exportsKey = this.opts.useDefault ? "module.exports.default" : "module.exports";
             const ext = path.extname(file.absPath);
             if (ext === ".svg") {
                 file.loadContents();
                 let content = SVG2Base64.get(file.contents);
-                file.contents = `module.exports = ${JSON.stringify(content)}`;
+                file.contents = `${exportsKey} = ${JSON.stringify(content)}`;
                 return;
             }
             file.isLoaded = true;
             const data = base64Img.base64Sync(file.absPath);
 
-            let exportsKey = this.opts.useDefault ? "module.exports.default" : "module.exports";
             file.contents = `${exportsKey} = ${JSON.stringify(data)}`;
             context.cache.writeStaticCache(file, undefined);
         }


### PR DESCRIPTION
When using `ImageBase64Plugin({ useDefault: true })`, all the images can be references with the default import, but SVG couldn't.
