### PR TITLE
fix: Ensure correct path names for last changed file in bundle for VueComponentPlugin

### DIFF
--- a/src/plugins/vue/VuePlugin.ts
+++ b/src/plugins/vue/VuePlugin.ts
@@ -138,9 +138,9 @@ export class VueComponentClass implements Plugin {
       cacheValid = true;
 
       if (bundle && bundle.lastChangedFile) {
-        const lasChangedFusePath = ensurePublicExtension(bundle.lastChangedFile);
+        const lastChangedFusePath = ensurePublicExtension(bundle.lastChangedFile);
 
-        if (data.template[lasChangedFusePath] || data.script[lasChangedFusePath] || data.styles[lasChangedFusePath]) {
+        if (data.template[lastChangedFusePath] || data.script[lastChangedFusePath] || data.styles[lastChangedFusePath]) {
           cacheValid = false;
         }
       }

--- a/src/plugins/vue/VuePlugin.ts
+++ b/src/plugins/vue/VuePlugin.ts
@@ -139,7 +139,6 @@ export class VueComponentClass implements Plugin {
 
       if (bundle && bundle.lastChangedFile) {
         const lasChangedFusePath = ensurePublicExtension(bundle.lastChangedFile);
-        console.log(lasChangedFusePath)
 
         if (data.template[lasChangedFusePath] || data.script[lasChangedFusePath] || data.styles[lasChangedFusePath]) {
           cacheValid = false;

--- a/src/plugins/vue/VuePlugin.ts
+++ b/src/plugins/vue/VuePlugin.ts
@@ -1,7 +1,7 @@
 import { File } from "../../core/File";
 import { WorkFlowContext, Plugin } from "../../core/WorkflowContext";
 import { CSSPluginClass } from "../stylesheet/CSSplugin";
-import { Concat, hashString } from "../../Utils";
+import { Concat, hashString, ensurePublicExtension } from "../../Utils";
 import { VueBlockFile } from './VueBlockFile';
 import { VueTemplateFile } from './VueTemplateFile';
 import { VueStyleFile } from './VueStyleFile';
@@ -138,7 +138,10 @@ export class VueComponentClass implements Plugin {
       cacheValid = true;
 
       if (bundle && bundle.lastChangedFile) {
-        if (data.template[bundle.lastChangedFile] || data.script[bundle.lastChangedFile] || data.styles[bundle.lastChangedFile]) {
+        const lasChangedFusePath = ensurePublicExtension(bundle.lastChangedFile);
+        console.log(lasChangedFusePath)
+
+        if (data.template[lasChangedFusePath] || data.script[lasChangedFusePath] || data.styles[lasChangedFusePath]) {
           cacheValid = false;
         }
       }


### PR DESCRIPTION
The issue was being caused by a mismatch of the `fuseBoxPath` stored in cache and the `lastChangedFile` when using typescript as the .ts extension gets normalised to .js

This will fix #879