### PR TITLE
allow uglify options via quantum

### DIFF
--- a/src/quantum/plugin/QuantumOptions.ts
+++ b/src/quantum/plugin/QuantumOptions.ts
@@ -196,7 +196,7 @@ export class QuantumOptions {
     }
 
     public shouldUglify() {
-        return this.uglify === true;
+        return this.uglify;
     }
 
     public shouldBakeApiIntoBundle() {


### PR DESCRIPTION
By checking specifically for `true` here, it prevents an uglify options object from being passed through Quantum.  

https://github.com/fuse-box/fuse-box/blob/master/src/quantum/plugin/BundleWriter.ts#L16 is already set up to take uglify options from this method.