### PR TITLE
feat(error-logging): minimize/hide in browser

### DIFF
--- a/src/core/Bundle.ts
+++ b/src/core/Bundle.ts
@@ -91,18 +91,29 @@ export class Bundle {
             });
 
             if (this.context.showErrorsInBrowser) {
+                const type = "update-bundle-errors",
+                    getData = () => ({
+                        bundleName: this.name,
+                        messages: this.errors
+                    })
+
                 this.errorEmitter.on(message => {
                     server.send("bundle-error", {
                         bundleName: this.name,
                         message
                     })
-                });
+                })
 
                 this.clearErrorEmitter.on(() => {
-                    server.send("clear-bundle-errors", {
-                        bundleName: this.name
-                    })
-                });
+                    server.send(type, getData())
+                })
+
+                server.server.on("connection", client => {
+                    client.send(JSON.stringify({
+                        type,
+                        data: getData()
+                    }))
+                })
             }
         });
         return this;


### PR DESCRIPTION
## Updates
* Send bundle errors to new browsers as soon as they open.  Previously they would only get the errors in the browser after a consecutive bundle execution.
* Allow user to minimize the error output in the browser
  * This is persisted in local storage, so output stays minimized after refresh
  * Minimized:
![image](https://user-images.githubusercontent.com/3026298/29837502-eb4c96f8-8cbd-11e7-930f-1e0708fa1bf9.png)
  * Expanded:
![image](https://user-images.githubusercontent.com/3026298/29837517-f62fa88a-8cbd-11e7-9d36-a9e5bcf5bf66.png)
* Allow user to hide the error output
  * This is not persisted in local storage.  If a user doesn't want errors in the browser, they can set `showErrorsInBrowser: false`

Big thanks to @adye for putting together the styles 🎉 
