### PR TITLE
Catching typescript transpilation errors

### DIFF
--- a/src/core/File.ts
+++ b/src/core/File.ts
@@ -612,7 +612,12 @@ export class File {
     public transpileUsingTypescript(){
         try {
             const ts = require("typescript");
-            return ts.transpileModule(this.contents, this.getTranspilationConfig());
+	    try {
+                return ts.transpileModule(this.contents, this.getTranspilationConfig());
+	    } catch(e) {
+	        this.context.fatal(`${this.info.absPath}: ${e}`);
+                return;
+	    }
         } catch(e){
             this.context.fatal('You need TypeScript installed to transpile modules automatically');
             return;


### PR DESCRIPTION
Outputs any errors that occur during transpilation and shows the file where they happened.

Did not test this, just edited the file here directly on github. 