### PR TITLE
Allow relative URLs in less files

### DIFF
--- a/docs/plugins/css/LessPlugin.md
+++ b/docs/plugins/css/LessPlugin.md
@@ -59,7 +59,17 @@ import "./styles/main.less"
 
 ## Options
 
-`LessPlugin` accepts a `key/value` `Less` object options as a parameter. For example:
+### relativeUrls
+
+By default URLs are kept as-is, so if you import a file in a sub-directory that references an image, exactly the same URL will be output in the css. This option allows you to re-write URL's in imported files so that the URL is always relative to the base imported file.
+
+```js
+fuse.plugin(
+    [LESSPlugin({ relativeUrls: true }), CSSPlugin()]
+)
+```
+
+### paths
 
 ```js
 fuse.plugin(

--- a/src/plugins/stylesheet/LESSPlugin.ts
+++ b/src/plugins/stylesheet/LESSPlugin.ts
@@ -1,6 +1,7 @@
 import { File } from "../../core/File";
 import { WorkFlowContext } from "./../../core/WorkflowContext";
 import { Plugin } from "../../core/WorkflowContext";
+import * as path from "path";
 let less;
 
 export interface LESSPluginOptions {
@@ -56,7 +57,7 @@ export class LESSPluginClass implements Plugin {
             less = require("less");
         }
 
-        options.filename = file.context.homeDir + (options.filename || file.info.fuseBoxPath);
+        options.filename = options.filename ? path.join(file.context.homeDir, options.filename) : file.info.absPath;
 
         if ("sourceMapConfig" in context) {
             options.sourceMap = { ...sourceMapDef, ...options.sourceMap || {} };

--- a/src/plugins/stylesheet/LESSPlugin.ts
+++ b/src/plugins/stylesheet/LESSPlugin.ts
@@ -6,6 +6,7 @@ let less;
 
 export interface LESSPluginOptions {
     sourceMap?: any;
+    relativeUrls?: boolean;
 }
 
 export interface LESSPluginInternalOpts {


### PR DESCRIPTION
This PR adds the `relativeUrls` option to `LESSPlugin`.  Its necessary when you want to automatically rebase urls in imported less files relative to the entry file.  The previous fix for filename is actually only ever used (AFAIK) when `relativeUrls` is turned on so I believe nothing should be broken by that.