### PR TITLE
Update the condition for vue HMR

### DIFF
--- a/src/plugins/vue/VuePlugin.ts
+++ b/src/plugins/vue/VuePlugin.ts
@@ -269,7 +269,7 @@ export class VueComponentClass implements Plugin {
         if (${process}.env.NODE_ENV !== "production") {
           var api = require('vue-hot-reload-api');
 
-          if (__VUE_HOT_MAP__ && !__VUE_HOT_MAP__['${moduleId}']) {
+          if (api && !api.isRecorded('${moduleId}')) {
             api.createRecord('${moduleId}', module.exports.default);
           }
         }


### PR DESCRIPTION
Hello, i have add function `isRecorded` on vue-hot-reload-api ([this PR](https://github.com/vuejs/vue-hot-reload-api/pull/66)).

Now the VueComponentPlugin require `vue-hot-reload-api@^2.3.0`.


I have two question, would not it be better to add plugin dependencies in `peerDependencies`.
Do you want replace `ws` lib by `uws` for have more performance on HMR and less dependencies. 
End for end, the `watch` dependencies is not used ?
Yep i search how to reduce dependencies size :)

Thanks.