### PR TITLE
feat: Allow typescript decorators for vue components

### DIFF
--- a/docs/plugins/transpilers/VueComponentPlugin.md
+++ b/docs/plugins/transpilers/VueComponentPlugin.md
@@ -96,8 +96,18 @@ const fsbx = FuseBox.init({
     ]
 })
 ```
-
 note: Overriding a plugin chain for a .vue block will make the VueComponentPlugin ignore any lang attributes.
+
+### Using Typescript Decorators
+If you are writing Vue components with Typescript and are making use of [vue-class-component](https://github.com/vuejs/vue-class-component) then you will need to install [tslib](https://github.com/Microsoft/tslib) and update your `tsconfig.json`:
+
+```js
+{
+  "compilerOptions": {
+    "importHelpers": true
+  }
+}
+```
 
 ### External Files
 The `VueComponentPlugin` fully understands the `src` attribute and will handle external files just the same as inline content.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -246,7 +246,7 @@ gulp.task("make-test-runner", (done) => {
 
 
 gulp.task("copy-to-dev", () => {
-    const devFolder = "random/fuse-box-quantum-test";
+    const devFolder = "vue-seed";
 
     gulp.src("modules/fuse-box-css/**/**.**")
         .pipe(gulp.dest(`../${devFolder}/node_modules/fuse-box/modules/fuse-box-css`));
@@ -324,6 +324,7 @@ gulp.task("installDevDeps", function(done) {
         "vue",
         "vue-server-renderer",
         "vue-hot-reload-api",
+        "vue-class-component",
         "rollup",
         "buble",
         "consolidate",

--- a/src/tests/plugins/VueComponentPlugin.test.ts
+++ b/src/tests/plugins/VueComponentPlugin.test.ts
@@ -1,4 +1,4 @@
-import { VueComponentPlugin, BabelPlugin, HTMLPlugin, SassPlugin, TypeScriptHelpers } from "../../index";
+import { VueComponentPlugin, BabelPlugin, HTMLPlugin, SassPlugin } from "../../index";
 import { createEnv } from "../stubs/TestEnvironment";
 import { should } from "fuse-test-runner";
 

--- a/src/tests/plugins/VueComponentPlugin.test.ts
+++ b/src/tests/plugins/VueComponentPlugin.test.ts
@@ -173,7 +173,7 @@ export class VuePluginTest {
         });
     }
 
-    "Should be compatible with vue-class-component decorators when used with TypeScriptHelpers"() {
+    "Should be compatible with vue-class-component decorators"() {
         return createEnv({
             project: {
                 polyfillNonStandardDefaultUsage: true,
@@ -181,7 +181,6 @@ export class VuePluginTest {
                     "app.vue": `${getTemplateBlock('', 'Decorators')}${getDecoratorScriptBlock()}${getStyleBlock('')}`
                 },
                 plugins: [
-                  TypeScriptHelpers(),
                   VueComponentPlugin()
                 ],
                 instructions: "app.vue",

--- a/src/tests/plugins/VueComponentPlugin.test.ts
+++ b/src/tests/plugins/VueComponentPlugin.test.ts
@@ -1,4 +1,4 @@
-import { VueComponentPlugin, BabelPlugin, HTMLPlugin, SassPlugin } from "../../index";
+import { VueComponentPlugin, BabelPlugin, HTMLPlugin, SassPlugin, TypeScriptHelpers } from "../../index";
 import { createEnv } from "../stubs/TestEnvironment";
 import { should } from "fuse-test-runner";
 
@@ -20,6 +20,16 @@ const getScriptBlock = (langAttribute: string = '') => `
             }
         }
     }
+</script>`;
+
+const getDecoratorScriptBlock = () => `
+<script lang="ts">
+  import Vue from 'vue';
+  import Component from 'vue-class-component';
+
+  @Component({})
+  export default class VueClassComponent extends Vue {
+  }
 </script>`;
 
 const getStyleBlock = (langAttribute: string = '', isScoped: boolean = false) => `
@@ -59,7 +69,7 @@ export class VuePluginTest {
         return createEnv({
             project: {
                 files: {
-                    "app.vue": `${getTemplateBlock('lang="html"', 'LangAttributes')}${getScriptBlock('lang="coffee"')}${getStyleBlock('lang="scss"')}`
+                    "app.vue": `${getTemplateBlock('lang="html"', 'LangAttributes')}${getScriptBlock('lang="ts"')}${getStyleBlock('lang="scss"')}`
                 },
                 plugins: [VueComponentPlugin()],
                 instructions: "app.vue",
@@ -159,6 +169,34 @@ export class VuePluginTest {
           renderer.renderToString(app, (err, html) => {
             should(html).findString(component._scopeId);
             should(html).findString('ScopedStyles');
+          })
+        });
+    }
+
+    "Should be compatible with vue-class-component decorators when used with TypeScriptHelpers"() {
+        return createEnv({
+            project: {
+                polyfillNonStandardDefaultUsage: true,
+                files: {
+                    "app.vue": `${getTemplateBlock('', 'Decorators')}${getDecoratorScriptBlock()}${getStyleBlock('')}`
+                },
+                plugins: [
+                  TypeScriptHelpers(),
+                  VueComponentPlugin()
+                ],
+                instructions: "app.vue",
+            },
+        }).then((result) => {
+          const Vue = require('vue')
+          const renderer = require('vue-server-renderer').createRenderer()
+          const component = result.project.FuseBox.import('./app.vue').default.options;
+          const app = new Vue(component);
+
+          should(component.render).notEqual(undefined);
+          should(component.staticRenderFns).notEqual(undefined);
+
+          renderer.renderToString(app, (err, html) => {
+            should(html).findString('Decorators');
           })
         });
     }


### PR DESCRIPTION
This allows vue components to work with decorators such as `vue-class-component`:

```js
import Vue from 'vue';
import Component from 'vue-class-component';

@Component({})
export default class VueClassComponent extends Vue {
   message: string = 'Hello!'
   onClick (): void {
      window.alert(this.message)
   }
}
```

All the user needs to do is install `tslib` and update their `tsconfig.json` to `importHelpers`:

```json
{
  "compilerOptions": {
    "importHelpers": true
  }
}
```

This also fixes a couple of other bugs:

- Hot reloading did not work for non-scoped styled components
- `DEFAULT_OPTIONS` were being extended each time a `VueComponentPlugin` instance was created.