### PR TITLE
fix: Ensure .babelrc options and direct BabelPlugin options are merged

### DIFF
--- a/docs/plugins/transpilers/BabelPlugin.md
+++ b/docs/plugins/transpilers/BabelPlugin.md
@@ -54,3 +54,5 @@ plugins: [
   })
 ]
 ```
+
+note: The BabelPlugin will merge options from your .babelrc file and any options passed into the plugin directly. If an option exists in both, then the options object passed into the plugin will take priority.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -238,7 +238,7 @@ gulp.task("make-test-runner", (done) => {
 
 
 gulp.task("copy-to-dev", () => {
-    const devFolder = "vue-seed";
+    const devFolder = "fuse-box-vue-sourcemaps";
 
     gulp.src("modules/fuse-box-css/**/**.**")
         .pipe(gulp.dest(`../${devFolder}/node_modules/fuse-box/modules/fuse-box-css`));

--- a/src/plugins/js-transpilers/BabelPlugin.ts
+++ b/src/plugins/js-transpilers/BabelPlugin.ts
@@ -60,13 +60,19 @@ export class BabelPluginClass implements Plugin {
 
         let babelRcConfig;
         let babelRcPath = path.join(this.context.appRoot, `.babelrc`);
+
         if (fs.existsSync(babelRcPath)) {
             babelRcConfig = fs.readFileSync(babelRcPath).toString();
-            if (babelRcConfig) babelRcConfig = JSON.parse(babelRcConfig);
+
+            if (babelRcConfig) {
+              babelRcConfig = Object.assign({}, JSON.parse(babelRcConfig), this.config);
+            }
         }
+
         if (babelRcConfig) {
             this.config = babelRcConfig;
         }
+
         this.configLoaded = true;
     }
 


### PR DESCRIPTION
Issue identified by @apostololeg in #919 

The fix here is to merge both the `.babelrc` and `BabelPlugin(options)` together. Previously the plugin would just use the `.babelrc` file if it existed and ignore any options provided directly.