### PR TITLE
feat: Uglify-es support for quantum

### DIFF
--- a/docs/quantum.md
+++ b/docs/quantum.md
@@ -44,7 +44,7 @@ FuseBox.init({
 });
 ```
 
-UglifyJs is used optionally and activated with `{uglify : true}` option, don't forget it install it
+If you're planning to minify produced bundles make sure that you have the LATEST `uglify-js` (or `uglify-es` if your target is ES6) installed. 
 
 Via NPM:
 ```bash
@@ -55,11 +55,9 @@ Via yarn:
 ```bash
 yarn install uglify-js
 ```
-note: Make sure you have the LATEST uglify-js
 
 Make sure you are using [Web Index Plugin](/plugins/web-index-plugin#webindexplugin) as Quantum may produce more bundles than configured in the first place.
 
-note: Remove UglifyJSPlugin from the plugin list, it will conflict with Quantum
 
 ## How it works?
 
@@ -489,6 +487,40 @@ QuantumPlugin({
     warnings : false
 })
 ```
+
+### uglify
+Default value: `false`
+
+A boolean flag or an object literal with uglify's options.
+
+Quantum supports both [uglify-js](https://github.com/mishoo/UglifyJS2) 
+and [uglify-es](https://github.com/mishoo/UglifyJS2/tree/harmony). 
+Which one to use is determined by `es6` option. 
+
+Enable `uglify-js`:
+```js
+QuantumPlugin({
+    uglify : true
+})
+```
+
+Enable `uglify-js` and pass some options to it:
+```js
+QuantumPlugin({
+    uglify : { toplevel: false }
+})
+```
+
+Enable `uglify-es`:
+```js
+QuantumPlugin({
+    uglify : { es6: true }
+})
+```
+
+Alternatively, Quantum could pick up uglify's options from [UglifyJSPlugin](/plugins/misc/UglifyJSPlugin) or 
+[UglifyESPlugin](/plugins/misc/UglifyESPlugin), so if you already have one of them set up then minification 
+in Quantum should work right away. 
 
 ## Computed statement resolution
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -62,8 +62,8 @@ export function printCurrentVersion() {
 
 
 
-export function uglify(contents: string | Buffer, opts: any = {}) {
-    const UglifyJs = require("uglify-js");
+export function uglify(contents: string | Buffer, { es6 = false, ...opts }: any = {}) {
+    const UglifyJs = es6 ? require("uglify-es") : require("uglify-js");
     return UglifyJs.minify(contents.toString(), opts);
 }
 

--- a/src/quantum/plugin/QuantumPlugin.ts
+++ b/src/quantum/plugin/QuantumPlugin.ts
@@ -24,6 +24,11 @@ export class QuantumPluginClass implements Plugin {
                     // remove uglify js
                     delete plugins[index];
                 }
+                if (plugin.constructor.name === "UglifyESPluginClass") {
+                    this.coreOpts.uglify = { es6:true, ...plugin.options };
+                    // remove uglify es
+                    delete plugins[index];
+                }
 
                 if (plugin.constructor.name === "WebIndexPluginClass") {
                     this.coreOpts.webIndexPlugin = plugin as WebIndexPluginClass;


### PR DESCRIPTION
I asked at gitter for the best way to design an API for it, but got no reply.  So here is the simplest implementation possible, though it probably isn't very straightforward to use.

It picks up uglify's options from the `UglifyESPlugin` or could be triggered by quantum option `uglify: { es6: true }`