### PR TITLE
Fix: Child Dependencies Not Resolved/Processed When Detected In Plugin.transform()

### DIFF
--- a/src/core/ModuleCollection.ts
+++ b/src/core/ModuleCollection.ts
@@ -364,7 +364,7 @@ export class ModuleCollection {
      *
      * @memberOf ModuleCollection
      */
-    public resolve(file: File, shouldIgnoreDeps?: boolean) {
+    public async resolve(file: File, shouldIgnoreDeps?: boolean) {
         file.shouldIgnoreDeps = shouldIgnoreDeps;
         file.collection = this;
         if (this.bundle) {
@@ -404,7 +404,7 @@ export class ModuleCollection {
 
             // Consuming file
             // Here we read it and return a list of require statements
-            file.consume();
+            await file.consume();
 
             // if a file belong to a split bundle, pipe it there
             if (this.isDefault && this.context.shouldSplit(file)) {


### PR DESCRIPTION
#### Issue
If I have a plugin that transpiles code/styles asynchronously then the updated `file.analysis.dependencies` are never processed by FuseBox.  

#### Cause
This is because the async `tryPlugin()` methods values was not used (i.e. didnt wait for promise resolution). So the processing had completed before FuseBox knew about the new dependencies.

#### Fix
Make FuseBox consume and wait for those promises to resolve before moving on, ensuring the new dependencies are resolved.

#### Additional
This could have a small impact on performance, but the project I am working on hasn't experience much change in execution time. Some minor TSLint errors have also been fixed.