### PR TITLE
Consolidate Plugin

### DIFF
--- a/docs/_meta.json
+++ b/docs/_meta.json
@@ -35,6 +35,7 @@
         "files": [
             "plugins/html/HTMLPlugin.md",
             "plugins/html/MarkdownPlugin.md",
+            "plugins/html/ConsolidatePlugin.md",
             "plugins/html/WebIndexPlugin.md"
         ]
     }, {

--- a/docs/plugins/html/ConsolidatePlugin.md
+++ b/docs/plugins/html/ConsolidatePlugin.md
@@ -1,0 +1,103 @@
+# Consolidate Plugin
+
+## Description
+Allows importing of templates as a string in your code. Please check the [consolidate documentation](https://github.com/tj/consolidate.js) for available template engines.
+
+## Install
+This plugin depends on the following node modules:
+
+- `consolidate`
+- Template engine(s) of your choice, e.g. `pug`, `handlebars` etc.
+
+```bash
+# Using yarn:
+yarn add consolidate <template_engine(s)> --dev
+
+# Using npm:
+npm install consolidate <template_engine(s)> --save-dev
+```
+
+## Usage
+### Setup
+Import from FuseBox
+
+```js
+const {ConsolidatePlugin} = require("fuse-box");
+```
+
+Inject into a chain
+
+```js
+fuse.plugin(
+     ConsolidatePlugin({
+       engine: 'pug'
+     })
+)
+```
+
+Or add it to the main config plugins list to make it available across bundles
+
+```js
+FuseBox.init({
+    plugins : [
+         ConsolidatePlugin({
+           engine: 'pug'
+         })
+    ]
+});
+```
+
+## Configuration
+### engine
+The `engine` option is required to tell the `ConsolidatePlugin` what template engine you want to use. For a list of available engines please refer to the [consolidate documentation](https://github.com/tj/consolidate.js)
+
+### extension
+If you want to use a different file extension for the `ConsolidatePlugin` to process then set the `extension` option. By default the `ConsolidatePlugin` will use the `engine` option you provided. For example:
+
+```js
+ConsolidatePlugin({ engine: 'pug' }) // will process all files with the extension `.pug` using the `pug` template engine
+```
+
+```js
+ConsolidatePlugin({ engine: 'pug', extension: '.custom-extension' }) // will process all files with the extension `.custom-extension` using the `pug` template engine
+```
+
+You can mix and match as you please.
+
+### useDefault
+`useDefault` is enable by default. So the transpiled output would look like:
+
+```js
+module.exports.default = "<!DOCTYPE html><title>eh</title>";
+```
+
+You can override it and drop back to `module.exports` by switching to `useDefault : false`
+
+```js
+ConsolidatePlugin({ useDefault : false})
+```
+
+Which will result in:
+
+```js
+module.exports = "<!DOCTYPE html><title>eh</title>";
+```
+
+### Require file in your code
+With `useDefault : false`
+
+```js
+import * as tpl from "./views/file.pug"
+```
+
+With `useDefault : true`
+
+```js
+import  tpl from "./views/file.pug"
+```
+
+## Test
+To run tests
+```
+node test --file=ConsolidatePlugin.test.ts
+```

--- a/docs/plugins/transpilers/VueComponentPlugin.md
+++ b/docs/plugins/transpilers/VueComponentPlugin.md
@@ -58,15 +58,22 @@ When `VueComponentPlugin` detects a `lang` attribute on a block it will attempt 
 - `<script lang="js">` - [BabelPlugin](/plugins/babelplugin) (will read configuration from `.babelrc` file)
 - `<style lang="less">` - [LESSPlugin](/plugins/less-plugin)
 - `<style lang="scss">` - [SASSPlugin](/plugins/sass-plugin)
+- `<template lang="pug">` - [ConsolidatePlugin](/plugins/consolidate-plugin)
+- `<template lang="hogan">` - [ConsolidatePlugin](/plugins/consolidate-plugin)
+
+In addition, the `VueComponentPlugin` will try to infer the `lang` type if it is not explicitly set but the `src` contains an extension:
+
+```html
+<template src="my-template.pug"> <!-- VueComponentPlugin will infer lang as "pug" -->
+```
 
 note: If using lang="js" and configuration item useTypescriptCompiler: true then FuseBox will use the internal Typescript compiler and NOT BabelPlugin
-
 
 ### Using Custom Plugin Chains
 If the above functionality doesn't fit your needs, you can override the pre-processing by optionally setting the `script`, `style` or `template` options. This follows the standard FuseBox way of defining plugin chains:
 
 ```js
-const { FuseBox, VueComponentPlugin, BabelPlugin, SassPlugin, CSSResourcePlugin, PostCSSPlugin, CSSPlugin } = require('fuse-box')
+const { FuseBox, VueComponentPlugin, BabelPlugin, ConsolidatePlugin, SassPlugin, CSSResourcePlugin, PostCSSPlugin, CSSPlugin } = require('fuse-box')
 
 const fsbx = FuseBox.init({
     homeDir: './src',
@@ -74,7 +81,7 @@ const fsbx = FuseBox.init({
     plugins: [
       VueComponentPlugin({
           script: BabelPlugin({ ... }),
-          template: HTMLPlugin({ ... })
+          template: ConsolidatePlugin({ ... })
           style: [
               SassPlugin({ ... }),
               CSSResourcePlugin({ ... }),

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -326,6 +326,8 @@ gulp.task("installDevDeps", function(done) {
         "vue-hot-reload-api",
         "rollup",
         "buble",
+        "consolidate",
+        "pug"
     ];
 
     const ext = /^win/.test(os.platform()) ? ".cmd" : ""

--- a/src/core/File.ts
+++ b/src/core/File.ts
@@ -85,7 +85,6 @@ export class File {
     public isLoaded = false;
 
     public ignoreCache = false;
-
     /**
      *
      *

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,4 +45,5 @@ export { CSSModules } from "./plugins/stylesheet/CSSModules";
 export { CopyPlugin } from "./plugins/CopyPlugin";
 export { WebIndexPlugin } from "./plugins/WebIndexPlugin";
 export { PlainJSPlugin } from "./plugins/PlainJSPlugin";
+export { ConsolidatePlugin } from "./plugins/ConsolidatePlugin";
 export { File } from "./core/File";

--- a/src/plugins/ConsolidatePlugin.ts
+++ b/src/plugins/ConsolidatePlugin.ts
@@ -1,0 +1,80 @@
+import { Plugin, WorkFlowContext } from '../core/WorkflowContext';
+import { File } from '../core/File';
+
+export interface IConsolidatePluginOptions {
+  engine: string;
+  extension?: string;
+  useDefault?: boolean;
+}
+
+export class ConsolidatePluginClass implements Plugin {
+  public test: RegExp;
+  private extension: string;
+  private engine: string;
+  private useDefault: boolean;
+
+  constructor(options: IConsolidatePluginOptions) {
+    if (!options.engine) {
+      const message = 'ConsolidatePlugin - requires an engine to be provided in the options'
+      throw new Error(message);
+    }
+
+    this.engine = options.engine;
+    this.extension = options.extension || `.${options.engine}`;
+    this.useDefault = (options.useDefault !== undefined) ? options.useDefault : true;
+    this.test = new RegExp(this.extension);
+  }
+
+  public init(context: WorkFlowContext) {
+      context.allowExtension(this.extension);
+  }
+
+  public async transform(file: File) {
+    const consolidate = require('consolidate');
+
+    if (file.context.useCache) {
+      const cached = file.context.cache.getStaticCache(file);
+
+      if (cached) {
+          file.isLoaded = true;
+          file.contents = cached.contents;
+          return Promise.resolve();
+      }
+    }
+
+    file.loadContents();
+
+    if (!consolidate[this.engine]) {
+      const message = `ConsolidatePlugin - consolidate did not recognise the engine "${this.engine}"`;
+      file.context.log.echoError(message);
+      return Promise.reject(new Error(message));
+    }
+
+    try {
+      file.contents = await consolidate[this.engine].render(file.contents, {
+        cache: false,
+        filename: 'base',
+        basedir: file.context.homeDir,
+        includeDir: file.context.homeDir
+      });
+
+      if (this.useDefault) {
+          file.contents = `module.exports.default = ${JSON.stringify(file.contents)}`;
+      } else {
+          file.contents = `module.exports = ${JSON.stringify(file.contents)}`;
+      }
+    } catch (e) {
+      file.context.log.echoError(`ConsolidatePlugin - could not process template, ${e}`);
+      return Promise.reject(e);
+    }
+
+    if (file.context.useCache) {
+      file.context.emitJavascriptHotReload(file);
+      file.context.cache.writeStaticCache(file, file.sourceMap);
+    }
+  }
+}
+
+export const ConsolidatePlugin = (options: IConsolidatePluginOptions) => {
+  return new ConsolidatePluginClass(options);
+}

--- a/src/plugins/vue/VuePlugin.ts
+++ b/src/plugins/vue/VuePlugin.ts
@@ -53,10 +53,19 @@ export class VueComponentClass implements Plugin {
     let src = `./${block.type}.${extension}`;
 
     if (block.src) {
-      extension = path.extname(block.src);
-      src = extension ? block.src : `${block.src}.${block.lang || this.getDefaultExtension(block)}`;
+        let srcExtension = path.extname(block.src) || '';
+
+        if (srcExtension.indexOf('.') > -1) {
+          srcExtension = srcExtension.substr(1);
+          extension = srcExtension;
+          src = block.src;
+        } else {
+          extension = (block.lang) ? `${block.lang}` : '' || this.getDefaultExtension(block);
+          src = `${block.src}.${extension}`;
+        }
     }
 
+    file.context.allowExtension(`.${extension}`);
     const fileInfo = file.collection.pm.resolve(src, file.info.absDir);
 
     switch (block.type) {
@@ -236,7 +245,7 @@ export class VueComponentClass implements Plugin {
     if (file.context.useCache) {
       concat.add(null, `
         var process = FuseBox.import('process');
-        
+
         if (process.env.NODE_ENV !== "production") {
           var api = require('vue-hot-reload-api');
 

--- a/src/tests/plugins/ConsolidatePlugin.test.ts
+++ b/src/tests/plugins/ConsolidatePlugin.test.ts
@@ -1,0 +1,58 @@
+import { ConsolidatePlugin } from "../../index";
+import { createEnv } from "../stubs/TestEnvironment";
+import { should } from "fuse-test-runner";
+
+export class ConsolidatePluginTest {
+    "Should compile a template using consolidate"() {
+        return createEnv({
+            project: {
+                files: {
+                    "template.pug": "p Compiled with Pug"
+                },
+                plugins: [ConsolidatePlugin({
+                  engine: 'pug'
+                })],
+                instructions: "template.pug"
+            },
+        }).then((result) => {
+          const template = result.project.FuseBox.import('./template.pug');
+          should(template.default).equal("<p>Compiled with Pug</p>");
+        });
+    }
+
+    "Should allow user to override extension"() {
+        return createEnv({
+            project: {
+                files: {
+                    "template.foobar": "p Compiled with Pug"
+                },
+                plugins: [ConsolidatePlugin({
+                  engine: 'pug',
+                  extension: '.foobar'
+                })],
+                instructions: "template.foobar"
+            },
+        }).then((result) => {
+          const template = result.project.FuseBox.import('./template.foobar');
+          should(template.default).equal("<p>Compiled with Pug</p>");
+        });
+    }
+
+    "Should allow user to override default exports"() {
+        return createEnv({
+            project: {
+                files: {
+                    "template.pug": "p Compiled with Pug"
+                },
+                plugins: [ConsolidatePlugin({
+                  engine: 'pug',
+                  useDefault: false
+                })],
+                instructions: "template.pug"
+            },
+        }).then((result) => {
+          const template = result.project.FuseBox.import('./template.pug');
+          should(template).equal("<p>Compiled with Pug</p>");
+        });
+    }
+}


### PR DESCRIPTION
This adds the [consolidate](https://www.npmjs.com/package/consolidate) library as a plugin - which saves us creating *X* number of template renderers! Additionally, we utilise this new plugin in `VueComponentPlugin` so users can use any template language they see fit using either the `lang` attribute or inferring the `lang` from the `src` if specified.