### PR TITLE
normal function expression instead of => function

### DIFF
--- a/modules/fuse-box-responsive-api/dev-imports.js
+++ b/modules/fuse-box-responsive-api/dev-imports.js
@@ -67,7 +67,7 @@ var $fsmp$ = (function() {
 
     return function(id) {
 
-        return new Promise((resolve, reject) => {
+        return new Promise(function(resolve, reject) {
             if (FuseBox.exists(id)) {
                 return resolve(FuseBox.import(id));
             }


### PR DESCRIPTION
It will with normal fn support IE11, which now throws Syntax error because of => function.