### PR TITLE
Target npm

### DIFF
--- a/modules/fuse-box-responsive-api/index.js
+++ b/modules/fuse-box-responsive-api/index.js
@@ -8,6 +8,7 @@
     /* @end */
 
     /* @if universal */
+    var isBrowser = typeof window !== "undefined";
     /* @if !npm */
     var isBrowser = typeof window !== "undefined";
     if (!isBrowser) {

--- a/modules/fuse-box-responsive-api/index.js
+++ b/modules/fuse-box-responsive-api/index.js
@@ -9,11 +9,6 @@
 
     /* @if universal */
     var isBrowser = typeof window !== "undefined";
-    /* @if !npm */
-    if (!isBrowser) {
-        global.require = require;
-    }
-    /* @end */
     /* @if !isContained */
     var storage = isBrowser ? window : global;
     if (storage.$fsx) {

--- a/modules/fuse-box-responsive-api/index.js
+++ b/modules/fuse-box-responsive-api/index.js
@@ -8,11 +8,12 @@
     /* @end */
 
     /* @if universal */
+    /* @if !npm */
     var isBrowser = typeof window !== "undefined";
     if (!isBrowser) {
         global.require = require;
     }
-
+    /* @end */
     /* @if !isContained */
     var storage = isBrowser ? window : global;
     if (storage.$fsx) {

--- a/modules/fuse-box-responsive-api/index.js
+++ b/modules/fuse-box-responsive-api/index.js
@@ -10,7 +10,6 @@
     /* @if universal */
     var isBrowser = typeof window !== "undefined";
     /* @if !npm */
-    var isBrowser = typeof window !== "undefined";
     if (!isBrowser) {
         global.require = require;
     }

--- a/modules/fuse-box-responsive-api/index.js
+++ b/modules/fuse-box-responsive-api/index.js
@@ -9,6 +9,7 @@
 
     /* @if universal */
     var isBrowser = typeof window !== "undefined";
+    
     /* @if !isContained */
     var storage = isBrowser ? window : global;
     if (storage.$fsx) {

--- a/src/quantum/plugin/ResponsiveAPI.ts
+++ b/src/quantum/plugin/ResponsiveAPI.ts
@@ -103,6 +103,7 @@ export class ResponsiveAPI {
         const options: any = {
             browser: this.core.opts.isTargetBrowser(),
             universal: this.core.opts.isTargetUniveral(),
+            npm: this.core.opts.isTargetNpm(),
             server: this.core.opts.isTargetServer(),
             isServerFunction: this.isServerFunction,
             isBrowserFunction: this.isBrowserFunction,


### PR DESCRIPTION
I had a bug report on a line appearing in the npm bundle :
```
global.require = require
```
In an npm bundle, this definitely makes no sense. The modification basically removes this line allowing as a side effect `fuse-box-responsive-api` to access the `npm` target