### PR TITLE
Typescript under Vue

### DIFF
--- a/src/plugins/VuePlugin.ts
+++ b/src/plugins/VuePlugin.ts
@@ -143,8 +143,8 @@ var _v = function(exports){${jsContent}
 };
 _p.render = ` + toFunction(compiled.render) + `
 _p.staticRenderFns = [ ` + compiled.staticRenderFns.map(toFunction).join(',') + ` ];
-var _e = {}; _v(_e); _p = Object.assign(_e.default, _p)
-module.exports =_p
+var _e = {}; _v(_e); Object.assign(_e.default.options||_e.default, _p)
+module.exports = _e.default
     `;
 }
 


### PR DESCRIPTION
[Issue](https://github.com/fuse-box/fuse-box/issues/701)
Hi, here a little report for a specific VuePlugin usage.

When VuePlugin does not return a Vue options parameter but an instanciated Vue object, the render functions are not added to the options but to the instance - this leads to this error : [Vue warn]: Failed to mount component: template or render function not defined.

This happens on this line :

_p = Object.assign(_e.default, _p);
There, if e.default instanceof VueComponent (indeed, if typeof e.default === 'function' or even if !!e.default.options) then _e.default.options should be extended instead - it is really about adding a condition and a line.

Note: this use-case appears when vue-class-component or similar libraries are used, to have a completely typescript Vue definition.