### PR TITLE
fix: Allow postcss `to` to be overridden by options given to the plugin

### DIFF
--- a/src/plugins/stylesheet/PostCSSPlugin.ts
+++ b/src/plugins/stylesheet/PostCSSPlugin.ts
@@ -81,7 +81,7 @@ export class PostCSSPluginClass implements Plugin {
             fromFile = fromFile.slice(1)
         }
         postCssOptions.from = postCssOptions.from || file.info.absPath;
-        postCssOptions.to = fromFile
+        postCssOptions.to = postCssOptions.to || fromFile;
         return postcss(this.processors)
             .process(file.contents, postCssOptions)
             .then(result => {


### PR DESCRIPTION
Currently the `to` options given to postcss is set to be the same as `from`.  This is ok in many situations, but in some situations you want to be able to set it manually; specifically when using plugins that move and rebase stuff (e.g. `postcss-url`, `postcss-copy-assets` and others).