### PR TITLE
Fix error on VueComponentPlugin and optimize plugins on electron

### DIFF
--- a/modules/fuse-box-loader-api/fusebox.js
+++ b/modules/fuse-box-loader-api/fusebox.js
@@ -1,7 +1,7 @@
 (function(__root__){
 if (__root__["FuseBox"]) return __root__["FuseBox"];
 var $isWebWorker = typeof WorkerGlobalScope !== "undefined";
-var $isBrowser = typeof window !== "undefined" && window.navigator || $isWebWorker;
+var $isBrowser = typeof window !== "undefined" && typeof window.navigator !== "undefined" || $isWebWorker;
 var g = $isBrowser ? ($isWebWorker ? {} : window) : global;
 if ($isBrowser) {
     g["global"] = $isWebWorker ? {} : window;

--- a/src/BundleSource.ts
+++ b/src/BundleSource.ts
@@ -62,6 +62,20 @@ export class BundleSource {
      */
     public init() {
         this.concat.add(null, "(function(FuseBox){FuseBox.$fuse$=FuseBox;");
+
+        // handle server bundle
+        if (this.context.target) {
+            this.concat.add(null, `FuseBox.target = "${this.context.target}"`);
+        }
+
+        if (this.context.serverBundle) {
+            this.concat.add(null, `FuseBox.isServer = true;`);
+        }
+
+        if (this.context.fuse.producer && this.context.fuse.producer.allowSyntheticDefaultImports) {
+            this.concat.add(null, `// allowSyntheticDefaultImports`);
+            this.concat.add(null, `FuseBox.sdep = true`);
+        }
     }
 
     public annotate(comment: string) {
@@ -190,19 +204,6 @@ ${file.headerContent ? file.headerContent.join("\n") : ""}`);
 
         let mainEntry;
 
-        // handle server bundle
-        if (this.context.target) {
-            this.concat.add(null, `FuseBox.target = "${this.context.target}"`);
-        }
-
-        if (context.serverBundle) {
-            this.concat.add(null, `FuseBox.isServer = true;`);
-        }
-
-        if ( context.fuse.producer && context.fuse.producer.allowSyntheticDefaultImports ){
-            this.concat.add(null, `// allowSyntheticDefaultImports`);
-            this.concat.add(null, `FuseBox.sdep = true`);
-        }
         // writing other bundles info
         if (this.bundleInfoObject) {
             this.concat.add(null, `FuseBox.global("__fsbx__bundles__",${JSON.stringify(this.bundleInfoObject)})`);

--- a/src/core/WorkflowContext.ts
+++ b/src/core/WorkflowContext.ts
@@ -553,6 +553,8 @@ export class WorkFlowContext {
         if (this.target === "electron") {
             return isElectronPolyfill(name)
         }
+
+        return false
     }
 
     public resetNodeModules() {

--- a/src/plugins/EnvPlugin.ts
+++ b/src/plugins/EnvPlugin.ts
@@ -19,6 +19,8 @@ export class EnvPluginClass implements Plugin {
         }
         if (context.target === "server"){
             context.source.addContent(`Object.assign(process.env, ${JSON.stringify(this.env)})`);
+        } else if (context.target === "electron") {
+          context.source.addContent(`Object.assign(global.process.env, ${JSON.stringify(this.env)})`);
         } else {
             context.source.addContent(`var __process_env__ = ${JSON.stringify(this.env)};`);
         }

--- a/src/plugins/vue/VuePlugin.ts
+++ b/src/plugins/vue/VuePlugin.ts
@@ -94,10 +94,11 @@ export class VueComponentClass implements Plugin {
 
   public bundleEnd(context: WorkFlowContext) {
     if (context.useCache && this.hasProcessedVueFile) {
-      context.source.addContent(`
-        var process = FuseBox.import('process');
-
-        if (process.env.NODE_ENV !== "production") {
+      const haveGlobal = context.isGlobalyIgnored('process')
+      const process = haveGlobal ? 'global.process' : 'process'
+      const importProcess = haveGlobal ? '' : 'var process = FuseBox.import(\'process\');\n\n'
+      context.source.addContent(`${importProcess}
+        if (${process}.env.NODE_ENV !== "production") {
           var api = FuseBox.import('vue-hot-reload-api');
           var Vue = FuseBox.import('vue');
 
@@ -261,16 +262,17 @@ export class VueComponentClass implements Plugin {
     }
 
     if (file.context.useCache) {
-      concat.add(null, `
-        var process = FuseBox.import('process');
-
-        if (process.env.NODE_ENV !== "production") {
+      const haveGlobal = file.context.isGlobalyIgnored('process')
+      const process = haveGlobal ? 'global.process' : 'process'
+      const importProcess = haveGlobal ? '' : 'var process = FuseBox.import(\'process\');\n\n'
+      concat.add(null, `${importProcess}
+        if (${process}.env.NODE_ENV !== "production") {
           var api = require('vue-hot-reload-api');
 
-          process.env.vueHMR = process.env.vueHMR || {};
+          ${process}.env.vueHMR = process.env.vueHMR || {};
 
-          if (!process.env.vueHMR['${moduleId}']) {
-            process.env.vueHMR['${moduleId}'] = true;
+          if (!${process}.env.vueHMR['${moduleId}']) {
+            ${process}.env.vueHMR['${moduleId}'] = true;
             api.createRecord('${moduleId}', module.exports.default);
           }
         }

--- a/src/plugins/vue/VuePlugin.ts
+++ b/src/plugins/vue/VuePlugin.ts
@@ -94,9 +94,9 @@ export class VueComponentClass implements Plugin {
 
   public bundleEnd(context: WorkFlowContext) {
     if (context.useCache && this.hasProcessedVueFile) {
-      const haveGlobal = context.isGlobalyIgnored('process')
-      const process = haveGlobal ? 'global.process' : 'process'
-      const importProcess = haveGlobal ? '' : 'var process = FuseBox.import(\'process\');\n\n'
+      const hasGlobal = context.isGlobalyIgnored('process')
+      const process = hasGlobal ? 'global.process' : 'process'
+      const importProcess = hasGlobal ? '' : 'var process = FuseBox.import(\'process\');\n\n'
       context.source.addContent(`${importProcess}
         if (${process}.env.NODE_ENV !== "production") {
           var api = FuseBox.import('vue-hot-reload-api');
@@ -262,17 +262,14 @@ export class VueComponentClass implements Plugin {
     }
 
     if (file.context.useCache) {
-      const haveGlobal = file.context.isGlobalyIgnored('process')
-      const process = haveGlobal ? 'global.process' : 'process'
-      const importProcess = haveGlobal ? '' : 'var process = FuseBox.import(\'process\');\n\n'
+      const hasGlobal = file.context.isGlobalyIgnored('process')
+      const process = hasGlobal ? 'global.process' : 'process'
+      const importProcess = hasGlobal ? '' : 'var process = FuseBox.import(\'process\');\n\n'
       concat.add(null, `${importProcess}
         if (${process}.env.NODE_ENV !== "production") {
           var api = require('vue-hot-reload-api');
 
-          ${process}.env.vueHMR = process.env.vueHMR || {};
-
-          if (!${process}.env.vueHMR['${moduleId}']) {
-            ${process}.env.vueHMR['${moduleId}'] = true;
+          if (__VUE_HOT_MAP__ && !__VUE_HOT_MAP__['${moduleId}']) {
             api.createRecord('${moduleId}', module.exports.default);
           }
         }


### PR DESCRIPTION
Hello, i have fix error on VueComponentPlugin and optimize plugins on electron.

Changes :
-  Fix error "Uncaught Package not found process" when use VueComponentPlugin in development.
This error is produced because VueComponentPlugin call `FuseBox.import("process")` before define `FuseBox.target`.

    This fix, fix probably other bugs when we need falls functions before `FuseBox.target`, `FuseBox.isServer` and `FuseBox.sdep`.
    For fix that i have just move this lines to start bundle.
- Add verry small memory save on FuseBox loader when check if is browser (variable : `$isBrowser`). This variable now store only boolean and not reference to `window.navigator`
- Optimize VueComponentPlugin when running on electron or server.
For this, i have replace `FuseBox.import('process')` by `global.process`.
And i have replace `process.env.vueHMR` by `__VUE_HOT_MAP__` (this is temporary because i wait this PR is accepted https://github.com/vuejs/vue-hot-reload-api/pull/66)
This is fix a bug when is runned on electron because the vueHMR is string serialized.
- Optimize EnvPlugin when running on electron.
For this i have replace variable `__process_env__` by directly `global.process.env`, like server.

Thanks for your work !