### PR TITLE
fix: data URLs handling in CSSResourcePlugin

### DIFF
--- a/src/lib/CSSUrlParser.ts
+++ b/src/lib/CSSUrlParser.ts
@@ -24,7 +24,7 @@ export class CSSUrlParser {
                 return match;
             }
             
-            const replaced = fn(value);
+            const replaced = value && fn(value);
             if (typeof replaced === "string") {
                 return `url("${replaced}")`
             } else {


### PR DESCRIPTION
Not sure how it really supposed to work in such cases, but without this check it fails with 

```
TypeError: Cannot read property 'startsWith' of undefined
    at walker (fuse-box\plugins\stylesheet\CSSResourcePlugin.js:104:21)
    at contents.replace (fuse-box\lib\CSSUrlParser.js:24:30)
    at String.replace (<anonymous>)
    at Function.walk (fuse-box\lib\CSSUrlParser.js:22:25)
    at CSSResourcePluginClass.transform (fuse-box\plugins\stylesheet\CSSResourcePlugin.js:160:53)
    ...
```