### PR TITLE
add source-map to package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "regexpu-core": "^4.1.3",
     "request": "^2.79.0",
     "shorthash": "0.0.2",
+    "source-map": "^0.7.1", 
     "tslib": "^1.8.0",
     "watch": "^1.0.1",
     "ws": "^1.1.1",


### PR DESCRIPTION
Here's the error message

```
Error: Cannot find module 'source-map'
    at Function.Module._resolveFilename (module.js:538:15)
    at Function.Module._load (module.js:468:25)
    at Module.require (module.js:587:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (...\node_modules\fuse-box\core\SourceMapGenerator.js:4:19)
    at Module._compile (module.js:643:30)
    at Object.Module._extensions..js (module.js:654:10)
    at Module.load (module.js:556:32)
    at tryModuleLoad (module.js:499:12)
    at Function.Module._load (module.js:491:3)
```