### PR TITLE
fix: Support tsconfig.json with comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "wires-reactive": "^1.1.1"
   },
   "dependencies": {
+    "@types/comment-json": "^1.1.1",
     "acorn": "^5.1.2",
     "acorn-jsx": "^4.0.1",
     "ansi": "^0.3.1",
@@ -75,6 +76,7 @@
     "base64-js": "^1.2.0",
     "chokidar": "^1.6.1",
     "clean-css": "^4.1.9",
+    "comment-json": "^1.1.3",
     "escodegen": "^1.8.1",
     "express": "^4.14.0",
     "fliplog": "^0.3.13",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/fuse-box/fuse-box#readme",
   "devDependencies": {
+    "@types/comment-json": "^1.1.1",
     "@types/node": "^6.0.74",
     "cheerio": "^0.22.0",
     "commitizen": "^2.9.6",
@@ -67,7 +68,6 @@
     "wires-reactive": "^1.1.1"
   },
   "dependencies": {
-    "@types/comment-json": "^1.1.1",
     "acorn": "^5.1.2",
     "acorn-jsx": "^4.0.1",
     "ansi": "^0.3.1",

--- a/src/core/TypescriptConfig.ts
+++ b/src/core/TypescriptConfig.ts
@@ -4,6 +4,7 @@ import { ensureUserPath, findFileBackwards } from "../Utils";
 import { ScriptTarget } from "./File";
 import * as fs from "fs";
 import { Config } from "../Config";
+import * as json from 'comment-json';
 
 const CACHED: { [path: string]: any } = {};
 
@@ -86,7 +87,7 @@ export class TypescriptConfig {
             if (configFile) {
                 this.context.log.echoInfo(`Typescript config file:  ${configFile.replace(this.context.appRoot, "")}`);
                 configFileFound = true;
-                config = require(configFile);
+                config = json.parse(fs.readFileSync(configFile).toString());
             }
 
 


### PR DESCRIPTION
I was having issues using the default `tsconfig.json` provided by `tsc --init`. This file includes comments which are not support by NodeJS's default JSON parser. I've switched to an alternative parser to support JSON comments.