### PR TITLE
Quantum "npm" target

### DIFF
--- a/docs/quantum.md
+++ b/docs/quantum.md
@@ -254,7 +254,7 @@ Here is a list of what you can configure:
 
 ### Target
 Default value: `browser`
-Possible values `server`, `browser`, `universal`,  `electron`
+Possible values `server`, `browser`, `universal`,  `electron`, `npm`
 
 ```js
 QuantumPlugin({
@@ -264,6 +264,7 @@ QuantumPlugin({
 
 These options define the API, for example, if you choose `browser` the API will have no checks for browser and target it directly.
 
+note: With an `npm` target, `bakeApiIntoBundle` should be used and `containedAPI` should be `true`. Also, no vendor should be produced while the bundle is specified with the `[ ]` arithmetics to avoid bundling dependencies.
 
 ### bakeApiIntoBundle 
 Instead of creating a separate file with the api, you can chose to bake it into an existing bundle. 

--- a/src/quantum/plugin/FlatFileGenerator.ts
+++ b/src/quantum/plugin/FlatFileGenerator.ts
@@ -76,7 +76,7 @@ export class FlatFileGenerator {
                     this.contents.push(`module.exports = ${req}`);
                 }
 
-                if (this.core.opts.isTargetUniveral()) {
+                if (this.core.opts.isTargetNpm()) {
                     this.contents.push(`module.exports = ${req}`);
                 }
 

--- a/src/quantum/plugin/FlatFileGenerator.ts
+++ b/src/quantum/plugin/FlatFileGenerator.ts
@@ -77,7 +77,7 @@ export class FlatFileGenerator {
                 }
 
                 if (this.core.opts.isTargetUniveral()) {
-                    //this.contents.push(`module.exports = ${req}`);
+                    this.contents.push(`module.exports = ${req}`);
                 }
 
                 if (this.core.opts.isTargetBrowser()) {

--- a/src/quantum/plugin/FlatFileGenerator.ts
+++ b/src/quantum/plugin/FlatFileGenerator.ts
@@ -72,11 +72,7 @@ export class FlatFileGenerator {
             const req = `$fsx.r(${JSON.stringify(this.entryId)})`;
 
             if (this.globalsName) {
-                if (this.core.opts.isTargetServer()) {
-                    this.contents.push(`module.exports = ${req}`);
-                }
-
-                if (this.core.opts.isTargetNpm()) {
+                if (this.core.opts.isTargetNpm() || this.core.opts.isTargetServer()) {
                     this.contents.push(`module.exports = ${req}`);
                 }
 

--- a/src/quantum/plugin/QuantumOptions.ts
+++ b/src/quantum/plugin/QuantumOptions.ts
@@ -222,7 +222,10 @@ export class QuantumOptions {
         return this.optsTarget === "electron";
     }
     public isTargetUniveral() {
-        return this.optsTarget === "universal";
+        return this.optsTarget === "universal" || this.optsTarget === "npm";
+    }
+    public isTargetNpm() {
+        return this.optsTarget === "npm";
     }
 
     public isTargetServer() {

--- a/src/quantum/plugin/modifications/StatementModifaction.ts
+++ b/src/quantum/plugin/modifications/StatementModifaction.ts
@@ -41,8 +41,9 @@ export class StatementModification {
                     statement.setFunctionName('$fsx.r');
                     statement.setValue(resolvedFile.getID());
                 } else {
-
-                    if (core.opts.isTargetServer() || core.opts.isTargetUniveral()) {
+					if(core.opts.isTargetUniveral()) {
+						statement.setFunctionName('require');
+                    } else if (core.opts.isTargetServer()) {
                         core.api.useServerRequire();
                         statement.setFunctionName('$fsx.s');
                     } else {

--- a/src/quantum/plugin/modifications/StatementModifaction.ts
+++ b/src/quantum/plugin/modifications/StatementModifaction.ts
@@ -41,8 +41,8 @@ export class StatementModification {
                     statement.setFunctionName('$fsx.r');
                     statement.setValue(resolvedFile.getID());
                 } else {
-					if(core.opts.isTargetUniveral()) {
-						statement.setFunctionName('require');
+                    if(core.opts.isTargetUniveral()) {
+                        statement.setFunctionName('require');
                     } else if (core.opts.isTargetServer()) {
                         core.api.useServerRequire();
                         statement.setFunctionName('$fsx.s');

--- a/src/quantum/plugin/modifications/StatementModifaction.ts
+++ b/src/quantum/plugin/modifications/StatementModifaction.ts
@@ -41,9 +41,9 @@ export class StatementModification {
                     statement.setFunctionName('$fsx.r');
                     statement.setValue(resolvedFile.getID());
                 } else {
-                    if(core.opts.isTargetUniveral()) {
+                    if(core.opts.isTargetNpm()) {
                         statement.setFunctionName('require');
-                    } else if (core.opts.isTargetServer()) {
+                    } else if (core.opts.isTargetServer() || core.opts.isTargetUniveral()) {
                         core.api.useServerRequire();
                         statement.setFunctionName('$fsx.s');
                     } else {


### PR DESCRIPTION
When working with modules that are independently used server-side and client-side, there is a need of creating a module file that uses the standard require/module.exports, regardless of its usage on the server or in the browser.

I corrected here 2 little points about the "universal" target that, I think, was done for this figure case :
- The values exported by the fused module are given in module.exports (like in the case of "server" target)
- The unresolved imports are just imported with the `require` keyword.

This way, I could make a module that just exports functions, whether it is bundled for server or browser use.