### PR TITLE
feat: expose `package.json` in file info

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "url": "git+https://github.com/fuse-box/fuse-box.git"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/fuse-box/fuse-box/issues"
   },

--- a/src/tests/CSSDependencyExtractor.test.ts
+++ b/src/tests/CSSDependencyExtractor.test.ts
@@ -19,7 +19,7 @@ export class DependencyExtractorTest {
             `
         });
         let deps = extractor.getDependencies();
-        let expected = ["tests/stubs/css/path1/foo.scss", "tests/stubs/css/path1/woo.scss", "tests/stubs/css/path1/hello.scss"]
+        let expected = ["tests/stubs/css/path1/foo.scss", "tests/stubs/css/path1/woo.scss", "tests/stubs/css/path1/hello.scss"].map(path.normalize)
         deps.forEach((dep, index) => {
             should(dep).findString(expected[index])
         });
@@ -39,7 +39,7 @@ export class DependencyExtractorTest {
             `
         });
         let deps = extractor.getDependencies();
-        let expected = ["tests/stubs/css/path1/_underscore.scss"]
+        let expected = ["tests/stubs/css/path1/_underscore.scss"].map(path.normalize)
         deps.forEach((dep, index) => {
             should(dep).findString(expected[index])
         });
@@ -59,7 +59,7 @@ export class DependencyExtractorTest {
             `
         });
         let deps = extractor.getDependencies();
-        let expected = ["tests/stubs/css/path1/_underscore.scss"]
+        let expected = ["tests/stubs/css/path1/_underscore.scss"].map(path.normalize)
         deps.forEach((dep, index) => {
             should(dep).findString(expected[index])
         });
@@ -78,7 +78,7 @@ export class DependencyExtractorTest {
             `
         });
         let deps = extractor.getDependencies();
-        let expected = ["tests/stubs/css/path1/_underscore_css.css"];
+        let expected = ["tests/stubs/css/path1/_underscore_css.css"].map(path.normalize)
         deps.forEach((dep, index) => {
             should(dep).findString(expected[index])
         });


### PR DESCRIPTION
This sets the raw `package.json` data onto a `packageJson` property in `IPackageInformation`

Also gets the sass dep extraction tests working on windows.

The test for the `packageJson` property is a bit hacky, mostly because there is no way (afaik) to configure a PathMaster instance outside of the global Config object