### PR TITLE
feat: allow CSS mask images to be processed with PostCSSResourcePlugin

### DIFF
--- a/src/lib/postcss/PostCSSResourcePlugin.ts
+++ b/src/lib/postcss/PostCSSResourcePlugin.ts
@@ -20,7 +20,7 @@ export const PostCSSResourcePlugin = postcss.plugin("css-resource", function (op
         css.walkDecls(declaration => {
             if (declaration.prop) {
 
-                if (declaration.prop.indexOf("background") === 0 || declaration.prop.indexOf("src") === 0) {
+                if (declaration.prop.indexOf("background") === 0 || declaration.prop.indexOf("src") === 0 || declaration.prop.indexOf("mask-image") > -1) {
                     let re = /url\(([^\)]+)\)/gm;
                     let match;
                     const v = declaration.value;


### PR DESCRIPTION
Currently `PostCSSResourcePlugin` targets background images and fonts when it looks for `url(...)` values.

This PR adds support for CSS `mask-image` property.

so this:
```css
 -webkit-mask-image: url("mask.svg");
```
can be transformed to:
```css
-webkit-mask-image: url("/149583776.svg");
```

I would have written some tests, but I did not know how to setup the tests as there does not seem to be any existing tests for `CSSResourcePlugin` / `PostCSSResourcePlugin`.