### PR TITLE
feat: add `appendBundles`-option to WebIndex-plugin

### DIFF
--- a/docs/plugins/html/WebIndexPlugin.md
+++ b/docs/plugins/html/WebIndexPlugin.md
@@ -32,6 +32,7 @@ fuse.plugin(
 | ` templateString `   | Provide your own template as a string  |
 | ` target `   | The main filename. Default is `index.html`  |
 | ` resolve `   | `resolve ?: {(output : UserOutput) : string}` Allows to completely override the output  |
+| ` appendBundles ` | Append $bundles to provided template |
 
 note: If you specify template and templateString then template will take precedent 
 

--- a/src/plugins/WebIndexPlugin.ts
+++ b/src/plugins/WebIndexPlugin.ts
@@ -16,6 +16,7 @@ export interface IndexPluginOptions {
     target?: string;
     template?: string;
     templateString?: string;
+    appendBundles?: boolean;
     async?: boolean;
     resolve ?: {(output : UserOutput) : string};
 }
@@ -67,6 +68,16 @@ export class WebIndexPluginClass implements Plugin {
         if (this.opts.template) {
             let filePath = ensureAbsolutePath(this.opts.template);
             html = fs.readFileSync(filePath).toString();
+
+            if (this.opts.appendBundles && html.indexOf('$bundles') === -1) {
+                if (html.indexOf('</body>') !== -1) {
+                    html = html.replace('</body>', '$bundles</body>');
+                } else if (html.indexOf('</head>') !== -1) {
+                    html = html.replace('</head>', '$bundles</head>');
+                } else {
+                    html = `${html}$bundles`; 
+                }
+            }
         }
 
         let jsTags = bundlePaths.map(bundle =>


### PR DESCRIPTION
for cross-usage with other bundlers, it would be nice to have an option to automatically append `$bundles` to template.