### PR TITLE
feat: WebIndexPlugin now accepts a template as a string literal

### DIFF
--- a/docs/plugins/html/WebIndexPlugin.md
+++ b/docs/plugins/html/WebIndexPlugin.md
@@ -29,6 +29,7 @@ fuse.plugin(
 | ` bundles ` | Provide a list of bundle names (if not set all registered bundles are through) |
 | ` path `   | The relative url bundles are served from. Default is `/`. Empty is set with `.`  |
 | ` template `   | Provide a path to your own template  |
+| ` templateString `   | Provide your own template as a string  |
 | ` target `   | The main filename. Default is `index.html`  |
 | ` resolve `   | `resolve ?: {(output : UserOutput) : string}` Allows to completely override the output  |
 

--- a/docs/plugins/html/WebIndexPlugin.md
+++ b/docs/plugins/html/WebIndexPlugin.md
@@ -33,6 +33,7 @@ fuse.plugin(
 | ` target `   | The main filename. Default is `index.html`  |
 | ` resolve `   | `resolve ?: {(output : UserOutput) : string}` Allows to completely override the output  |
 
+note: If you specify template and templateString then template will take precedent 
 
 ### Resolve example
 `resolve` option allows you to completely override the path

--- a/src/plugins/WebIndexPlugin.ts
+++ b/src/plugins/WebIndexPlugin.ts
@@ -15,6 +15,7 @@ export interface IndexPluginOptions {
     path?: string;
     target?: string;
     template?: string;
+    templateString?: string;
     async?: boolean;
     resolve ?: {(output : UserOutput) : string};
 }
@@ -50,7 +51,7 @@ export class WebIndexPluginClass implements Plugin {
             }
         });
 
-        let html = `<!DOCTYPE html>
+        let html = this.opts.templateString || `<!DOCTYPE html>
 <html>
 <head>
     <title>$title</title>


### PR DESCRIPTION
As requested by @pyros2097 in #885 . Its a simple enough change so I did it real quick. Allows you to do the following:

```js
plugins: [
   WebIndexPlugin({
      templateString: `Your stuff here`
   })
]
```

***NOTE:*** If you specify a `templateString` and `template` then `template` will take precedent 