### PR TITLE
feat(languagelevel): adds template literal as identifier of ES2015

### DIFF
--- a/src/analysis/plugins/LanguageLevel.ts
+++ b/src/analysis/plugins/LanguageLevel.ts
@@ -10,6 +10,8 @@ export class LanguageLevel {
             file.setLanguageLevel(ScriptTarget.ES2015);
         } else if (node.type === "ArrowFunctionExpression") {
             file.setLanguageLevel(ScriptTarget.ES2015);
+        } else if (node.type === "TemplateLiteral") {
+            file.setLanguageLevel(ScriptTarget.ES2015);
         }
     }
     public static onEnd(file: File) {


### PR DESCRIPTION
Code containing template literal now correctly idenfied as ES2015