### PR TITLE
Fix Sparkflow dependency

### DIFF
--- a/src/sparky/SparkFlow.ts
+++ b/src/sparky/SparkFlow.ts
@@ -5,7 +5,7 @@ import { each } from "realm-utils";
 import { ensureDir, string2RegExp } from "../Utils";
 import { SparkyFile } from "./SparkyFile";
 import { log } from "./Sparky";
-import { Plugin } from '../core/WorkFlowContext';
+import { Plugin } from '../core/WorkflowContext';
 import { parse, SparkyFilePatternOptions } from "./SparkyFilePattern";
 
 export class SparkFlow {


### PR DESCRIPTION
Hi all,

I'm using FuseBox as a dependency in my typescript project, and so I import FuseBox modules.

When compiling, TypeScript on Linux is throwing an error because of the case of a dependency :
```
import { Plugin } from '../core/WorkFlowContext';
```
in `src/sparky/SparkFlow.ts` should be
```
import { Plugin } from '../core/WorkflowContext';
```