### PR TITLE
fix: css plugin doesnt check type before calling generateCorrectSourc…

### DIFF
--- a/src/plugins/stylesheet/CSSplugin.ts
+++ b/src/plugins/stylesheet/CSSplugin.ts
@@ -211,7 +211,7 @@ export class CSSPluginClass implements Plugin {
             return;
         }
 
-        if (file.sourceMap) {
+        if (typeof file.sourceMap === "string") {
             file.sourceMap = file.generateCorrectSourceMap();
         }
         /**


### PR DESCRIPTION
generally it is bad to reuse variables with differently typed values. This bug is an example of that: 

```
    public generateCorrectSourceMap(fname?: string) {
        if (this.sourceMap) {
            let jsonSourceMaps = JSON.parse(this.sourceMap);
```

where the if isn't going to stop when this.sourceMap is assigned to an object. Alternatively you may want to do this typecheck in File.ts.