### PR TITLE
VueComponentPlugin - Dependency Fixes

### DIFF
--- a/src/plugins/vue/VueScriptFile.ts
+++ b/src/plugins/vue/VueScriptFile.ts
@@ -1,8 +1,8 @@
 import { VueBlockFile } from './VueBlockFile';
-const typescriptTranspiler = require("typescript");
 
 export class VueScriptFile extends VueBlockFile {
   public async process() {
+    const typescriptTranspiler = require("typescript");
     this.loadContents();
 
     if (this.pluginChain.length > 1) {

--- a/src/plugins/vue/VueStyleFile.ts
+++ b/src/plugins/vue/VueStyleFile.ts
@@ -1,7 +1,6 @@
 import { VueBlockFile } from './VueBlockFile'
 import { CSSPluginClass } from "../stylesheet/CSSplugin";
 import { TrimPlugin, AddScopeIdPlugin } from './PostCSSPlugins';
-const postcss = require('postcss');
 
 export class VueStyleFile extends VueBlockFile {
   public fixSourceMapName () {
@@ -19,6 +18,8 @@ export class VueStyleFile extends VueBlockFile {
   }
 
   private async applyScopeIdToStyles(scopeId: string) {
+    const postcss = require('postcss');
+
     const plugins = [
       TrimPlugin(),
       AddScopeIdPlugin({ id: scopeId })


### PR DESCRIPTION
Moved TypeScript and PostCSS imports out of module scope as it was causing issues for people not using these modules in their projects.