### PR TITLE
fix(sparky): Update watch flow to use user base path

### DIFF
--- a/src/sparky/SparkFlow.ts
+++ b/src/sparky/SparkFlow.ts
@@ -3,7 +3,7 @@ import * as fs from "fs-extra";
 import * as chokidar from "chokidar";
 import * as path from "path";
 import { each } from "realm-utils";
-import { ensureDir, string2RegExp } from "../Utils";
+import { ensureDir, string2RegExp, ensureUserPath } from "../Utils";
 import { SparkyFile } from "./SparkyFile";
 import { log } from "./Sparky";
 import { Plugin } from '../core/WorkflowContext';
@@ -44,7 +44,7 @@ export class SparkFlow {
         this.activities.push(() => new Promise((resolve, reject) => {
 
             var chokidarOptions = {
-                cwd: opts ? opts.base : null
+                cwd: opts ? ensureUserPath(opts.base) : null
             };
 
             this.watcher = chokidar.watch(globs, chokidarOptions)


### PR DESCRIPTION
#995

When using `Sparky.watch` with a parent base directory, (because my `fuse.js` file is in a subdirectory (see screenshot)) it wouldn't copy files to my `.dest` directory.

```js
Sparky.task("watch-assets", () => Sparky.watch("./assets/*.png", { base: '../src/' }).dest('../dist'));
```

Using the `ensureUserPath` fixes this. 

My folder structure would be:

<img width="381" alt="screen shot 2017-12-27 at 21 03 14" src="https://user-images.githubusercontent.com/12511178/34392011-dc87349e-eb49-11e7-9884-18502b3fa73c.png">

And my full `fuse.js` file looks like this:

```js
const {
  FuseBox,
  WebIndexPlugin,
  Sparky
} = require("../../../.dev");

let fuse;

const DIRS = {
	src: '../src',
	dist: '../dist',
	assets: './assets'
}

Sparky.task("clean", () => Sparky.src(DIRS.dist).clean("dist/"));
Sparky.task("watch-assets", () => Sparky.watch(`${DIRS.assets}/*.*`, { base: DIRS.src }).dest(DIRS.dist));
Sparky.task("copy-assets", () => Sparky.src(`${DIRS.assets}/*.*`, {  base: DIRS.src }).dest(DIRS.dist));

Sparky.task("config", () => {
  fuse = FuseBox.init({
    homeDir: DIRS.src,
    output: `${DIRS.dist}/$name.js`,
    target: 'browser',
    plugins: [
      WebIndexPlugin(),
    ]
  });

  fuse.dev({
    port: 8080
  });

  const app = fuse.bundle("app")
    .instructions("> index.ts");

  app.watch().hmr();
})

Sparky.task("default", ["clean", "watch-assets", "config"], () => {
	return fuse.run();
});

Sparky.task("dist", ["clean", "copy-assets", "config"], () => {
	return fuse.run();
});
```
