### PR TITLE
fix: Ensures typescript plugin is used when vue lang="ts"

### DIFF
--- a/src/plugins/vue/VueBlockFile.ts
+++ b/src/plugins/vue/VueBlockFile.ts
@@ -49,7 +49,7 @@ export abstract class VueBlockFile extends File {
     }
 
     if (pluginChain.length === 0 && block.lang) {
-      if (defaultExtension === 'js' && this.context.useTypescriptCompiler) {
+      if ((defaultExtension === 'js' && this.context.useTypescriptCompiler) || block.lang === 'ts') {
         pluginChain.push(PLUGIN_LANG_MAP.get('ts'));
       } else {
         const PluginToUse = PLUGIN_LANG_MAP.get(block.lang.toLowerCase());

--- a/src/tests/plugins/VueComponentPlugin.test.ts
+++ b/src/tests/plugins/VueComponentPlugin.test.ts
@@ -80,6 +80,31 @@ export class VuePluginTest {
         });
     }
 
+    "Should compile using Typescript if lang='ts'"() {
+        return createEnv({
+            project: {
+                files: {
+                    "app.vue": `${getTemplateBlock('lang="html"', 'LangAttributes')}${getScriptBlock('lang="ts"')}${getStyleBlock('lang="scss"')}`
+                },
+                plugins: [VueComponentPlugin()],
+                instructions: "app.vue",
+            },
+        }).then((result) => {
+          const Vue = require('vue')
+          const renderer = require('vue-server-renderer').createRenderer()
+          const component = result.project.FuseBox.import('./app.vue').default;
+          const app = new Vue(component)
+
+          should(component.render).notEqual(undefined);
+          should(component.staticRenderFns).notEqual(undefined);
+
+          renderer.renderToString(app, (err, html) => {
+            should(html).findString('<p class="msg">Welcome to Your Vue.js App - LangAttributes</p>');
+            should(html).findString('<input type="text" value="Welcome to Your Vue.js App">');
+          })
+        });
+    }
+
     "Should use plugin chain from user options"() {
         return createEnv({
             project: {


### PR DESCRIPTION
When using `<script lang="ts">` and the files default extension is `.js` the `VueComponentPlugin` would complain it could not find a matching plugin (when it should pick up Typescript). This PR fixes that.