### PR TITLE
import as exported

### DIFF
--- a/src/plugins/VuePlugin.ts
+++ b/src/plugins/VuePlugin.ts
@@ -144,7 +144,7 @@ var _v = function(exports){${jsContent}
 _p.render = ` + toFunction(compiled.render) + `
 _p.staticRenderFns = [ ` + compiled.staticRenderFns.map(toFunction).join(',') + ` ];
 var _e = {}; _v(_e); Object.assign(_e.default.options||_e.default, _p)
-module.exports = _e.default
+module.exports = _e
     `;
 }
 

--- a/src/tests/plugins/VuePlugin.test.ts
+++ b/src/tests/plugins/VuePlugin.test.ts
@@ -54,7 +54,7 @@ export class VuePluginTest {
                 instructions: "app.vue",
             },
         }).then((result) => {
-            const component = result.project.FuseBox.import('./app.vue');
+            const component = result.project.FuseBox.import('./app.vue').default;
 
             // //test for render functions
             should( component.render ).notEqual( undefined );

--- a/src/tests/plugins/VuePlugin.test.ts
+++ b/src/tests/plugins/VuePlugin.test.ts
@@ -85,7 +85,7 @@ export class VuePluginTest {
                 instructions: "app.vue",
             },
         }).then((result) => {
-            const component = result.project.FuseBox.import('./app.vue');
+            const component = result.project.FuseBox.import('./app.vue').default;
 
             // //test for render functions
             should( component.render ).notEqual( undefined );


### PR DESCRIPTION
Little change, big effects.

When a vue single-file component is defined, it exports the component as default :
```
@Component
export default class myComponent extends Vue {
```

So, it would seem logical to import it as default too :
```
import myComponent from '../components/myComponent.vue'
```

Instead, for now, the default has become the "whole" export, so we have to use this instead :
```
import * as myComponent from '../components/myComponent.vue'
```

Allowing it to remain `default`, beside notation consistency, would also allow component single-files to export other values, like global configurations, etc.