### PR TITLE
Fixes #1084

### DIFF
--- a/src/lib/CSSUrlParser.ts
+++ b/src/lib/CSSUrlParser.ts
@@ -20,6 +20,10 @@ export class CSSUrlParser {
         const re = /url\(([^\)]+)\)/gm;
         return contents.replace(re, (match, data, offset, input_string) => {
             const value = this.extractValue(data);
+            if (typeof value === 'undefined') {
+                return match;
+            }
+            
             const replaced = fn(value);
             if (typeof replaced === "string") {
                 return `url("${replaced}")`


### PR DESCRIPTION
When the `extractValue()` method returns undefined a TypeError occurs because an operation is applied on a variable that doesn't exist. If `extractValue()` returns undefined the `match` value should be returned which fixes the crash.