### PR TITLE
Possibility to shape how bundles are emited

### DIFF
--- a/src/plugins/WebIndexPlugin.ts
+++ b/src/plugins/WebIndexPlugin.ts
@@ -21,6 +21,7 @@ export interface IndexPluginOptions {
     async?: boolean;
     pre?: { relType: 'fetch' | 'load' };
     resolve?: { (output: UserOutput): string };
+    emitBundles?: (bundles: string[]) => string;
 }
 export class WebIndexPluginClass implements Plugin {
     constructor(public opts?: IndexPluginOptions) {
@@ -83,9 +84,9 @@ $bundles
             }
         }
 
-        let jsTags = bundlePaths.map(bundle =>
-            `<script ${this.opts.async ? 'async' : ''} type="text/javascript" src="${bundle}"></script>`
-        ).join("\n");
+        let jsTags = this.opts.emitBundles
+            ? this.opts.emitBundles(bundlePaths)
+            : bundlePaths.map(bundle => `<script ${this.opts.async ? 'async' : ''} type="text/javascript" src="${bundle}"></script>`).join('\n');
 
         let preloadTags;
         if (this.opts.pre) {


### PR DESCRIPTION
I have a scenario in which I am only loading JS if I am on a specific browser, supporting ES6 with async await. For all other browsers I am disabling the app. It is a corporate app so don't judge.

I can now do:

```html
<script type="text/javascript">
            function isGeneratorSupported() {
                try {
                    eval('(function*(){})()');
                    return true;
                } catch (err) {
                    return false;
                }
            }
            let c = document.getElementById('hiddenContent');
            if (!isGeneratorSupported() || /MSIE \d|Trident.*rv:/.test(navigator.userAgent)) {
                c.style.display = 'block';
            } else {
                $bundles
            } 
        </script>
```

and

```js
WebIndexPlugin({
        template: 'src/client/index.html',
        emitBundles: bundles =>
          bundles
            .map(b => `document.write('<script type="text/javascript" src="${b}"><\\/script>');`)
            .join('\n')
      }),
```