### PR TITLE
feat: centralized error logging for bundles

### DIFF
--- a/src/Log.ts
+++ b/src/Log.ts
@@ -359,6 +359,9 @@ export class Log {
         log.red().bold(msg).echo();
         return this;
     }
+    public echoError(str: string) {
+        log.red(`  → ERROR ${str}`).echo()
+    }
     public echoRed(msg) {
         log.red(msg).echo();
         return this;

--- a/src/core/Bundle.ts
+++ b/src/core/Bundle.ts
@@ -26,6 +26,7 @@ export class Bundle {
     public lastChangedFile: string;
     public webIndexed = true;
     public splitFiles: Map<string, File>;
+    private errors: string[] = [];
 
     public bundleSplit: BundleSplit;
     public quantumItem: QuantumItem;
@@ -217,12 +218,14 @@ export class Bundle {
 
     public exec(): Promise<Bundle> {
         return new Promise((resolve, reject) => {
+            this.clearErrors()
             this.fuse
                 .initiateBundle(this.arithmetics || "", () => {
                     this.process.setFilePath(this.fuse.context.output.lastWrittenPath);
                     if (this.onDoneCallback && this.producer.writeBundles === true) {
                         this.onDoneCallback(this.process);
                     }
+                    this.printErrors()
                     return resolve(this);
                 }).then(source => {
                 }).catch(e => {
@@ -247,4 +250,24 @@ export class Bundle {
         }
     }
 
+    private clearErrors() {
+        this.errors = []
+    }
+
+    public addError(message: string) {
+        this.errors.push(message)
+    }
+
+    public getErrors() {
+        return this.errors.slice()
+    }
+
+    public printErrors() {
+        if (this.errors.length && this.fuse.context.showErrors) {
+            this.fuse.context.log.echoBreak()
+            this.fuse.context.log.echoBoldRed(`Errors for ${this.name} bundle`)
+            this.errors.forEach(error => this.fuse.context.log.echoError(error))
+            this.fuse.context.log.echoBreak()
+        }
+    }
 }

--- a/src/core/BundleProducer.ts
+++ b/src/core/BundleProducer.ts
@@ -77,6 +77,12 @@ export class BundleProducer {
         list.push(message);
     }
 
+    public getErrors() {
+        const errors = []
+        this.bundles.forEach(bundle => errors.push(...bundle.getErrors()))
+        return errors
+    }
+
     public devCodeHasBeenInjected(key: string) {
         return this.injectedCode.has(key);
     }

--- a/src/core/File.ts
+++ b/src/core/File.ts
@@ -540,4 +540,8 @@ export class File {
             }
         );
     }
+
+    public addError (message: string) {
+        this.context.bundle.addError(message)
+    }
 }

--- a/src/core/FuseBox.ts
+++ b/src/core/FuseBox.ts
@@ -48,6 +48,8 @@ export interface FuseBoxOptions {
     alias?: any;
     useJsNext?: boolean,
     runAllMatchedPlugins?: boolean;
+    showErrors?: boolean
+    showErrorsInBrowser?: boolean
 }
 
 /**
@@ -110,6 +112,18 @@ export class FuseBox {
 
         if (opts.warnings !== undefined) {
             this.context.showWarnings = opts.warnings;
+        }
+
+        if (opts.showErrors !== undefined) {
+            this.context.showErrors = opts.showErrors;
+
+            if (opts.showErrorsInBrowser === undefined) {
+                this.context.showErrorsInBrowser = opts.showErrors
+            }
+        }
+
+        if (opts.showErrorsInBrowser !== undefined) {
+            this.context.showErrorsInBrowser = opts.showErrorsInBrowser;
         }
 
         if (opts.ignoreModules) {

--- a/src/core/WorkflowContext.ts
+++ b/src/core/WorkflowContext.ts
@@ -77,6 +77,8 @@ export class WorkFlowContext {
 
     public showErrors = true;
 
+    public showErrorsInBrowser = true;
+
     public useJsNext = false;
 
     public sourceChangedEmitter = new EventEmitter<SourceChangedEvent>();

--- a/src/core/WorkflowContext.ts
+++ b/src/core/WorkflowContext.ts
@@ -75,6 +75,8 @@ export class WorkFlowContext {
 
     public showWarnings = true;
 
+    public showErrors = true;
+
     public useJsNext = false;
 
     public sourceChangedEmitter = new EventEmitter<SourceChangedEvent>();

--- a/src/plugins/stylesheet/SassPlugin.ts
+++ b/src/plugins/stylesheet/SassPlugin.ts
@@ -96,11 +96,12 @@ export class SassPluginClass implements Plugin {
         }
 
         options.includePaths.push(file.info.absDir);
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve) => {
             return sass.render(options, (err, result) => {
                 if (err) {
+                    const errorFile = err.file === 'stdin' ? file.absPath : err.file
                     file.contents = "";
-                    console.log(err.stack || err)
+                    file.addError(`${err.message}\n      at ${errorFile}:${err.line}:${err.column}`)
                     return resolve();
                 }
                 file.sourceMap = result.map && result.map.toString();


### PR DESCRIPTION
I decided to store the errors on the `Bundle`s instead of `BundleProducer`.  This allows us to clear any existing errors each time a bundle executes, without having to worry about other bundles that are/are not executing at the same time.  All current errors across bundles can be accessed through `producer.getErrors()`

I updated the `SassPlugin` to use the new error logging, and update the output to be more useful.

Once this is in, we can discuss the best path for getting the errors to the browser.

![image](https://user-images.githubusercontent.com/3026298/29150848-e03269c6-7d42-11e7-9017-26031a650cdf.png)
