### PR TITLE
Cache Buster - Handle "Non-Standard" Runtime Environments

### DIFF
--- a/src/CacheBreaker.ts
+++ b/src/CacheBreaker.ts
@@ -4,19 +4,24 @@ import { fastHash, removeFolder, ensureDir } from "./Utils";
 import * as fs from "fs";
 import { Log } from "./Log";
 /**
- * 
+ *
  * The only purpose of this ugly function is to break cache when user changes the config..
- * 
+ *
  * @export
  */
 export function breakCache() {
-
     const mainFile = require.main.filename;
     const fileKey = fastHash(mainFile);
     const currentStat = fs.statSync(mainFile);
     const fileModificationTime = currentStat.mtime.getTime()
     const bustingCacheFolder = path.join(Config.NODE_MODULES_DIR, "fuse-box/.cache-busting");
-    ensureDir(bustingCacheFolder)
+
+    try {
+      ensureDir(bustingCacheFolder);
+    } catch (error) {
+      return;
+    }
+
     const infoFile = path.join(bustingCacheFolder, fileKey as string);
     if (fs.existsSync(infoFile)) {
         const lastModifiedStored = fs.readFileSync(infoFile).toString();


### PR DESCRIPTION
I'm trying to run FuseBox in places like AWS Lambda, Firebase Cloud Functions etc. but they all fail because they have read only file systems and its this check that is causing it.

You might be wondering why I am doing this? Its for a cool new tool for the FuseBox community but its nowhere near ready to share...