### PR TITLE
feat: Allow extension overrides configuration

### DIFF
--- a/docs/bundle.md
+++ b/docs/bundle.md
@@ -248,6 +248,7 @@ Available methods:
 | ` tsConfig() `   | Sets `tsconfig.json` location for typescript  |
 | ` hmr() `   | Enables HMR. Read up [development](/page/development)  |
 | ` alias() `   | Sets up [aliases](/page/configuration#alias) |
+| ` extensionOverrides() `   | Sets up [extensionOverrides](/page/configuration#extension-overrides) |
 | ` split() `   | Defines [code splitting](/page/code-splitting) rules.  |
 | ` splitConfig() `   | Defines [code splitting](/page/code-splitting) configuration.  |
 | ` cache() `   | Toggles cache  |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -662,6 +662,26 @@ import faraway from "faraway";
 console.log(utils, faraway);
 ```
 
+## Extension Overrides
+
+You can optionally override how file extensions are resolved. This is useful if you want to create platform specific bundles:
+
+```js
+FuseBox.init({
+    overrideExtensions: ['.desktop.js', '.desktop.json'],
+})
+```
+
+Alternatively you can use the chainable API
+
+```js
+fuse.bundle("app")
+    .overrideExtensions('.desktop.js', '.desktop.json');
+```
+
+The above configuration would first look for JavaScript and JSON files with a `.desktop.js` or `.desktop.json` extension.
+If they cannot be found then the default `.js` and `.json` files will be loaded.
+
 ## Filter File
 You can filter files and tell FuseBox what you want to be excluded:
 

--- a/src/core/Bundle.ts
+++ b/src/core/Bundle.ts
@@ -12,7 +12,9 @@ import { Config } from "../Config";
 import { QuantumItem, QuantumSplitResolveConfiguration } from "../quantum/plugin/QuantumSplit";
 import { BundleAbstraction } from "../quantum/core/BundleAbstraction";
 import { PackageAbstraction } from "../quantum/core/PackageAbstraction";
-import { EventEmitter } from '../EventEmitter'
+import { EventEmitter } from '../EventEmitter';
+import { ExtensionOverrides } from "./ExtensionOverrides";
+
 export interface HMROptions {
     port?: number;
     socketURI? : string;
@@ -185,6 +187,16 @@ export class Bundle {
         this.context.doLog = log;
         this.context.log.printLog = log;
         return this;
+    }
+
+    public extensionOverrides(...overrides: string[]) {
+      if (!this.context.extensionOverrides) {
+        this.context.extensionOverrides = new ExtensionOverrides(overrides);
+      } else {
+        overrides.forEach((override) => this.context.extensionOverrides.add(override));
+      }
+
+      return this;
     }
 
     /**

--- a/src/core/ExtensionOverrides.ts
+++ b/src/core/ExtensionOverrides.ts
@@ -1,0 +1,56 @@
+import { File } from './File';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export class ExtensionOverrides {
+  public overrides: string[];
+
+  constructor(overrides: string[]) {
+    this.overrides = [];
+    overrides.forEach((override) => this.add(override));
+  }
+
+  private isValid(override: string) {
+    return (typeof override === 'string' && override.indexOf('.') === 0);
+  }
+
+  public add(override: string) {
+    if (this.isValid(override)) {
+      this.overrides.push(override);
+    }
+  }
+
+  public setOverrideFileInfo(file: File): string {
+    if (this.overrides.length === 0 || !file.belongsToProject()) {
+      return;
+    }
+
+    const fileInfo = path.parse(file.info.absPath);
+
+    for (let overrideExtension of this.overrides) {
+      const overridePath = path.resolve(fileInfo.dir, `${fileInfo.name}${overrideExtension}`);
+
+      if (overrideExtension.indexOf(fileInfo.ext) > -1 && fs.existsSync(overridePath)) {
+        file.absPath = file.info.absPath = overridePath;
+        file.hasExtensionOverride = true;
+        file.context.log.echoInfo(`Extension override found. Mapping ${file.info.fuseBoxPath} to ${path.basename(file.info.absPath)}`)
+      }
+    }
+  }
+
+  public getPathOverride(pathStr: string) {
+    if (this.overrides.length === 0) {
+      return;
+    }
+
+    const fileInfo = path.parse(pathStr);
+
+    for (let overrideExtension of this.overrides) {
+      const overridePath = path.resolve(fileInfo.dir, `${fileInfo.name}${overrideExtension}`);
+
+      if (overrideExtension.indexOf(fileInfo.ext) > -1 && fs.existsSync(overridePath)) {
+        return overridePath;
+      }
+    }
+  }
+}

--- a/src/core/File.ts
+++ b/src/core/File.ts
@@ -143,6 +143,8 @@ export class File {
 
     public groupHandler: Plugin;
 
+    public hasExtensionOverride = false;
+
     public addAlternativeContent(str: string) {
         this.alternativeContent = this.alternativeContent || "";
         this.alternativeContent += "\n" + str;
@@ -428,9 +430,13 @@ export class File {
         if (this.info.isRemoteFile) {
             return;
         }
+
         if (!this.absPath) {
             return;
         }
+        
+        this.context.extensionOverrides && this.context.extensionOverrides.setOverrideFileInfo(this);
+
         if (!fs.existsSync(this.info.absPath)) {
 
             if (/\.js$/.test(this.info.fuseBoxPath) && this.context.fuse && this.context.fuse.producer) {

--- a/src/core/FuseBox.ts
+++ b/src/core/FuseBox.ts
@@ -17,6 +17,7 @@ import { BundleProducer } from "./BundleProducer";
 import { Bundle } from "./Bundle";
 import { SplitConfig } from "./BundleSplit";
 import { File, ScriptTarget } from "./File";
+import { ExtensionOverrides } from "./ExtensionOverrides";
 
 const appRoot = require("app-root-path");
 
@@ -54,7 +55,7 @@ export interface FuseBoxOptions {
     experimentalFeatures?: boolean;
     output?: string;
     emitHMRDependencies?: boolean;
-    filterFile? : {(file : File) : boolean} 
+    filterFile? : {(file : File) : boolean}
     debug?: boolean;
     files?: any;
     alias?: any;
@@ -64,6 +65,7 @@ export interface FuseBoxOptions {
     showErrorsInBrowser?: boolean
     polyfillNonStandardDefaultUsage?: boolean | string[];
     transformers?: CustomTransformers;
+    extensionOverrides?: string[];
 }
 
 /**
@@ -192,7 +194,7 @@ export class FuseBox {
         }
 
         if ( opts.filterFile){
-            
+
             this.context.filterFile = opts.filterFile;
         }
 
@@ -240,6 +242,10 @@ export class FuseBox {
         this.virtualFiles = opts.files;
         if (opts.output) {
             this.context.output = new UserOutput(this.context, opts.output);
+        }
+
+        if (opts.extensionOverrides) {
+          this.context.extensionOverrides = new ExtensionOverrides(opts.extensionOverrides);
         }
     }
 
@@ -460,7 +466,7 @@ export class FuseBox {
         }
     }
 
-  
+
     public initiateBundle(str: string, bundleReady?: any) {
         this.context.reset();
         // Locking deferred calls until everything is written

--- a/src/core/WorkflowContext.ts
+++ b/src/core/WorkflowContext.ts
@@ -20,6 +20,7 @@ import { BundleProducer } from "./BundleProducer";
 import { QuantumSplitConfig, QuantumItem, QuantumSplitResolveConfiguration } from "../quantum/plugin/QuantumSplit";
 import { isPolyfilledByFuseBox } from "./ServerPolyfillList";
 import { CSSDependencyExtractor, ICSSDependencyExtractorOptions } from "../lib/CSSDependencyExtractor";
+import { ExtensionOverrides } from "./ExtensionOverrides";
 
 const appRoot = require("app-root-path");
 
@@ -114,6 +115,8 @@ export class WorkFlowContext {
     public rollupOptions: any;
 
     public output: UserOutput;
+
+    public extensionOverrides?: ExtensionOverrides;
 
     public hash: string | Boolean;
 
@@ -296,7 +299,7 @@ export class WorkFlowContext {
         if (file.ignoreCache) {
           return
         }
-      
+
         let content = file.contents;
         if (file.context.emitHMRDependencies) {
             this.emitter.addListener("bundle-collected", () => {

--- a/src/plugins/stylesheet/CSSResourcePlugin.ts
+++ b/src/plugins/stylesheet/CSSResourcePlugin.ts
@@ -134,6 +134,11 @@ export class CSSResourcePluginClass implements Plugin {
                 }
                 let urlFile = path.isAbsolute(url) ? url : path.resolve(currentFolder, url);
                 urlFile = urlFile.replace(/[?\#].*$/, "");
+
+                if (file.context.extensionOverrides && file.belongsToProject()) {
+                  urlFile = file.context.extensionOverrides.getPathOverride(urlFile) || urlFile;
+                }
+
                 if (this.inlineImages) {
                     if (IMG_CACHE[urlFile]) {
                         return IMG_CACHE[urlFile];

--- a/src/plugins/stylesheet/SassPlugin.ts
+++ b/src/plugins/stylesheet/SassPlugin.ts
@@ -80,12 +80,20 @@ export class SassPluginClass implements Plugin {
                 if (/https?:/.test(url)) {
                     return done({ url });
                 }
+
                 for (let key in options.macros) {
                     if (options.macros.hasOwnProperty(key)) {
                         url = url.replace(key, options.macros[key]);
                     }
                 }
-                done({ file: path.normalize(url) });
+
+                let file = path.normalize(url);
+
+                if (context.extensionOverrides) {
+                  file = context.extensionOverrides.getPathOverride(file) || file;
+                }
+
+                done({ file });
             };
         }
 

--- a/src/plugins/vue/VueBlockFile.ts
+++ b/src/plugins/vue/VueBlockFile.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import { extractExtension } from '../../Utils'
 import { File } from "../../core/File";
-import { WorkFlowContext, Plugin } from "../../core/WorkflowContext";
+import { Plugin } from "../../core/WorkflowContext";
 import { IPathInformation } from '../../core/PathMaster';
 import { CSSPluginClass } from "../stylesheet/CSSplugin";
 import { LESSPluginClass } from "../stylesheet/LESSPlugin";
@@ -23,13 +23,15 @@ const PLUGIN_LANG_MAP = new Map<string, any>()
 
 export abstract class VueBlockFile extends File {
   constructor(
-    public context: WorkFlowContext,
+    public file: File,
     public info: IPathInformation,
     public block: any,
     public scopeId: string,
     public pluginChain: Plugin[]
   ) {
-    super(context, info);
+    super(file.context, info);
+    this.collection = file.collection;
+    this.context.extensionOverrides && this.context.extensionOverrides.setOverrideFileInfo(this);
     this.ignoreCache = true;
   }
 
@@ -86,7 +88,7 @@ export abstract class VueBlockFile extends File {
         return;
     }
 
-    if (this.block.src) {
+    if (this.block.src || this.hasExtensionOverride) {
       try {
         this.contents = fs.readFileSync(this.info.absPath).toString();
       } catch (e) {

--- a/src/tests/BundleApi.test.ts
+++ b/src/tests/BundleApi.test.ts
@@ -135,6 +135,34 @@ export class BundleApiTest {
         should(bundle2.context.plugins).deepEqual(["bar"]);
     }
 
+    "Should set extension overrides"() {
+        const fuse = createFuse();
+        const bundle = fuse.bundle("app")
+            .extensionOverrides(".foo.js", ".foo.json")
+            .extensionOverrides(".foo.css", ".foo.less");
+
+        should(bundle.context.extensionOverrides.overrides).deepEqual([".foo.js", ".foo.json", ".foo.css", ".foo.less"]);
+    }
+
+    "Should not add an extension override if it is invalid"() {
+        const fuse = createFuse();
+        const bundle = fuse.bundle("app")
+            .extensionOverrides("foo.js", ".foo.json");
+
+        should(bundle.context.extensionOverrides.overrides).deepEqual([".foo.json"]);
+    }
+
+    "Should not share extension overrides across bundles"() {
+        const fuse = createFuse();
+        const bundle1 = fuse.bundle("app")
+            .extensionOverrides(".foo.js", ".foo.json");
+        const bundle2 = fuse.bundle("app")
+            .extensionOverrides(".bar.js", ".bar.json");
+
+        should(bundle1.context.extensionOverrides.overrides).deepEqual([".foo.js", ".foo.json"]);
+        should(bundle2.context.extensionOverrides.overrides).deepEqual([".bar.js", ".bar.json"]);
+    }
+
     "Should setup arithmetics"() {
         const fuse = createFuse();
         const bundle = fuse.bundle("app").instructions("hello");

--- a/src/tests/ExtensionOverrides.test.ts
+++ b/src/tests/ExtensionOverrides.test.ts
@@ -1,0 +1,57 @@
+import { should } from "fuse-test-runner";
+import { FuseTestEnv } from "./stubs/FuseTestEnv";
+import { ExtensionOverrides } from "../core/ExtensionOverrides";
+import { File } from "../core/File";
+import { ModuleCollection } from "../core/ModuleCollection";
+import { WorkFlowContext } from "../core/WorkFlowContext";
+
+export class ExtensionOverridesTest {
+  "Should create an instance and set overrides if they are valid"() {
+    const extensionOverrides = new ExtensionOverrides(['.foo.ts', '.foo.css']);
+
+    should(extensionOverrides.overrides).deepEqual(['.foo.ts', '.foo.css']);
+  }
+
+  "Should create an instance and not set overrides if they are invalid"() {
+    const extensionOverrides = new ExtensionOverrides(['not-valid.ts', '.foo.css']);
+
+    should(extensionOverrides.overrides).deepEqual(['.foo.css']);
+  }
+
+  "Should allow adding additional overrides"() {
+    const extensionOverrides = new ExtensionOverrides(['.foo.ts']);
+
+    should(extensionOverrides.overrides).deepEqual(['.foo.ts']);
+
+    extensionOverrides.add('.foo.css');
+
+    should(extensionOverrides.overrides).deepEqual(['.foo.ts', '.foo.css']);
+  }
+
+  "Should not update a File's path info if the file does not belong to the project"() {
+    const extensionOverrides = new ExtensionOverrides(['.foo.ts']);
+    const file = new File(new WorkFlowContext(), {
+      absPath: 'some/fake/abs/path/index.ts'
+    });
+
+    extensionOverrides.setOverrideFileInfo(file);
+
+    should(file.info.absPath).equal('some/fake/abs/path/index.ts');
+    should(file.hasExtensionOverride).equal(false);
+  }
+
+  "Should update a File's path info if an override matches"() {
+    return FuseTestEnv.create({
+        project: {
+          extensionOverrides: ['.foo.ts'],
+          files: {
+              "index.ts": `export {getMessage} from './hello'`,
+              "hello.ts": `export function getMessage() { return 'I should not be included'; }`,
+              "hello.foo.ts": `export function getMessage() { return 'I should be included'; }`
+          }
+        }
+      }).simple().then((env) => env.browser((window) => {
+        should(window.FuseBox.import("./index").getMessage()).equal('I should be included');
+      }));
+  }
+}

--- a/src/tests/plugins/BabelPlugin.test.ts
+++ b/src/tests/plugins/BabelPlugin.test.ts
@@ -1,4 +1,5 @@
 import { createEnv } from "./../stubs/TestEnvironment";
+import { FuseTestEnv } from "../stubs/FuseTestEnv";
 import { should } from "fuse-test-runner";
 import { BabelPlugin } from "../../plugins/js-transpilers/BabelPlugin";
 
@@ -17,5 +18,37 @@ export class BabelPluginTest {
           const out = result.project.FuseBox.import("./index.wxyz");
           should(out).deepEqual({ canada: { result: "igloo" } });
         });
+    }
+
+    "Should allow extension overrides"() {
+      return FuseTestEnv.create({
+          project: {
+            extensionOverrides: ['.foo.js'],
+            plugins: [BabelPlugin({ config: { presets: ["latest"] } })]
+            files: {
+                "index.js": `export {getMessage} from './hello'`,
+                "hello.js": `export function getMessage() { return 'I should not be included'; }`,
+                "hello.foo.js": `export function getMessage() { return 'I should be included'; }`
+            }
+          }
+        }).simple('> index.js').then((env) => env.browser((window) => {
+          should(window.FuseBox.import("./index").getMessage()).equal('I should be included');
+        }));
+    }
+
+    "Should allow extension overrides with custom extensions"() {
+      return FuseTestEnv.create({
+          project: {
+            extensionOverrides: ['.foo.wxyz'],
+            plugins: [BabelPlugin({ extensions: [".wxyz"], config: { "presets": ["latest"] } })]
+            files: {
+                "index.wxyz": `export {getMessage} from './hello.wxyz'`,
+                "hello.wxyz": `export function getMessage() { return 'I should not be included'; }`,
+                "hello.foo.wxyz": `export function getMessage() { return 'I should be included'; }`
+            }
+          }
+        }).simple('> index.wxyz').then((env) => env.browser((window) => {
+          should(window.FuseBox.import("./index.wxyz").getMessage()).equal('I should be included');
+        }));
     }
 }

--- a/src/tests/plugins/CSSPlugin.test.ts
+++ b/src/tests/plugins/CSSPlugin.test.ts
@@ -1,4 +1,5 @@
 import { createEnv } from "./../stubs/TestEnvironment";
+import { FuseTestEnv } from "../stubs/FuseTestEnv";
 import { should } from "fuse-test-runner";
 import * as path from "path";
 import * as appRoot from "app-root-path";
@@ -277,5 +278,23 @@ export class CssPluginTest {
             const js = result.projectContents.toString();
             should(js).findString(`require("fuse-box-css")("all.css", "`);
         });
+    }
+
+    "Should allow overrides of .css extensions"() {
+      return FuseTestEnv.create({
+          project: {
+            plugins: [CSSPlugin()],
+            extensionOverrides: ['.foo.css'],
+            files: {
+                "index.ts": `import './main.css'`,
+                "main.css": `html { background: red; }`
+                "main.foo.css": `html { background: blue; }`
+            }
+          }
+        }).simple().then((env) => env.browser((window) => {
+          should(window.document.querySelectorAll('style')).haveLength(1);
+          should(window.document.querySelector('style').attributes.id.value).equal("main-css");
+          should(window.document.querySelector('style').innerHTML).equal('html { background: blue; }');
+        }));
     }
 }

--- a/src/tests/plugins/CoffeePlugin.test.ts
+++ b/src/tests/plugins/CoffeePlugin.test.ts
@@ -1,9 +1,10 @@
 import { CoffeePlugin, RawPlugin } from "../../index";
 import { createEnv } from "../stubs/TestEnvironment";
+import { FuseTestEnv } from "../stubs/FuseTestEnv";
 import { should } from "fuse-test-runner";
 
 const coffeeFileSource = `class Demo
-                                           demo: -> 
+                                           demo: ->
                                             "hello"
 `;
 
@@ -71,5 +72,20 @@ Demo = (function() {
 `
             );
         });
+    }
+
+    "Should allow extension overrides"() {
+      return FuseTestEnv.create({
+          project: {
+            extensionOverrides: ['.foo.coffee'],
+            plugins: [CoffeePlugin({})]
+            files: {
+                "hello.coffee": `module.exports = getMessage: -> 'I should not be included'`,
+                "hello.foo.coffee": `module.exports = getMessage: -> 'I should be included'`
+            }
+          }
+        }).simple('>hello.coffee').then((env) => env.browser((window) => {
+          should(window.FuseBox.import("./hello.coffee").getMessage()).equal('I should be included');
+        }));
     }
 }

--- a/src/tests/plugins/ConsolidatePlugin.test.ts
+++ b/src/tests/plugins/ConsolidatePlugin.test.ts
@@ -1,5 +1,6 @@
 import { ConsolidatePlugin } from "../../index";
 import { createEnv } from "../stubs/TestEnvironment";
+import { FuseTestEnv } from "../stubs/FuseTestEnv";
 import { should } from "fuse-test-runner";
 
 export class ConsolidatePluginTest {
@@ -54,5 +55,22 @@ export class ConsolidatePluginTest {
           const template = result.project.FuseBox.import('./template.pug');
           should(template).equal("<p>Compiled with Pug</p>");
         });
+    }
+
+    "Should allow extension overrides"() {
+      return FuseTestEnv.create({
+          project: {
+            extensionOverrides: ['.foo.pug'],
+            plugins: [ConsolidatePlugin({
+              engine: 'pug'
+            })]
+            files: {
+                "template.pug": "p I should not be included",
+                "template.foo.pug": "p I should be included"
+            }
+          }
+        }).simple('>template.pug').then((env) => env.browser((window) => {
+          should(window.FuseBox.import("./template.pug")).deepEqual({ default: '<p>I should be included</p>' });
+        }));
     }
 }

--- a/src/tests/plugins/HTMLPlugin.test.ts
+++ b/src/tests/plugins/HTMLPlugin.test.ts
@@ -1,4 +1,5 @@
 import { createEnv } from "./../stubs/TestEnvironment";
+import { FuseTestEnv } from "../stubs/FuseTestEnv";
 import { should } from "fuse-test-runner";
 import { HTMLPlugin } from "../../plugins/HTMLplugin";
 
@@ -68,5 +69,21 @@ export class HtmlPluginTest {
             const out = result.project.FuseBox.import("./index.html");
             should(out).equal("<h1>hello</h1>");
         });
+    }
+
+    "Should allow extension overrides"() {
+      return FuseTestEnv.create({
+          project: {
+            extensionOverrides: ['.foo.html'],
+            plugins: [HTMLPlugin({ useDefault: false })]
+            files: {
+              "index.ts": `const template = require('./index.html');`,
+              "index.html": `<h1>I should not be included</h1>`,
+              "index.foo.html": `<h1>I should be included</h1>`,
+            }
+          }
+        }).simple().then((env) => env.browser((window) => {
+          should(window.FuseBox.import("./index.html")).deepEqual('<h1>I should be included</h1>');
+        }));
     }
 }

--- a/src/tests/plugins/JSONPlugin.test.ts
+++ b/src/tests/plugins/JSONPlugin.test.ts
@@ -1,4 +1,5 @@
 import { createEnv } from "./../stubs/TestEnvironment";
+import { FuseTestEnv } from "../stubs/FuseTestEnv";
 import { should } from "fuse-test-runner";
 import { JSONPlugin } from "../../plugins/JSONplugin";
 
@@ -21,5 +22,20 @@ export class JSONPluginTest {
             should(out).deepEqual({ "name": "test", "tags": ["fusebox", "test"] }
             );
         });
+    }
+
+    "Should allow extension overrides"() {
+      return FuseTestEnv.create({
+          project: {
+            extensionOverrides: ['.foo.json'],
+            plugins: [JSONPlugin()]
+            files: {
+                "file.json": `{ "contents": "I should not be included" }`,
+                "file.foo.json": `{ "contents": "I should be included" }`,
+            }
+          }
+        }).simple('>file.json').then((env) => env.browser((window) => {
+          should(window.FuseBox.import("./file.json")).deepEqual({ contents: 'I should be included' });
+        }));
     }
 }

--- a/src/tests/plugins/MarkdownPlugin.test.ts
+++ b/src/tests/plugins/MarkdownPlugin.test.ts
@@ -1,4 +1,5 @@
 import { createEnv } from "./../stubs/TestEnvironment";
+import { FuseTestEnv } from "../stubs/FuseTestEnv";
 import { should } from "fuse-test-runner";
 import { MarkdownPlugin } from "../../plugins/Markdownplugin";
 
@@ -68,5 +69,20 @@ export class MarkdownPluginTest {
             const out = result.project.FuseBox.import("./index.md");
             should(out).equal("<h1 id=\"hello\">hello</h1>\n");
         });
+    }
+
+    "Should allow extension overrides"() {
+      return FuseTestEnv.create({
+          project: {
+            extensionOverrides: ['.foo.md'],
+            plugins: [MarkdownPlugin({useDefault: false})]
+            files: {
+                "file.md": `# I should not be included`,
+                "file.foo.md": `# I should be included`
+            }
+          }
+        }).simple('>file.md').then((env) => env.browser((window) => {
+          should(window.FuseBox.import("./file.md")).deepEqual('<h1 id=\"i-should-be-included\">I should be included</h1>\n');
+        }));
     }
 }

--- a/src/tests/plugins/RawPlugin.test.ts
+++ b/src/tests/plugins/RawPlugin.test.ts
@@ -1,4 +1,5 @@
 import { createEnv } from "./../stubs/TestEnvironment";
+import { FuseTestEnv } from "../stubs/FuseTestEnv";
 import { should } from "fuse-test-runner";
 import { RawPlugin } from "../../plugins/RawPlugin";
 
@@ -33,5 +34,20 @@ export class RawPluginTest {
             should(fileRaw1).equal("\nthis is\n\traw\n\t\tcontent\n");
             should(fileRaw2).equal("\nthis is\n\traw\n\t\tcontent\n");
         });
+    }
+
+		"Should allow extension overrides"() {
+      return FuseTestEnv.create({
+          project: {
+            extensionOverrides: ['.foo.raw'],
+            plugins: [/raw$/, RawPlugin({ extensions: [".raw"] })],
+            files: {
+                "file.raw": "I should not be included",
+                "file.foo.raw": "I should be included"
+            }
+          }
+        }).simple('>file.raw').then((env) => env.browser((window) => {
+          should(window.FuseBox.import("./file.raw")).deepEqual('I should be included');
+        }));
     }
 }

--- a/src/tests/plugins/StylusPlugin.test.ts
+++ b/src/tests/plugins/StylusPlugin.test.ts
@@ -1,4 +1,5 @@
 import { createEnv } from "./../stubs/TestEnvironment";
+import { FuseTestEnv } from "../stubs/FuseTestEnv";
 import { should } from "fuse-test-runner";
 import { CSSPlugin } from "../../plugins/stylesheet/CSSplugin";
 import { StylusPlugin } from "../../plugins/stylesheet/StylusPlugin";
@@ -21,5 +22,29 @@ export class StylusPluginTest {
             const out = result.projectContents.toString();
             should(out).findString(`color: #fff`);
         });
+    }
+
+    "Should allow extension overrides"() {
+      return FuseTestEnv.create({
+          project: {
+            extensionOverrides: ['.foo.styl'],
+            plugins: [[StylusPlugin({}), CSSPlugin({})]],
+            files: {
+              "index.ts": `import "./main.styl";`,
+              "main.styl": `
+              body
+                color red
+              `,
+              "main.foo.styl": `
+              body
+                color blue
+              `
+            }
+          }
+        }).simple().then((env) => env.browser((window) => {
+          should(window.document.querySelectorAll('style')).haveLength(1);
+          should(window.document.querySelector('style').attributes.id.value).equal("main-styl");
+          should(window.document.querySelector('style').innerHTML).findString('color: #00f;');
+        }));
     }
 }

--- a/src/tests/plugins/VueComponentPlugin.test.ts
+++ b/src/tests/plugins/VueComponentPlugin.test.ts
@@ -1,5 +1,6 @@
 import { VueComponentPlugin, BabelPlugin, HTMLPlugin, SassPlugin } from "../../index";
 import { createEnv } from "../stubs/TestEnvironment";
+import { FuseTestEnv } from "../stubs/FuseTestEnv";
 import { should } from "fuse-test-runner";
 
 const getTemplateBlock = (langAttribute: string = '', testIdentifer: string = '') => `
@@ -171,6 +172,40 @@ export class VuePluginTest {
             should(html).findString('ScopedStyles');
           })
         });
+    }
+
+    "Should allow extension overrides"() {
+      return FuseTestEnv.create({
+          project: {
+            useTypescriptCompiler: true,
+            extensionOverrides: ['.foo.ts', '.foo.html', '.foo.css'],
+            plugins: [VueComponentPlugin()]
+            files: {
+                "app.vue": `
+                  <template src="./template.html"></template>
+                  <script src="./script.ts"></script>
+                  <style src="./style.scss"></style>
+                `
+                "template.html": "<h1>I should not be included</h1>",
+                "template.foo.html": "<h1>I should be included</h1>",
+                "script.ts": "export default { message: 'I should not be included' }",
+                "script.foo.ts": "export default { message: 'I should be included' }",
+                "style.ts": "h1 { color: red; }",
+                "style.foo.ts": "h1 { color: blue; }"
+            }
+          }
+        }).simple('>app.vue').then((env) => env.browser((window) => {
+          const Vue = require('vue')
+          const renderer = require('vue-server-renderer').createRenderer()
+          const component = window.FuseBox.import('./app.vue').default;
+          const app = new Vue(component);
+
+          should(component.message).equal('I should be included');
+
+          renderer.renderToString(app, (err, html) => {
+            should(html).findString('I should be included');
+          });
+        }));
     }
 
     "Should be compatible with vue-class-component decorators"() {


### PR DESCRIPTION
FuseBox can now be configured to look for customised extensions ahead of standard ones. This is
useful for platform specific builds. For example:

```js
FuseBox.init({
   extensionOverrides: ['.desktop.js']
});
```

With the above configuration FuseBox will favour loading contents from files with a `.desktop.js` extension over `.js` extension. If `.desktop.js` does not exist then normal resolution will occur. This a essentially a port of the Webpack functionality for [resolve extensions](https://webpack.js.org/configuration/resolve/#resolve-extensions).

In Summary:
- Added Functionality
- Added Unit Tests
- Added Documentation