### PR TITLE
chore: remove unnecessary acorn plugins

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -2072,7 +2072,6 @@ ${file.headerContent ? file.headerContent.join("\n") : ""}`);
             const HeaderImport_1 = require("./HeaderImport");
             const acorn = require("acorn");
             const escodegen = require("escodegen");
-            require("acorn-es7")(acorn);
             require("acorn-jsx/inject")(acorn);
             class FileAnalysis {
                 constructor(file) {
@@ -2097,8 +2096,8 @@ ${file.headerContent ? file.headerContent.join("\n") : ""}`);
                         this.ast = acorn.parse(this.file.contents, Object.assign({}, options || {}, {
                             sourceType: "module",
                             tolerant: true,
-                            ecmaVersion: 8,
-                            plugins: { es7: true, jsx: true },
+                            ecmaVersion: '2018',
+                            plugins: { jsx: true },
                             jsx: { allowNamespacedObjects: true }
                         }));
                     } catch (err) {

--- a/package.json
+++ b/package.json
@@ -79,9 +79,7 @@
     "wires-reactive": "^1.1.1"
   },
   "dependencies": {
-    "acorn": "^5.0.3",
-    "acorn-es7": "^0.1.0",
-    "acorn-es7-plugin": "^1.1.7",
+    "acorn": "^5.1.2",
     "acorn-jsx": "^4.0.1",
     "ansi": "^0.3.1",
     "app-root-path": "^2.0.1",

--- a/src/analysis/FileAnalysis.ts
+++ b/src/analysis/FileAnalysis.ts
@@ -9,9 +9,7 @@ import { OwnBundle } from "./plugins/OwnBundle";
 import { ImportDeclaration } from "./plugins/ImportDeclaration";
 import { DynamicImportStatement } from "./plugins/DynamicImportStatement";
 
-require("acorn-es7")(acorn);
 require("acorn-jsx/inject")(acorn);
-require('acorn-es7-plugin')(acorn);
 
 export interface TraversalPlugin {
     onNode(file: File, node: any, parent: any): void
@@ -25,9 +23,9 @@ export function acornParse(contents, options?: any) {
         ...options || {}, ...{
             sourceType: "module",
             tolerant: true,
-            ecmaVersion: 8,
+            ecmaVersion: '2018',
             plugins: {
-                es7: true, jsx: true, asyncawait: true
+                jsx: true
             },
             jsx: { allowNamespacedObjects: true },
         },


### PR DESCRIPTION
Updates acorn and removes invalidated plugins.

I'm not able to update `bin.js` which will cause the tests to fail. (manually updating it passes the tests)
