### PR TITLE
Fix the scoped selector for vue

### DIFF
--- a/src/plugins/vue/PostCSSPlugins.ts
+++ b/src/plugins/vue/PostCSSPlugins.ts
@@ -47,7 +47,7 @@ export const AddScopeIdPlugin = postcss.plugin('add-scope-id', function (opts) {
             attribute: opts.id
           }))
         })
-      }).process(node.selector).result
+      }).processSync(node.selector)
     })
 
     // If keyframes are found in this <style>, find and rewrite animation names


### PR DESCRIPTION
Hello, the implementation for `postcss-selector-parser` on [PostCSSPlugin#50](https://github.com/fuse-box/fuse-box/blob/master/src/plugins/vue/PostCSSPlugins.ts#L50) is wrong.

I have fix the `undefined` selector with that.