### PR TITLE
fix: ScriptTarget ES-edition to ES-year aliases (#990)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -541,7 +541,7 @@ Possible levels
 
 Aliases `es6` & `es7` are provided to align with the configuration options of TypeScript, but we recommend using the es-year form instead.
 
-The default language level is `es2017`
+The default language level is `es2016`
 
 
 ### Example

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -534,11 +534,14 @@ FuseBox.init({
 Possible levels
 
 * es5
-* es2015
-* es2016
+* es2015 (alias: es6)
+* es2016 (alias: es7)
 * es2017
 * esnext
 
+Aliases `es6` & `es7` are provided to align with the configuration options of TypeScript, but we recommend using the es-year form instead.
+
+The default language level is `es2017`
 
 
 ### Example

--- a/src/core/File.ts
+++ b/src/core/File.ts
@@ -14,10 +14,10 @@ import { ensureFuseBoxPath, readFuseBoxModule, isStylesheetExtension } from "../
 export enum ScriptTarget {
     ES5 = 1,
     ES2015 = 2,
+    ES6 = 2,
     ES2016 = 3,
-    ES6 = 3,
+    ES7 = 3,
     ES2017 = 4,
-    ES7 = 4,
     ESNext = 5
 }
 

--- a/src/core/FuseBox.ts
+++ b/src/core/FuseBox.ts
@@ -112,7 +112,7 @@ export class FuseBox {
         if (level) {
             this.context.forcedLanguageLevel = ScriptTarget[level];
         }
-        this.context.languageLevel = ScriptTarget[level] || ScriptTarget.ES6;
+        this.context.languageLevel = ScriptTarget[level] || ScriptTarget.ES2017;
 
         if (opts.polyfillNonStandardDefaultUsage !== undefined) {
             this.context.polyfillNonStandardDefaultUsage = opts.polyfillNonStandardDefaultUsage;

--- a/src/core/FuseBox.ts
+++ b/src/core/FuseBox.ts
@@ -112,7 +112,7 @@ export class FuseBox {
         if (level) {
             this.context.forcedLanguageLevel = ScriptTarget[level];
         }
-        this.context.languageLevel = ScriptTarget[level] || ScriptTarget.ES2017;
+        this.context.languageLevel = ScriptTarget[level] || ScriptTarget.ES2016;
 
         if (opts.polyfillNonStandardDefaultUsage !== undefined) {
             this.context.polyfillNonStandardDefaultUsage = opts.polyfillNonStandardDefaultUsage;


### PR DESCRIPTION
I've also set the default language level to ES2016 for compatibility with the old ES6 default which was actually ES7/ES2016. If the default should actually be ES6 then it may be best to use ES2015 form - avoiding the ESx aliases entirely within the codebase.

(It's so easy to get the ES year mixed up - i'm doing it myself now, you may notice from the extra commit!!!)

Added some notes to docs regarding aliases and recommendation to use year form, and state the default.

Personally i'd ditch the es-edition aliases entirely and go with the es-year form always, but i don't know if you need them for possible TypeScript configuration compatibility.