### PR TITLE
Allow class components

### DIFF
--- a/src/plugins/vue/VuePlugin.ts
+++ b/src/plugins/vue/VuePlugin.ts
@@ -190,7 +190,7 @@ export class VueComponentClass implements Plugin {
         await scriptFile.process();
         this.addToCacheObject(cache.script, scriptFile.info.fuseBoxPath, scriptFile.contents, scriptFile.sourceMap);
         concat.add(null, scriptFile.contents, scriptFile.sourceMap);
-        concat.add(null, "Object.assign(exports.default, _options)");
+        concat.add(null, "Object.assign(exports.default.options||exports.default, _options)");
       }
     } else {
       if (!cacheValid) {


### PR DESCRIPTION
When using [vue-class-component](https://github.com/vuejs/vue-class-component), the exported value is not the options but a `VueComponent` object that specifies options.

When this happens, the render option shouldn't be added to the default exported object but to its options