### PR TITLE
fix error when tsconfig.json has trailing commas

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Fuse-Box a bundler that does it right",
   "typings": "index.d.ts",
   "main": "index.js",
-  "bin" : { "fuse" : "./cli/entry.js" },
+  "bin": {
+    "fuse": "./cli/entry.js"
+  },
   "scripts": {
     "help": "node bin/fsbx --help",
     "test": "cross-env FUSE_TEST_TIMEOUT=5000 node ./test.js",
@@ -31,7 +33,6 @@
   },
   "homepage": "https://github.com/fuse-box/fuse-box#readme",
   "devDependencies": {
-    "@types/comment-json": "^1.1.1",
     "@types/node": "^6.0.74",
     "cheerio": "^0.22.0",
     "commitizen": "^2.9.6",
@@ -77,7 +78,6 @@
     "base64-js": "^1.2.0",
     "chokidar": "^1.6.1",
     "clean-css": "^4.1.9",
-    "comment-json": "^1.1.3",
     "escodegen": "^1.8.1",
     "express": "^4.14.0",
     "fliplog": "^0.3.13",

--- a/src/core/TypescriptConfig.ts
+++ b/src/core/TypescriptConfig.ts
@@ -4,7 +4,7 @@ import { ensureUserPath, findFileBackwards } from "../Utils";
 import { ScriptTarget } from "./File";
 import * as fs from "fs";
 import { Config } from "../Config";
-import * as json from 'comment-json';
+import * as ts from "typescript";
 
 const CACHED: { [path: string]: any } = {};
 
@@ -85,9 +85,14 @@ export class TypescriptConfig {
                 }
             }
             if (configFile) {
-                this.context.log.echoInfo(`Typescript config file:  ${configFile.replace(this.context.appRoot, "")}`);
+                const configFileRelPath = configFile.replace(this.context.appRoot, "");
+                this.context.log.echoInfo(`Typescript config file:  ${configFileRelPath}`);
                 configFileFound = true;
-                config = json.parse(fs.readFileSync(configFile).toString());
+                const res = ts.readConfigFile(configFile, (p) => fs.readFileSync(p).toString());
+                config = res.config;
+                if (res.error) {
+                    this.context.log.echoError(`Errors in ${configFileRelPath}`);
+                }
             }
 
 


### PR DESCRIPTION
Right now fuse-fox fails if tsconfig.json has trailing commas, which is valid, because of the use of the library comment-json that doesn't support it.
But theres no need to use a library because typescript api provides a method.