### PR TITLE
fix: Fix #1030 (`this !== module.exports`) for Quantum

### DIFF
--- a/modules/fuse-box-responsive-api/index.js
+++ b/modules/fuse-box-responsive-api/index.js
@@ -339,7 +339,7 @@
         cached = $fsx.m[id] = {};
         cached.exports = {};
         cached.m = { exports: cached.exports };
-        file(cached.m, cached.exports);
+        file.call(cached.exports, cached.m, cached.exports);
         return cached.m.exports;
     };
 


### PR DESCRIPTION
Missed this before as I wasn't yet making use of Quantum :)