### PR TITLE
Fix postCSS error "without 'from' option"

### DIFF
--- a/src/plugins/vue/VueStyleFile.ts
+++ b/src/plugins/vue/VueStyleFile.ts
@@ -26,7 +26,8 @@ export class VueStyleFile extends VueBlockFile {
     ];
 
     return postcss(plugins).process(this.contents, {
-      map: false
+      map: false,
+      from: this.file.info.absPath
     }).then((result) => {
       this.contents = result.css;
     });


### PR DESCRIPTION
Hello, i have fix this error: `Without 'from' option PostCSS could generate wrong source map and will not find
Browserslist config. Set it to CSS file path or to `undefined` to prevent this w
arning.`