### PR TITLE
Added the $css macro in custom template

### DIFF
--- a/docs/plugins/html/WebIndexPlugin.md
+++ b/docs/plugins/html/WebIndexPlugin.md
@@ -55,5 +55,6 @@ A custom template has the following macro available:
 | ------------- | ------------- |
 | ` $title `   | Html Title  |
 | ` $bundles `   | A list of script tags |
+| ` $css `   | A list of styles tags |
 
 github_example: vendor-splitting


### PR DESCRIPTION
The $css macro was missing in the doc.