### PR TITLE
Fix sourcemap problems ?

### DIFF
--- a/src/ModuleCache.ts
+++ b/src/ModuleCache.ts
@@ -216,7 +216,7 @@ export class ModuleCache {
         let cacheData: any = {
             contents: file.contents,
             dependencies: file.analysis.dependencies,
-            sourceMap: sourcemaps || {},
+            sourceMap: sourcemaps || "{}",
             headerContent: file.headerContent,
             mtime: stats.mtime.getTime(),
             _ : file.cacheData || {}

--- a/src/core/File.ts
+++ b/src/core/File.ts
@@ -658,7 +658,7 @@ export class File {
         if (typeof this.sourceMap === "string") {
             let jsonSourceMaps = JSON.parse(this.sourceMap);
             jsonSourceMaps.file = this.info.fuseBoxPath;
-            jsonSourceMaps.sources = jsonSourceMaps.sources.map((source: string) => {
+            jsonSourceMaps.sources = jsonSourceMaps.sources && jsonSourceMaps.sources.map((source: string) => {
                 return this.context.sourceMapsRoot + "/" + (fname || source);
             });
 


### PR DESCRIPTION
Hello,

I constantly run into this exception when hot reloading triggers:

```
SyntaxError: Unexpected token o in JSON at position 1
    at JSON.parse (<anonymous>)
    at File.generateCorrectSourceMap (/Users/geowarin/dev/mgp/myprivateadvisor/mgp-web/node_modules/fuse-box/src/core/File.ts:653:39)
    at CSSPluginClass.transform (/Users/geowarin/dev/mgp/myprivateadvisor/mgp-web/node_modules/fuse-box/src/plugins/stylesheet/CSSplugin.ts:215:35)
    at tasks.push (/Users/geowarin/dev/mgp/myprivateadvisor/mgp-web/node_modules/fuse-box/src/core/File.ts:308:63)
    at realm_utils_1.each.promise (/Users/geowarin/dev/mgp/myprivateadvisor/mgp-web/node_modules/fuse-box/src/core/File.ts:319:52)
    at iterate (/Users/geowarin/dev/mgp/myprivateadvisor/mgp-web/node_modules/realm-utils/dist/commonjs/each.js:79:34)
    at /Users/geowarin/dev/mgp/myprivateadvisor/mgp-web/node_modules/realm-utils/dist/commonjs/each.js:83:29
```

This is my fuse-box config, I'm running the latest version:

```ts
let fuse = new FuseBox({
  homeDir: `${paths.jsRoot}`,
  output: `${paths.devDist}/$name.js`,
  tsConfig: `${paths.root}/tsconfig.json`,
  target: "browser",
  plugins: [
    SVGPlugin(),
    [
      PostCSS(postCssPlugins, {from: 'src/main/ts/styles/main.css', sourceMaps: true}),
      CSSResourcePlugin({inline: true}),
      CSSPlugin()
    ],
    JSONPlugin()
  ] as any
});

fuse.dev();

fuse.bundle("vendor")
  .watch()
  .instructions(" ~ core/client.ts ~ pages/**/*.tsx");

fuse.bundle("pages")
  .watch()
  .hmr()
  .sourceMaps(true)
  .instructions(" !> [core/client.ts] + [pages/**/*.tsx]");

fuse.run();
```

A very shallow investigation led me to see that the error happens when `JSON.parse(this.sourceMap);` is given an empty **object** (`{}`).

So, It seems to come from that `ModuleCache` that I patched.
Also, in that case obviously, `jsonSourceMaps.sources` would be empty hence the other fix in File.ts.

I don't know enough about source maps in fuse-box to see if that's the correct fix.
I might only happen with the PostCSS plugin, I don't know.

@nchanged, any idea ?
