### PR TITLE
feat: log option now takes an object

### DIFF
--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -96,17 +96,39 @@ fuse.bundle("app")
     .instructions("> index.ts")
 ```
 
-## Debug and Log
-Additional logging and debugging can be enabled, but keep in mind they can reduce performance.
+## Debug
+
+Additional debugging can be enabled, but keep in mind they can reduce performance.
 ```js
 const fuse = FuseBox.init({
   homeDir: "src",
   output: "build/$name.js",
-  log: true,
   debug: true
 })
 ```
 
+## Log
+
+Log output can be customized using the `log` option:
+```js
+const fuse = FuseBox.init({
+  log: {
+      showBundledFiles: false, // Don't list all the bundled files every time we bundle
+      clearTerminalOnBundle: true, // Clear the terminal window every time we bundle
+  }
+})
+```
+
+These options are useful for seeing only the things you are interested in when developing incrementally using `.watch`.
+
+You can also disable logging completely:
+```js
+const fuse = FuseBox.init({
+  log: {
+      enabled: false
+  }
+})
+```
 
 ## Custom modules folder
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Fuse-Box a bundler that does it right",
   "typings": "index.d.ts",
   "main": "index.js",
-  "bin" : { "fuse" : "./cli/entry.js" },
+  "bin": {
+    "fuse": "./cli/entry.js"
+  },
   "scripts": {
     "help": "node bin/fsbx --help",
     "test": "cross-env FUSE_TEST_TIMEOUT=5000 node ./test.js",
@@ -87,6 +89,7 @@
     "ieee754": "^1.1.8",
     "inquirer": "^3.0.6",
     "lego-api": "^1.0.7",
+    "less": "^3.0.1",
     "mustache": "^2.3.0",
     "postcss": "^6.0.1",
     "pretty-time": "^0.2.0",

--- a/src/Log.ts
+++ b/src/Log.ts
@@ -60,12 +60,13 @@ export class Indenter {
 export class Log {
     public timeStart = process.hrtime();
     public printLog: any = true;
+    public showBundledFiles: boolean = true;
     public debugMode: any = false;
     public spinner: any;
     public indent: Indenter = new Indenter();
     private totalSize = 0;
     private static deferred: Function[] = [];
-    public static defer (fn: Function) {
+    public static defer(fn: Function) {
         Log.deferred.push(fn)
     }
 
@@ -142,6 +143,10 @@ export class Log {
         // }
         // this.indent.indent(-2)
         return this;
+    }
+
+    public clearTerminal() {
+        console.log('\x1Bc');
     }
 
     // --- start end ---
@@ -230,14 +235,16 @@ export class Log {
 
         // @example └──  (5 files, 7.6 kB) default
         // @TODO auto indent as with ansi
-        collection.dependencies.forEach(file => {
-            if (file.info.isRemoteFile) { return; }
-            const indent = this.indent.level(4).toString()
-            log
-                // .tags('filelist')
-                .white(`${indent}${file.info.fuseBoxPath}`)
-                .echo()
-        });
+        if (this.showBundledFiles) {
+            collection.dependencies.forEach(file => {
+                if (file.info.isRemoteFile) { return; }
+                const indent = this.indent.level(4).toString()
+                log
+                    // .tags('filelist')
+                    .white(`${indent}${file.info.fuseBoxPath}`)
+                    .echo()
+            });
+        }
 
         log
             .ansi()
@@ -333,7 +340,7 @@ export class Log {
         return this;
     }
 
-    public echoSparkyTaskEnd(taskName, took: [number, number]){
+    public echoSparkyTaskEnd(taskName, took: [number, number]) {
         const gray = log.chalk().gray;
         const magenta = log.chalk().magenta;
         let str = ['[', gray(getDateTime()), ']', ' Resolved']

--- a/src/core/FuseBox.ts
+++ b/src/core/FuseBox.ts
@@ -37,7 +37,7 @@ export interface FuseBoxOptions {
      * default: "universal@es5"
      */
     target?: string,
-    log?: boolean;
+    log?: { enabled?: boolean, showBundledFiles?: boolean, clearTerminalOnBundle?: boolean };
     globals?: { [packageName: string]: /** Variable name */ string };
     plugins?: Array<Plugin | Plugin[]>;
     autoImport?: any;
@@ -213,8 +213,17 @@ export class FuseBox {
             this.context.filterFile = opts.filterFile;
         }
 
+        if (opts.log) {
+            if (opts.log.enabled) {
+                this.context.doLog = opts.log.enabled;
+                this.context.log.printLog = opts.log.enabled;
+            }
+
+            this.context.log.showBundledFiles = opts.log.showBundledFiles;
+        }
+
         if (opts.log !== undefined) {
-            this.context.doLog = opts.log;
+            this.context.doLog = true;
             this.context.log.printLog = opts.log;
         }
 
@@ -352,6 +361,11 @@ export class FuseBox {
     }
 
     public process(bundleData: BundleData, bundleReady?: () => any) {
+        // If clearTerminalOnBundle is turned on then clear the terminal each time we bundle
+        if (this.opts.log && this.opts.log.clearTerminalOnBundle) {
+            this.context.log.clearTerminal();
+        }
+
         let bundleCollection = new ModuleCollection(this.context, this.context.defaultPackageName);
         bundleCollection.pm = new PathMaster(this.context, bundleData.homeDir);
         // swiching on typescript compiler
@@ -372,7 +386,6 @@ export class FuseBox {
                 public defaultContents: string;
                 public globalContents = [];
                 public setDefaultCollection() {
-
                     return bundleCollection;
                 }
 

--- a/src/quantum/plugin/BundleWriter.ts
+++ b/src/quantum/plugin/BundleWriter.ts
@@ -45,7 +45,7 @@ export class BundleWriter {
                 if (item.source) {
                     let shimPath = ensureUserPath(item.source);
                     if (!fs.existsSync(shimPath)) {
-                        console.warn(`Shim erro: Not found: ${shimPath}`);
+                        console.warn(`Shim error: Not found: ${shimPath}`);
                     } else {
                         shims.push(fs.readFileSync(shimPath).toString())
                     }
@@ -68,7 +68,7 @@ export class BundleWriter {
             throw result.error;
         }
         bundle.generatedCode = result.code;
-        this.core.log.echoInfo(`Done Uglifying ${bundle.name}`)
+        this.core.log.echoInfo(`Done uglifying ${bundle.name}`)
         this.core.log.echoGzip(result.code);
     }
 
@@ -98,7 +98,7 @@ export class BundleWriter {
             splitFileOptions = {
                 c: {
                     b: splitConf.getBrowserPath(),
-                    s:  splitConf.getServerPath()},
+                    s: splitConf.getServerPath()},
                 i: {}
             };
             this.core.api.setBundleMapping(splitFileOptions);


### PR DESCRIPTION
Adds some useful logging options.  Note that this is not backwards compatible, so anyone using `log: true` or `log: false` will need to change their config or will get a type error.