### PR TITLE
fix: LanguageLevel doesn't detect es2015 "const", "let" and "arrow function"

### DIFF
--- a/src/analysis/plugins/LanguageLevel.ts
+++ b/src/analysis/plugins/LanguageLevel.ts
@@ -4,6 +4,10 @@ export class LanguageLevel {
     public static onNode(file: File, node: any, parent: any) {
         if (node.async === true) {
             file.setLanguageLevel(ScriptTarget.ES2017)
+        } else if (node.kind === "const") {
+            file.setLanguageLevel(ScriptTarget.ES2015);
+        } else if (node.type === "ArrowFunctionExpression") {
+            file.setLanguageLevel(ScriptTarget.ES2015);
         }
     }
     public static onEnd(file: File) {

--- a/src/analysis/plugins/LanguageLevel.ts
+++ b/src/analysis/plugins/LanguageLevel.ts
@@ -3,8 +3,10 @@ import { File, ScriptTarget } from "../../core/File";
 export class LanguageLevel {
     public static onNode(file: File, node: any, parent: any) {
         if (node.async === true) {
-            file.setLanguageLevel(ScriptTarget.ES2017)
+            file.setLanguageLevel(ScriptTarget.ES2017);
         } else if (node.kind === "const") {
+            file.setLanguageLevel(ScriptTarget.ES2015);
+        } else if (node.kind === "let") {
             file.setLanguageLevel(ScriptTarget.ES2015);
         } else if (node.type === "ArrowFunctionExpression") {
             file.setLanguageLevel(ScriptTarget.ES2015);


### PR DESCRIPTION
As discussed in issue #916, I added detection of `const` and arrow functions `(...) => ...` since they are probably the most commonly used ES2015 features.

For complete language support, it would probably be better to create and use a separated module dedicated to this (something like 'acorn-detect-ecmaversion'), I didn't find anything existing covering this.