### PR TITLE
Prevent overwriting of sources in sourcemaps (sass)

### DIFF
--- a/src/core/File.ts
+++ b/src/core/File.ts
@@ -589,7 +589,14 @@ export class File {
         if (this.sourceMap) {
             let jsonSourceMaps = JSON.parse(this.sourceMap);
             jsonSourceMaps.file = this.info.fuseBoxPath;
-            jsonSourceMaps.sources = [this.context.sourceMapsRoot + "/" + (fname || this.info.fuseBoxPath)];
+            jsonSourceMaps.sources = jsonSourceMaps.sources.map((source : string) => {
+                if(source.indexOf('stdin') !== -1) {
+                    return this.context.sourceMapsRoot + "/" + (fname || this.info.fuseBoxPath);
+                }
+                
+                return this.context.sourceMapsRoot + "/" + source;
+            });
+            
             if (!this.context.inlineSourceMaps) {
                 delete jsonSourceMaps.sourcesContent;
             }


### PR DESCRIPTION
Change to keep all the sources in sourcemaps for stylesheets and allow to see all related source-files in browser.

**current:** 
Source/Linking is only available for the main/root scss file in browser and all @imports are ignored

**should**
Provide sources/linking to all related files

**done**
As far I understood is `stdin` the current file if `data` is used as source [info](https://github.com/sass/node-sass/issues/591).

I'm not really sure if its working like expected with `fname`. This should't break anything but I think it will not work for all sources (vendor specific) because `fname` is not used for all of them. `fname` is provided [here](https://github.com/fuse-box/fuse-box/blob/882b7d6949e086386194d39b33b4ad65c56646d5/src/core/File.ts#L530) and used in `loadVendorSourceMap()`