### PR TITLE
feat: PostCSS added support for .pcss extension

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -7,7 +7,7 @@ import * as LegoAPI from "lego-api";
 import { Log } from "./Log";
 
 const userFuseDir = Config.PROJECT_ROOT;
-const stylesheetExtensions = new Set<string>([".css", ".sass", ".scss", ".styl", ".less"]);
+const stylesheetExtensions = new Set<string>([".css", ".sass", ".scss", ".styl", ".less", ".pcss"]);
 const MBLACKLIST = [
     "freelist",
     "sys",

--- a/src/plugins/stylesheet/PostCSSPlugin.ts
+++ b/src/plugins/stylesheet/PostCSSPlugin.ts
@@ -25,7 +25,7 @@ export class PostCSSPluginClass implements Plugin {
      * @type {RegExp}
      * @memberOf FuseBoxCSSPlugin
      */
-    public test: RegExp = /\.css$/;
+    public test: RegExp = /\.p?css$/;
     public dependencies = [];
     constructor(public processors: Processors = [], public options: PostCSSPluginOptions = {}) { }
     /**
@@ -37,6 +37,7 @@ export class PostCSSPluginClass implements Plugin {
      */
     public init(context: WorkFlowContext) {
         context.allowExtension(".css");
+        context.allowExtension(".pcss");
     }
 
     /**
@@ -68,7 +69,7 @@ export class PostCSSPluginClass implements Plugin {
         const cssDependencies = file.context.extractCSSDependencies(file, {
             paths: paths,
             content: file.contents,
-            extensions: ["css"]
+            extensions: ["css", "pcss"]
         });
         file.cssDependencies = cssDependencies;
 


### PR DESCRIPTION
PostCSS recommends (if using a PostCSS extension) to use .pcss
https://twitter.com/postcss/status/661645290622083073

IntelliJ

> The IDE now recognises .pcss files.

https://plugins.jetbrains.com/plugin/8578-postcss-support