### PR TITLE
globalRequire in case of npm (server)

### DIFF
--- a/modules/fuse-box-responsive-api/index.js
+++ b/modules/fuse-box-responsive-api/index.js
@@ -50,9 +50,11 @@
 
 
     /* @if server */
+    /* @if globalRequire */
     if (typeof global === "object") {
         global.require = require;
     }
+    /* @end */
     /* @if !isContained */
     var $fsx = global.$fsx = {}
     if ($fsx.r) {


### PR DESCRIPTION
Finalising the `globalRequire` idea :
The flag really solves a lot of issues. The only thing here is that it was not taken into consideration in the `npm` or `server` target case.

With this PR, it affects all the cases of `global.require` references.