### PR TITLE
fix: issue #948 css bundling

### DIFF
--- a/src/plugins/stylesheet/CSSplugin.ts
+++ b/src/plugins/stylesheet/CSSplugin.ts
@@ -137,7 +137,16 @@ export class CSSPluginClass implements Plugin {
                   emitRequired = true;
               }
 
-              if (file.subFiles.find((subFile) => subFile.info.fuseBoxPath === bundle.lastChangedFile)) {
+              const { lastChangedFile } = bundle;
+              if (
+                file.subFiles.find(
+                  subFile =>
+                    subFile.info.fuseBoxPath === lastChangedFile ||
+                    !!subFile.cssDependencies.find(
+                      dep => dep.indexOf(lastChangedFile) !== -1
+                    )
+                )
+              ) {
                 emitRequired = true;
               }
             }


### PR DESCRIPTION
This is to fix https://github.com/fuse-box/fuse-box/issues/948. The root cause is that if you have a nested css structure like so:

a.scss
```scss
@import "./b.scss"
```

b.scss
```scss
// some css
```
Then somehow `b` is not recorded as a subfile of `a`, but is is available in `File.cssDependencies`. I'm not sure whether this is the right way `!!subFile.cssDependencies.find(dep => dep.indexOf(lastChangedFile) !== -1)`. Any pointer would be appreciated