### PR TITLE
Postcss fix: pass options through to plugins

### DIFF
--- a/docs/plugins/css/PostCSSPlugin.md
+++ b/docs/plugins/css/PostCSSPlugin.md
@@ -96,7 +96,7 @@ Or like this:
 ```js
 FuseBox.init({
     plugins : [
-         [PostCSSPlugin([], {
+         [PostCSSPlugin({
              // postcss plugins
              plugins: [require('postcss-url')({url: "rebase"})],
              // should fusebox generate sourcemaps (see below), default: true

--- a/docs/plugins/css/PostCSSPlugin.md
+++ b/docs/plugins/css/PostCSSPlugin.md
@@ -75,6 +75,27 @@ If you require more options, you can pass them to the plugin:
 ```js
 FuseBox.init({
     plugins : [
+         [PostCSSPlugin(
+             // postcss plugins
+             [require('postcss-url')({url: "rebase"})], 
+             {
+                 // should fusebox generate sourcemaps (see below), default: true
+                 sourceMaps: false,
+                 // additional paths for css resolution (see below)
+                 paths: [],
+                 // all other options will go to the postcss process function (see below) 
+                 parser: parser,
+            }
+         ), CSSPlugin()]
+    ]
+});
+```
+
+Or like this
+
+```js
+FuseBox.init({
+    plugins : [
          [PostCSSPlugin({
              // postcss plugins
              plugins: [require('postcss-url')({url: "rebase"})],

--- a/docs/plugins/css/PostCSSPlugin.md
+++ b/docs/plugins/css/PostCSSPlugin.md
@@ -1,7 +1,12 @@
 # PostCSS Plugin
 
 ## Description
-Allows using PostCSS, A tool for transforming CSS with JavaScript.
+
+Allows using PostCSS, a tool for transforming styles with JS plugins. 
+These plugins can lint your CSS, support variables and mixins, 
+transpile future CSS syntax, inline images, and more.
+
+Check [PostCSS website](http://postcss.org/) for more information.
 
 ## Install
 
@@ -12,12 +17,12 @@ npm install postcss --save-dev
 ```
 
 ## Usage
-check [PostCSS website](http://postcss.org/) for more information.
-note: The PostCSS plugin generates CSS, Therefor it must be chained prior to the CSSPlugin to be used.
+
+The PostCSS plugin generates CSS. It must therefore be chained prior to the CSSPlugin to be used.
 
 ### Setup
 
-Import from FuseBox
+Import the plugin from FuseBox
 
 ```js
 const {PostCSSPlugin} = require("fuse-box");
@@ -42,58 +47,104 @@ FuseBox.init({
 ```
 
 ### Require file in your code
+
 ```js
 import "./styles/main.css"
 ```
 
+### Plugins
+
+You can pass PostCss plugins directly to the PostCSSPlugin:
+
+```js
+FuseBox.init({
+    plugins : [
+         [PostCSSPlugin([
+             require('postcss-import'),
+             // You can optionally pass options to the plugins
+             require('postcss-url')({url: "rebase"}),
+             require('postcss-nested')
+         ]), 
+         CSSPlugin()]
+    ]
+});
+```
+
+If you require more options, you can pass them to the plugin:
+
+```js
+FuseBox.init({
+    plugins : [
+         [PostCSSPlugin({
+             // postcss plugins
+             plugins: [require('postcss-url')({url: "rebase"})],
+             // should fusebox generate sourcemaps (see below), default: true
+             sourceMaps: false,
+             // additional paths for css resolution (see below)
+             paths: [],
+             // all other options will go to the postcss process function (see below) 
+             parser: parser,
+         }), CSSPlugin()]
+    ]
+});
+```
+
 ## Options
 
-`PostCSSPlugin` accepts a `key/value` `PostCSS` object options as a parameter. For example:
+`PostCSSPlugin` passes any additional option as [process options](http://api.postcss.org/global.html#processOptions)
+to PostCss.
+For example:
 
 ```js
 var nested = require('postcss-nested');
 var sugarss = require('sugarss');
 
 fuse.plugin(
-    [PostCSSPlugin({
-       plugins, { parser: sugarss }
-    }), CSSPlugin()]
+    [
+        PostCSSPlugin({
+            plugins: [nested],
+            // passed to PostCss process function 
+            parser: sugarss
+        }), 
+        CSSPlugin()
+    ]
 )
 ```
 
 ## Paths for HMR
-If you are using `postcss-import` plugin, you would need to provide paths to FuseBox config too, if you want
-HMR to work and detect css dependendies automatically.
 
-You don't need to add paths if all you are resolving is relative paths (to the processed file)
+If you are using `postcss-import` plugin, you might need to provide additional paths to FuseBox config.
+It will allow fusebox's HMR to work and detect css dependencies automatically.
+
+You don't need to add the paths option if all you are using paths relative to the processed file.
 
 ```js
-plugins: [
-        [
-            PostCSSPlugin({
-                plugins : [require("postcss-import")({ path: ["src"]})],
-                paths : [ path.resolve(__dirname, "src/shared" )]
-            }),
-            CSSPlugin()
-        ]
+fuse.plugin(
+    [
+        PostCSSPlugin({
+            plugins : [ require("postcss-import")({ path: ["src"]}) ],
+            paths : [ path.resolve(__dirname, "src/shared" )]
+        }),
+        CSSPlugin()
     ]
+)
 ```
 
 ## Disable sourceMaps
 
-You can internally disable sourceMaps if you wish to preserve earlier generated source maps, (by Sass for example)
+You can internally disable sourceMaps if you wish to preserve source maps generated earlier (by Sass for example)
 
 
 ```js
-plugins: [
-        [
-            SassPlugin(),
-            PostCSSPlugin({
-                plugins : [require("postcss-import")({ path: ["src"]})],
-                sourceMaps : false
-            }),
-            CSSPlugin()
-        ]
+fuse.plugin(
+    [
+        SassPlugin(),
+        PostCSSPlugin({
+            plugins : [require("postcss-import")({ path: ["src"]})],
+            sourceMaps : false
+        }),
+        CSSPlugin()
     ]
+)
 ```
 

--- a/docs/plugins/css/PostCSSPlugin.md
+++ b/docs/plugins/css/PostCSSPlugin.md
@@ -54,7 +54,7 @@ import "./styles/main.css"
 
 ### Plugins
 
-You can pass PostCss plugins directly to the PostCSSPlugin:
+The `PostCSSPlugin` take PostCss plugins as a first argument:
 
 ```js
 FuseBox.init({
@@ -70,7 +70,7 @@ FuseBox.init({
 });
 ```
 
-If you require more options, you can pass them to the plugin:
+If you require more options, you can pass them as a second argument to the plugin:
 
 ```js
 FuseBox.init({
@@ -91,12 +91,12 @@ FuseBox.init({
 });
 ```
 
-Or like this
+Or like this:
 
 ```js
 FuseBox.init({
     plugins : [
-         [PostCSSPlugin({
+         [PostCSSPlugin([], {
              // postcss plugins
              plugins: [require('postcss-url')({url: "rebase"})],
              // should fusebox generate sourcemaps (see below), default: true
@@ -122,8 +122,8 @@ var sugarss = require('sugarss');
 
 fuse.plugin(
     [
-        PostCSSPlugin({
-            plugins: [nested],
+        PostCSSPlugin(
+            [nested], {
             // passed to PostCss process function 
             parser: sugarss
         }), 
@@ -142,10 +142,12 @@ You don't need to add the paths option if all you are using paths relative to th
 ```js
 fuse.plugin(
     [
-        PostCSSPlugin({
-            plugins : [ require("postcss-import")({ path: ["src"]}) ],
-            paths : [ path.resolve(__dirname, "src/shared" )]
-        }),
+        PostCSSPlugin(
+            [ require("postcss-import")({ path: ["src"]}) ],
+            {
+                paths : [ path.resolve(__dirname, "src/shared" )]
+            }
+        ),
         CSSPlugin()
     ]
 )
@@ -160,10 +162,12 @@ You can internally disable sourceMaps if you wish to preserve source maps genera
 fuse.plugin(
     [
         SassPlugin(),
-        PostCSSPlugin({
-            plugins : [require("postcss-import")({ path: ["src"]})],
-            sourceMaps : false
-        }),
+        PostCSSPlugin(
+            [require("postcss-import")({ path: ["src"]})], 
+            {
+                sourceMaps : false
+            }
+        ),
         CSSPlugin()
     ]
 )

--- a/src/plugins/stylesheet/PostCSSPlugin.ts
+++ b/src/plugins/stylesheet/PostCSSPlugin.ts
@@ -93,7 +93,7 @@ export class PostCSSPluginClass implements Plugin {
 }
 
 function PostCSS (processors?: Processors, opts?: PostCSSPluginOptions);
-function PostCSS (PostCSSPluginOptions);
+function PostCSS (options: PostCSSPluginOptions);
 function PostCSS (processors?: Processors | PostCSSPluginOptions, opts?: PostCSSPluginOptions) {
     if (Array.isArray(processors)) {
         return new PostCSSPluginClass(processors, opts);

--- a/src/plugins/stylesheet/PostCSSPlugin.ts
+++ b/src/plugins/stylesheet/PostCSSPlugin.ts
@@ -28,19 +28,7 @@ export class PostCSSPluginClass implements Plugin {
      */
     public test: RegExp = /\.css$/;
     public dependencies = [];
-    public options: PostCSSPluginOptions = {
-      sourceMaps: true,
-      plugins: [],
-      paths: []
-    };
-
-    constructor(opts: Processors | PostCSSPluginOptions) {
-        if (Array.isArray(opts)) {
-            this.options.plugins = opts
-        } else {
-            this.options = Object.assign(this.options, opts);
-        }
-    }
+    constructor(public processors: Processors = [], public options?: PostCSSPluginOptions) { }
     /**
      *
      *
@@ -71,11 +59,11 @@ export class PostCSSPluginClass implements Plugin {
         file.loadContents();
 
         const {
-            sourceMaps,
-            plugins,
-            paths,
+            sourceMaps = true,
+            plugins = [],
+            paths = [],
             ...postCssOptions
-        } = this.options;
+        } = this.options || {};
 
         paths.push(file.info.absDir);
 
@@ -89,7 +77,7 @@ export class PostCSSPluginClass implements Plugin {
             postcss = require("postcss");
         }
 
-        return postcss(plugins)
+        return postcss(this.processors.concat(plugins))
             .process(file.contents, postCssOptions)
             .then(result => {
                 file.contents = result.css;
@@ -104,6 +92,6 @@ export class PostCSSPluginClass implements Plugin {
     }
 }
 
-export const PostCSS = (opts?: Processors | PostCSSPluginOptions) => {
-    return new PostCSSPluginClass(opts);
+export const PostCSS = (processors?: Processors, opts?: PostCSSPluginOptions) => {
+    return new PostCSSPluginClass(processors, opts);
 };

--- a/src/plugins/stylesheet/PostCSSPlugin.ts
+++ b/src/plugins/stylesheet/PostCSSPlugin.ts
@@ -92,6 +92,9 @@ export class PostCSSPluginClass implements Plugin {
     }
 }
 
-export const PostCSS = (processors?: Processors, opts?: PostCSSPluginOptions) => {
-    return new PostCSSPluginClass(processors, opts);
+export const PostCSS = (processors?: Processors | PostCSSPluginOptions, opts?: PostCSSPluginOptions) => {
+    if (Array.isArray(processors)) {
+        return new PostCSSPluginClass(processors, opts);
+    }
+    return new PostCSSPluginClass([], opts);
 };

--- a/src/plugins/stylesheet/PostCSSPlugin.ts
+++ b/src/plugins/stylesheet/PostCSSPlugin.ts
@@ -96,5 +96,5 @@ export const PostCSS = (processors?: Processors | PostCSSPluginOptions, opts?: P
     if (Array.isArray(processors)) {
         return new PostCSSPluginClass(processors, opts);
     }
-    return new PostCSSPluginClass([], opts);
+    return new PostCSSPluginClass([], processors);
 };

--- a/src/plugins/stylesheet/PostCSSPlugin.ts
+++ b/src/plugins/stylesheet/PostCSSPlugin.ts
@@ -28,7 +28,19 @@ export class PostCSSPluginClass implements Plugin {
      */
     public test: RegExp = /\.css$/;
     public dependencies = [];
-    constructor(public processors: Processors = [], public options?: PostCSSPluginOptions) { }
+    public options: PostCSSPluginOptions = {
+      sourceMaps: true,
+      plugins: [],
+      paths: []
+    };
+
+    constructor(opts: Processors | PostCSSPluginOptions) {
+        if (Array.isArray(opts)) {
+            this.options.plugins = opts
+        } else {
+            this.options = Object.assign(this.options, opts);
+        }
+    }
     /**
      *
      *
@@ -59,11 +71,11 @@ export class PostCSSPluginClass implements Plugin {
         file.loadContents();
 
         const {
-            sourceMaps = true,
-            plugins = [],
-            paths = [],
+            sourceMaps,
+            plugins,
+            paths,
             ...postCssOptions
-        } = this.options || {};
+        } = this.options;
 
         paths.push(file.info.absDir);
 
@@ -77,7 +89,7 @@ export class PostCSSPluginClass implements Plugin {
             postcss = require("postcss");
         }
 
-        return postcss(this.processors.concat(plugins))
+        return postcss(plugins)
             .process(file.contents, postCssOptions)
             .then(result => {
                 file.contents = result.css;
@@ -92,6 +104,6 @@ export class PostCSSPluginClass implements Plugin {
     }
 }
 
-export const PostCSS = (processors?: Processors, opts?: PostCSSPluginOptions) => {
-    return new PostCSSPluginClass(processors, opts);
+export const PostCSS = (opts?: Processors | PostCSSPluginOptions) => {
+    return new PostCSSPluginClass(opts);
 };

--- a/src/plugins/stylesheet/PostCSSPlugin.ts
+++ b/src/plugins/stylesheet/PostCSSPlugin.ts
@@ -92,9 +92,13 @@ export class PostCSSPluginClass implements Plugin {
     }
 }
 
-export const PostCSS = (processors?: Processors | PostCSSPluginOptions, opts?: PostCSSPluginOptions) => {
+function PostCSS (processors?: Processors, opts?: PostCSSPluginOptions);
+function PostCSS (PostCSSPluginOptions);
+function PostCSS (processors?: Processors | PostCSSPluginOptions, opts?: PostCSSPluginOptions) {
     if (Array.isArray(processors)) {
         return new PostCSSPluginClass(processors, opts);
     }
     return new PostCSSPluginClass([], processors);
-};
+}
+
+export {PostCSS}

--- a/src/plugins/stylesheet/PostCSSPlugin.ts
+++ b/src/plugins/stylesheet/PostCSSPlugin.ts
@@ -58,8 +58,18 @@ export class PostCSSPluginClass implements Plugin {
         file.bustCSSCache = true;
         file.loadContents();
 
-        let paths: string[] = this.options && this.options.paths || [];
-        paths.push(file.info.absDir);
+        let generateSourceMaps = true;
+        let postCssOptions;
+        let pathOptions: string[] = [];
+
+        if (this.options) {
+            const {sourceMaps, plugins, paths, ...otherOptions} = this.options;
+            generateSourceMaps = sourceMaps;
+            postCssOptions = otherOptions;
+            pathOptions = paths || [];
+        }
+
+        pathOptions.push(file.info.absDir);
 
         const cssDependencies = file.context.extractCSSDependencies(file, {
             paths: this.options && this.options.paths || [file.info.absDir],
@@ -70,22 +80,9 @@ export class PostCSSPluginClass implements Plugin {
         if (!postcss) {
             postcss = require("postcss");
         }
-        let generateSourceMaps = true;
-        let postCSSPlugins = [];
-        if (Array.isArray(this.options)) {
-            postCSSPlugins = this.options;
-        } else {
-            if (this.options) {
-                if (Array.isArray(this.options.plugins)) {
-                    postCSSPlugins = this.options.plugins;
-                }
-                if (this.options.sourceMaps !== undefined) {
-                    generateSourceMaps = this.options.sourceMaps;
-                }
-            }
-        }
+
         return postcss(this.processors)
-            .process(file.contents, postCSSPlugins)
+            .process(file.contents, postCssOptions)
             .then(result => {
                 file.contents = result.css;
 

--- a/src/plugins/stylesheet/PostCSSPlugin.ts
+++ b/src/plugins/stylesheet/PostCSSPlugin.ts
@@ -60,22 +60,20 @@ export class PostCSSPluginClass implements Plugin {
 
         let generateSourceMaps = true;
         let postCssOptions;
-        let pathOptions: string[] = [];
+        let pathOptions: string[] = [file.info.absDir];
 
         if (this.options) {
-            const {sourceMaps, plugins, paths, ...otherOptions} = this.options;
+            const {sourceMaps = generateSourceMaps, plugins, paths = pathOptions, ...otherOptions} = this.options;
             generateSourceMaps = sourceMaps;
             postCssOptions = otherOptions;
-            pathOptions = paths || [];
+            pathOptions = paths;
         }
 
-        pathOptions.push(file.info.absDir);
-
         const cssDependencies = file.context.extractCSSDependencies(file, {
-            paths: this.options && this.options.paths || [file.info.absDir],
+            paths: pathOptions,
             content: file.contents,
             extensions: ["css"]
-        })
+        });
 
         if (!postcss) {
             postcss = require("postcss");

--- a/src/tests/plugins/PostcssPlugin.test.ts
+++ b/src/tests/plugins/PostcssPlugin.test.ts
@@ -77,7 +77,7 @@ export class PostcssPluginTest {
   "Should execute several plugins"() {
     return setup({
       plugins: [
-        [PostCSS({plugins: [idToClassPlugin, changeDisplayPlugin]}), CSSPlugin({})]
+        [PostCSS([changeDisplayPlugin], {plugins: [idToClassPlugin]}), CSSPlugin({})]
       ]
     })
       .then((result) => {
@@ -91,7 +91,7 @@ export class PostcssPluginTest {
   "Should be able to pass options to postcss"() {
     return setup({
       plugins: [
-        [PostCSS({plugins: [urlPlugin], from: "./somedir"}), CSSPlugin({})]
+        [PostCSS([urlPlugin], {from: "./somedir"}), CSSPlugin({})]
       ],
       styleContent: `
         body {

--- a/src/tests/plugins/PostcssPlugin.test.ts
+++ b/src/tests/plugins/PostcssPlugin.test.ts
@@ -77,7 +77,7 @@ export class PostcssPluginTest {
   "Should execute several plugins"() {
     return setup({
       plugins: [
-        [PostCSS([changeDisplayPlugin], {plugins: [idToClassPlugin]}), CSSPlugin({})]
+        [PostCSS({plugins: [idToClassPlugin, changeDisplayPlugin]}), CSSPlugin({})]
       ]
     })
       .then((result) => {
@@ -88,10 +88,10 @@ export class PostcssPluginTest {
       });
   }
 
-  "Should be able to pass options"() {
+  "Should be able to pass options to postcss"() {
     return setup({
       plugins: [
-        [PostCSS([urlPlugin], {from: "./somedir"}), CSSPlugin({})]
+        [PostCSS({plugins: [urlPlugin], from: "./somedir"}), CSSPlugin({})]
       ],
       styleContent: `
         body {

--- a/src/tests/plugins/PostcssPlugin.test.ts
+++ b/src/tests/plugins/PostcssPlugin.test.ts
@@ -77,7 +77,7 @@ export class PostcssPluginTest {
   "Should execute several plugins"() {
     return setup({
       plugins: [
-        [PostCSS([changeDisplayPlugin, idToClassPlugin]), CSSPlugin({})]
+        [PostCSS([changeDisplayPlugin], {plugins: [idToClassPlugin]}), CSSPlugin({})]
       ]
     })
       .then((result) => {

--- a/src/tests/plugins/PostcssPlugin.test.ts
+++ b/src/tests/plugins/PostcssPlugin.test.ts
@@ -1,0 +1,26 @@
+import { createEnv } from "../stubs/TestEnvironment";
+import { should } from "fuse-test-runner";
+import { CSSPlugin } from "../../plugins/stylesheet/CSSplugin";
+import { PostCSS } from "../../plugins/stylesheet/PostCSSPlugin";
+
+export class PostcssPluginTest {
+    "Should import compiled postcss code"() {
+        return createEnv({
+            project: {
+                files: {
+                    "index.ts": `exports.hello = { bar : require("./style.css") }`,
+                    "style.css": `
+				body {
+					color: white
+        }
+			`
+                },
+                plugins: [[PostCSS(), CSSPlugin({})]],
+                instructions: "index.ts",
+            },
+        }).then((result) => {
+            const out = result.projectContents.toString();
+            should(out).findString(`color: white`);
+        });
+    }
+}

--- a/src/tests/plugins/PostcssPlugin.test.ts
+++ b/src/tests/plugins/PostcssPlugin.test.ts
@@ -1,13 +1,14 @@
-import { createEnv } from "../stubs/TestEnvironment";
-import { should } from "fuse-test-runner";
-import { CSSPlugin } from "../../plugins/stylesheet/CSSplugin";
-import { PostCSS } from "../../plugins/stylesheet/PostCSSPlugin";
+import {createEnv} from "../stubs/TestEnvironment";
+import {should} from "fuse-test-runner";
+import {CSSPlugin} from "../../plugins/stylesheet/CSSplugin";
+import {PostCSS} from "../../plugins/stylesheet/PostCSSPlugin";
+
 const postcss = require("postcss");
 
-const pluginA = postcss.plugin("AllBlocks", function(options) {
-  return function(css) {
-    css.walkRules(function(rule) {
-      rule.walkDecls(function(decl, i) {
+const changeDisplayPlugin = postcss.plugin("ChangeDisplayPlugin", function (options) {
+  return function (css) {
+    css.walkRules(function (rule) {
+      rule.walkDecls(function (decl, i) {
         if (decl.prop === "display") {
           decl.value = "block";
         }
@@ -16,15 +17,94 @@ const pluginA = postcss.plugin("AllBlocks", function(options) {
   };
 });
 
-const pluginB = postcss.plugin("IdToClass", function(options) {
-  return function(css) {
-    css.walkRules(function(rule) {
+// This is essentially how the url plugin works
+// It requires the global postcss options to be passed through ("from", "to")
+const urlPlugin = postcss.plugin("UrlPlugin", function (options) {
+  return function (css, result) {
+    let opts = result.opts;
+    css.walkRules(function (rule) {
+      rule.walkDecls(function (decl) {
+
+        let pattern = /(url\(\s*['"]?)([^"')]+)(["']?\s*\))/g;
+
+        if (pattern.test(decl.value)) {
+          decl.value = decl.value
+            .replace(pattern, (matched, before, url, after) => {
+              const newUrl = opts.from + "/" + url;
+              return `${before}${newUrl}${after}`;
+            });
+        }
+      });
+    });
+  };
+});
+
+const idToClassPlugin = postcss.plugin("IdToClass", function (options) {
+  return function (css) {
+    css.walkRules(function (rule) {
       if (rule.selector && rule.selector[0] === "#") {
         rule.selector = "." + rule.selector.slice(1);
       }
     });
   };
 });
+
+export class PostcssPluginTest {
+  "Should be unmodified with no plugins"() {
+    return setup({
+      plugins: [
+        [PostCSS(), CSSPlugin({})]
+      ]
+    })
+      .then((result) => {
+        const out = result.projectContents.toString();
+        should(out).findString(`display: grid;`);
+      });
+  }
+
+  "Single plugin"() {
+    return setup({
+      plugins: [
+        [PostCSS(changeDisplayPlugin), CSSPlugin({})]
+      ]
+    })
+      .then((result) => {
+        const out = result.projectContents.toString();
+        should(out).findString(`display: block`);
+      });
+  }
+
+  "Several plugins"() {
+    return setup({
+      plugins: [
+        [PostCSS([changeDisplayPlugin, idToClassPlugin]), CSSPlugin({})]
+      ]
+    })
+      .then((result) => {
+        const out = result.projectContents.toString();
+        should(out).findString(`display: block`);
+        should(out).notFindString(`#moon`);
+        should(out).findString(`.moon`);
+      });
+  }
+
+  "Should be able to pass options"() {
+    return setup({
+      plugins: [
+        [PostCSS([urlPlugin], {from: "./somedir"}), CSSPlugin({})]
+      ],
+      styleContent: `
+        body {
+            background-image: url("paper.gif");
+        }
+      `
+    })
+      .then((result) => {
+        const out = result.projectContents.toString();
+        should(out).findString(`background-image: url(\\"./somedir/paper.gif\\")`);
+      });
+  }
+}
 
 const style = `
     .grid {
@@ -35,46 +115,12 @@ const style = `
     }
 `;
 
-export class PostcssPluginTest {
-    "Should be unmodified with no plugins"() {
-        return setup([
-          [PostCSS(), CSSPlugin({})]
-        ])
-          .then((result) => {
-            const out = result.projectContents.toString();
-            should(out).findString(`display: grid;`);
-        });
-    }
-
-    "Single plugin"() {
-        return setup([
-          [PostCSS(pluginA), CSSPlugin({})]
-        ])
-          .then((result) => {
-            const out = result.projectContents.toString();
-            should(out).findString(`display: block`);
-        });
-    }
-
-    "Several plugins"() {
-        return setup([
-          [PostCSS([pluginA, pluginB]), CSSPlugin({})]
-        ])
-          .then((result) => {
-            const out = result.projectContents.toString();
-            should(out).findString(`display: block`);
-            should(out).notFindString(`#moon`);
-            should(out).findString(`.moon`);
-        });
-    }
-}
-
-function setup(plugins) {
+function setup({plugins, styleContent = style}) {
   return createEnv({
     project: {
       files: {
         "index.ts": `exports.style = require("./style.css")`,
-        "style.css": style
+        "style.css": styleContent
       },
       plugins: plugins,
       instructions: "index.ts",

--- a/src/tests/plugins/PostcssPlugin.test.ts
+++ b/src/tests/plugins/PostcssPlugin.test.ts
@@ -2,25 +2,87 @@ import { createEnv } from "../stubs/TestEnvironment";
 import { should } from "fuse-test-runner";
 import { CSSPlugin } from "../../plugins/stylesheet/CSSplugin";
 import { PostCSS } from "../../plugins/stylesheet/PostCSSPlugin";
+const postcss = require("postcss");
+
+const pluginA = postcss.plugin("AllBlocks", function(options) {
+  return function(css) {
+    css.walkRules(function(rule) {
+      rule.walkDecls(function(decl, i) {
+        if (decl.prop === "display") {
+          decl.value = "block";
+        }
+      });
+    });
+  };
+});
+
+const pluginB = postcss.plugin("IdToClass", function(options) {
+  return function(css) {
+    css.walkRules(function(rule) {
+      if (rule.selector && rule.selector[0] === "#") {
+        rule.selector = "." + rule.selector.slice(1);
+      }
+    });
+  };
+});
+
+const style = `
+    .grid {
+        display: grid;
+    }
+    #moon {
+        color: #555;
+    }
+`;
 
 export class PostcssPluginTest {
-    "Should import compiled postcss code"() {
+    "Should be unmodified with no plugins"() {
         return createEnv({
             project: {
                 files: {
                     "index.ts": `exports.hello = { bar : require("./style.css") }`,
-                    "style.css": `
-				body {
-					color: white
-        }
-			`
+                    "style.css": style
                 },
                 plugins: [[PostCSS(), CSSPlugin({})]],
                 instructions: "index.ts",
             },
         }).then((result) => {
             const out = result.projectContents.toString();
-            should(out).findString(`color: white`);
+            should(out).findString(`display: grid;`);
+        });
+    }
+
+    "Single plugin"() {
+        return createEnv({
+            project: {
+                files: {
+                    "index.ts": `exports.hello = { bar : require("./style.css") }`,
+                    "style.css": style
+                },
+                plugins: [[PostCSS([pluginA]), CSSPlugin({})]],
+                instructions: "index.ts",
+            },
+        }).then((result) => {
+            const out = result.projectContents.toString();
+            should(out).findString(`display: block`);
+        });
+    }
+
+    "Several plugins"() {
+        return createEnv({
+            project: {
+                files: {
+                    "index.ts": `exports.hello = { bar : require("./style.css") }`,
+                    "style.css": style
+                },
+                plugins: [[PostCSS([pluginA, pluginB]), CSSPlugin({})]],
+                instructions: "index.ts",
+            },
+        }).then((result) => {
+            const out = result.projectContents.toString();
+            should(out).findString(`display: block`);
+            should(out).notFindString(`#moon`);
+            should(out).findString(`.moon`);
         });
     }
 }

--- a/src/tests/plugins/PostcssPlugin.test.ts
+++ b/src/tests/plugins/PostcssPlugin.test.ts
@@ -65,7 +65,7 @@ export class PostcssPluginTest {
   "Should execute single plugin"() {
     return setup({
       plugins: [
-        [PostCSS(changeDisplayPlugin), CSSPlugin({})]
+        [PostCSS([changeDisplayPlugin]), CSSPlugin({})]
       ]
     })
       .then((result) => {

--- a/src/tests/plugins/PostcssPlugin.test.ts
+++ b/src/tests/plugins/PostcssPlugin.test.ts
@@ -77,7 +77,35 @@ export class PostcssPluginTest {
   "Should execute several plugins"() {
     return setup({
       plugins: [
+        [PostCSS([changeDisplayPlugin, idToClassPlugin]), CSSPlugin({})]
+      ]
+    })
+      .then((result) => {
+        const out = result.projectContents.toString();
+        should(out).findString(`display: block`);
+        should(out).notFindString(`#moon`);
+        should(out).findString(`.moon`);
+      });
+  }
+
+  "Should execute several plugins (legacy option)"() {
+    return setup({
+      plugins: [
         [PostCSS([changeDisplayPlugin], {plugins: [idToClassPlugin]}), CSSPlugin({})]
+      ]
+    })
+      .then((result) => {
+        const out = result.projectContents.toString();
+        should(out).findString(`display: block`);
+        should(out).notFindString(`#moon`);
+        should(out).findString(`.moon`);
+      });
+  }
+
+  "Should execute several plugins (legacy option 2)"() {
+    return setup({
+      plugins: [
+        [PostCSS({plugins: [changeDisplayPlugin, idToClassPlugin]}), CSSPlugin({})]
       ]
     })
       .then((result) => {

--- a/src/tests/plugins/PostcssPlugin.test.ts
+++ b/src/tests/plugins/PostcssPlugin.test.ts
@@ -37,52 +37,47 @@ const style = `
 
 export class PostcssPluginTest {
     "Should be unmodified with no plugins"() {
-        return createEnv({
-            project: {
-                files: {
-                    "index.ts": `exports.hello = { bar : require("./style.css") }`,
-                    "style.css": style
-                },
-                plugins: [[PostCSS(), CSSPlugin({})]],
-                instructions: "index.ts",
-            },
-        }).then((result) => {
+        return setup([
+          [PostCSS(), CSSPlugin({})]
+        ])
+          .then((result) => {
             const out = result.projectContents.toString();
             should(out).findString(`display: grid;`);
         });
     }
 
     "Single plugin"() {
-        return createEnv({
-            project: {
-                files: {
-                    "index.ts": `exports.hello = { bar : require("./style.css") }`,
-                    "style.css": style
-                },
-                plugins: [[PostCSS([pluginA]), CSSPlugin({})]],
-                instructions: "index.ts",
-            },
-        }).then((result) => {
+        return setup([
+          [PostCSS(pluginA), CSSPlugin({})]
+        ])
+          .then((result) => {
             const out = result.projectContents.toString();
             should(out).findString(`display: block`);
         });
     }
 
     "Several plugins"() {
-        return createEnv({
-            project: {
-                files: {
-                    "index.ts": `exports.hello = { bar : require("./style.css") }`,
-                    "style.css": style
-                },
-                plugins: [[PostCSS([pluginA, pluginB]), CSSPlugin({})]],
-                instructions: "index.ts",
-            },
-        }).then((result) => {
+        return setup([
+          [PostCSS([pluginA, pluginB]), CSSPlugin({})]
+        ])
+          .then((result) => {
             const out = result.projectContents.toString();
             should(out).findString(`display: block`);
             should(out).notFindString(`#moon`);
             should(out).findString(`.moon`);
         });
     }
+}
+
+function setup(plugins) {
+  return createEnv({
+    project: {
+      files: {
+        "index.ts": `exports.style = require("./style.css")`,
+        "style.css": style
+      },
+      plugins: plugins,
+      instructions: "index.ts",
+    },
+  })
 }

--- a/src/tests/plugins/PostcssPlugin.test.ts
+++ b/src/tests/plugins/PostcssPlugin.test.ts
@@ -62,7 +62,7 @@ export class PostcssPluginTest {
       });
   }
 
-  "Single plugin"() {
+  "Should execute single plugin"() {
     return setup({
       plugins: [
         [PostCSS(changeDisplayPlugin), CSSPlugin({})]
@@ -74,7 +74,7 @@ export class PostcssPluginTest {
       });
   }
 
-  "Several plugins"() {
+  "Should execute several plugins"() {
     return setup({
       plugins: [
         [PostCSS([changeDisplayPlugin, idToClassPlugin]), CSSPlugin({})]


### PR DESCRIPTION
Should fix #788.

Sorry if I highjacked @ben33's pull request but we really need this to migrate to the new fuse-box version.
Please @ben33, tell me if it also solves your problem! Your review is very welcome.

In this PR, I migrated the old postcss tests.
I also added a new one, highlighting the issue mentioned in #788.

Some plugins, like the [url-plugin](https://github.com/postcss/postcss-url), need the postcss options to be passed through to work correctly.

---

@nchanged, I also think fusebox should follow some of [the guidelines](https://github.com/postcss/postcss/blob/master/docs/guidelines/runner.md) provided by the postcss team.

Especially for the warning and the error processing.
I was thinking about adding a `.catch()` function to handle this in the plugin code, a bit like the less plugin does.

Is it a good idea? 