### PR TITLE
Support HMR of files included through CSS Modules @value

### DIFF
--- a/src/lib/CSSDependencyExtractor.ts
+++ b/src/lib/CSSDependencyExtractor.ts
@@ -18,10 +18,10 @@ export class CSSDependencyExtractor {
 
 
     private extractDepsFromString(input: string, currentPath? : string) {
-        const re = /@import\s+("|')([^"']+)/g;
+        const re = /@(?:import|value)[^"']+["']([^"']+)/g;
         let match;
         while (match = re.exec(input)) {
-            let target = this.findTarget(match[2], currentPath);
+            let target = this.findTarget(match[1], currentPath);
             if (target) {
                 this.readFile(target, path.dirname(target));
                 this.dependencies.push(target);

--- a/src/plugins/stylesheet/PostCSSPlugin.ts
+++ b/src/plugins/stylesheet/PostCSSPlugin.ts
@@ -60,11 +60,10 @@ export class PostCSSPluginClass implements Plugin {
 
         const {
             sourceMaps = true,
-            paths = [],
             ...postCssOptions
         } = this.options;
 
-        paths.push(file.info.absDir);
+        const paths = [file.info.absDir, ...this.options.paths || []]
 
         const cssDependencies = file.context.extractCSSDependencies(file, {
             paths: paths,


### PR DESCRIPTION
The CSS Modules spec has a syntax for defining values which can be imported from within a css or js file. This syntax is supported by default via the postcss-modules library, so it works well for the first compile with fusebox. However, dependencies introduced by `@value` imports within CSS aren't tracked, so changes to the values themselves are not applied until the importing file is reloaded from some other change.

For example, 

main.css:
```css
@value primary from "./colors.css";

body {
  background: primary
}
```
colors.css:
```
@value primary: red;
```

If colors.css is modified so that primary is green, main.css is not reloaded and the change is not applied. This PR fixes that behavior. I also noticed that the PostCSSPlugin mutates its `paths` param, which is fixed.

I'm not 100% sure on this best design for this change, so this PR mainly follows patterns in other CSS plugins. I'd like for example to avoid passing the same `paths` parameter to both `CSSModules` and `PostCSSPlugin`, and it seems like there's now a lot of duplication between the two plugins in general. I'm also not sure about adding CSS Modules specific syntax to the `CSSDepedencyExtractor`.

Is this something you'd want to support, and if so is this a reasonable implementation?