### PR TITLE
 feat: sorted bundle sources

### DIFF
--- a/src/Log.ts
+++ b/src/Log.ts
@@ -230,7 +230,8 @@ export class Log {
 
         // @example └──  (5 files, 7.6 kB) default
         // @TODO auto indent as with ansi
-        collection.dependencies.forEach(file => {
+        const dependencies = new Map(Array.from(collection.dependencies).sort());
+        dependencies.forEach(file => {
             if (file.info.isRemoteFile) { return; }
             const indent = this.indent.level(4).toString()
             log

--- a/src/Log.ts
+++ b/src/Log.ts
@@ -4,18 +4,18 @@ import * as log from "fliplog";
 import * as prettysize from "prettysize";
 import * as  prettyTime from "pretty-time";
 import * as zlib from "zlib";
-import { getDateTime } from './Utils';
+import { getDateTime } from "./Utils";
 
 // @TODO: I've moved this into fliplog in v1, migrate to that
 export class Indenter {
-    public store: Map<string, any> = new Map()
+    public store: Map<string, any> = new Map();
     constructor() {
-        this.set('indent', 0);
+        this.set("indent", 0);
     }
 
     // easy set/set
     public set(key: string, val: any): Indenter {
-        this.store.set(key, val)
+        this.store.set(key, val);
         return this;
     }
     public get(key: string) {
@@ -23,7 +23,7 @@ export class Indenter {
     }
     // back to 0
     public reset(): Indenter {
-        return this.set('indent', 0);
+        return this.set("indent", 0);
     }
     // tap value
     public tap(key: string, cb: Function): Indenter {
@@ -32,22 +32,22 @@ export class Indenter {
     }
     // increment
     public indent(level: number): Indenter {
-        return this.tap('indent', indent => indent + level);
+        return this.tap("indent", indent => indent + level);
     }
     // specific number
     public level(level: number): Indenter {
-        return this.set('indent', level);
+        return this.set("indent", level);
     }
     // string repeat indent
     public toString(): string {
-        return ' '.repeat(this.get('indent'))
+        return " ".repeat(this.get("indent"));
     }
     public toNumber(): number {
-        return this.get('indent');
+        return this.get("indent");
     }
     public [Symbol.toPrimitive](hint: string) {
-        if (hint === 'number') { return this.toNumber(); }
-        return this.toString();;
+        if (hint === "number") { return this.toNumber(); }
+        return this.toString();
     }
 }
 
@@ -58,46 +58,47 @@ export class Indenter {
  * - [ ] fix the →→→→→→→
  */
 export class Log {
+    public static defer(fn: Function) {
+        Log.deferred.push(fn);
+    }
+    private static deferred: Function[] = [];
+
     public timeStart = process.hrtime();
     public printLog: any = true;
     public debugMode: any = false;
     public spinner: any;
     public indent: Indenter = new Indenter();
     private totalSize = 0;
-    private static deferred: Function[] = [];
-    public static defer (fn: Function) {
-        Log.deferred.push(fn)
-    }
 
     constructor(public context: WorkFlowContext) {
         this.printLog = context.doLog;
         this.debugMode = context.debugMode;
 
-        log.filter((arg) => {
+        log.filter(arg => {
             // conditions for filtering specific tags
-            const debug = this.debugMode
-            const level = this.printLog
+            const debug = this.debugMode;
+            const level = this.printLog;
             const hasTag = tag =>
-                arg.tags.includes(tag)
+                arg.tags.includes(tag);
             const levelHas = tag =>
-                debug || (level && level.includes && level.includes(tag) && !level.includes('!' + tag));
+                debug || (level && level.includes && level.includes(tag) && !level.includes("!" + tag));
 
 
             // when off, silent
-            if (level === false) return false;
+            if (level === false) { return false; }
 
             // counting this as verbose for now
             if (level === true && debug === true) { return null; }
 
-            if (level == 'error') {
-                if (!hasTag('error')) { return false; }
+            if (level === "error") {
+                if (!hasTag("error")) { return false; }
             }
             // could be verbose, reasoning, etc
-            if (hasTag('magic')) {
-                if (!levelHas('magic')) { return false; }
+            if (hasTag("magic")) {
+                if (!levelHas("magic")) { return false; }
             }
-            if (hasTag('filelist')) {
-                if (!levelHas('filelist')) { return false; }
+            if (hasTag("filelist")) {
+                if (!levelHas("filelist")) { return false; }
             }
 
             // if not false and conditions pass, log it
@@ -106,10 +107,10 @@ export class Log {
 
         setTimeout(() => {
             if (this.printLog) {
-                Log.deferred.forEach(x => x(this))
+                Log.deferred.forEach(x => x(this));
             }
-            Log.deferred = []
-        })
+            Log.deferred = [];
+        });
     }
     // --- config ---
 
@@ -120,21 +121,21 @@ export class Log {
         return this;
     }
     public printOptions(title: string, obj: any) {
-        let indent = this.indent.level(2) + '';;
+        const indent = this.indent.level(2) + "";
 
-        let indent2 = this.indent.level(4) + '';;
+        const indent2 = this.indent.level(4) + "";
 
         // @TODO: moved this into fliplog v1, migrate
-        log.addPreset('min', instance => {
+        log.addPreset("min", instance => {
             instance.formatter(data => {
-                return log.inspector()(data).split('\n')
-                    .map(data => indent2 + data)
-                    .map(data => data.replace(/[{},]/, ''))
-                    .join('\n');;
+                return log.inspector()(data).split("\n")
+                    .map(data2 => indent2 + data2)
+                    .map(data2 => data2.replace(/[{},]/, ""))
+                    .join("\n");
             });
         });
 
-        log.bold().yellow(`${indent}→ ${title}\n`).preset('min').data(obj).echo();
+        log.bold().yellow(`${indent}→ ${title}\n`).preset("min").data(obj).echo();
 
         // for (let i in obj) {
         //     indent = this.indent.level(6) + ''
@@ -160,7 +161,7 @@ export class Log {
         return this;
     }
     public bundleEnd(name: string, collection: ModuleCollection) {
-        let took = process.hrtime(this.timeStart) as [number, number];
+        const took = process.hrtime(this.timeStart) as [number, number];
 
         log
             .ansi()
@@ -178,12 +179,12 @@ export class Log {
         const indentStr = this.indent.toString();
         const indent = +this.indent;
         const interval = 20;
-        const frames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'].map(frame => indentStr + frame);
+        const frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"].map(frame => indentStr + frame);
         const spinner = { frames, interval };
 
         // @TODO @FIXME the spinner needs to be scoped inside of fliplog, has todo to update
         // instantiate
-        this.spinner = log.requirePkg('ora')({ text, indent, spinner });
+        this.spinner = log.requirePkg("ora")({ text, indent, spinner });
         this.spinner.start();
         this.spinner.indent = +this.indent;
         this.spinner.succeeded = false;
@@ -191,7 +192,7 @@ export class Log {
         // safety for if errors happen so it does not keep spinning
         setTimeout(() => {
             if (this.spinner.succeeded === false && this.spinner.fail) {
-                this.spinner.fail();;
+                this.spinner.fail();
             }
         }, 1000);
 
@@ -221,9 +222,9 @@ export class Log {
 
     // @TODO: list vendor files as filter
     public echoDefaultCollection(collection: ModuleCollection, contents: string) {
-        if (this.printLog === false) return this;
-        let bytes = Buffer.byteLength(contents, "utf8");
-        let size = prettysize(bytes);
+        if (this.printLog === false) { return this; }
+        const bytes = Buffer.byteLength(contents, "utf8");
+        const size = prettysize(bytes);
         this.totalSize += bytes;
 
         const indent = this.indent.reset().indent(+1).toString();
@@ -233,11 +234,11 @@ export class Log {
         const dependencies = new Map(Array.from(collection.dependencies).sort());
         dependencies.forEach(file => {
             if (file.info.isRemoteFile) { return; }
-            const indent = this.indent.level(4).toString()
+            const indentItem = this.indent.level(4).toString();
             log
                 // .tags('filelist')
-                .white(`${indent}${file.info.fuseBoxPath}`)
-                .echo()
+                .white(`${indentItem}${file.info.fuseBoxPath}`)
+                .echo();
         });
 
         log
@@ -256,8 +257,8 @@ export class Log {
     // └── lodash 14.2 kB (12 files)
     public echoCollection(collection: ModuleCollection, contents: string) {
         if (this.printLog === false) { return this; }
-        let bytes = Buffer.byteLength(contents, "utf8");
-        let size = prettysize(bytes);
+        const bytes = Buffer.byteLength(contents, "utf8");
+        const size = prettysize(bytes);
         this.totalSize += bytes;
         const indent = this.indent.toString(); // reset
 
@@ -275,7 +276,7 @@ export class Log {
     }
 
     public end(header?: string) {
-        let took = process.hrtime(this.timeStart) as [number, number];
+        const took = process.hrtime(this.timeStart) as [number, number];
         this.echoBundleStats(header || "Bundle", this.totalSize, took);
         return this;
     }
@@ -286,18 +287,18 @@ export class Log {
      *
      * string | number | Buffer
      */
-    public echoGzip(size: any, msg: string | any = '') {
-        if (!size) return this;
+    public echoGzip(size: any, msg: string | any = "") {
+        if (!size) { return this; }
         const yellow = log.chalk().yellow;
         const gzipped = zlib.gzipSync(size, { level: 9 }).length;
-        const gzippedSize = prettysize(gzipped) + ' (gzipped)';
+        const gzippedSize = prettysize(gzipped) + " (gzipped)";
         const compressedSize = prettysize(size.length);
         const prettyGzip = yellow(`${compressedSize}, ${gzippedSize}`);
         log
-            .title(this.indent + '')
+            .title(this.indent + "")
             .when(msg,
             () => log.text(msg),
-            () => log.bold('size: '))
+            () => log.bold("size: "))
             .data(prettyGzip)
             .echo();
         return this;
@@ -328,19 +329,19 @@ export class Log {
     public echoSparkyTaskStart(taskName: string) {
         const gray = log.chalk().gray;
         const magenta = log.chalk().magenta;
-        let str = ['[', gray(getDateTime()), ']', ' Starting']
-        str.push(` '${magenta(taskName)}' `)
-        console.log(str.join(''));
+        const str = ["[", gray(getDateTime()), "]", " Starting"];
+        str.push(` '${magenta(taskName)}' `);
+        console.log(str.join(""));
         return this;
     }
 
-    public echoSparkyTaskEnd(taskName, took: [number, number]){
+    public echoSparkyTaskEnd(taskName, took: [number, number]) {
         const gray = log.chalk().gray;
         const magenta = log.chalk().magenta;
-        let str = ['[', gray(getDateTime()), ']', ' Resolved']
-        str.push(` '${magenta(taskName)}' `, 'after ')
+        const str = ["[", gray(getDateTime()), "]", " Resolved"];
+        str.push(` '${magenta(taskName)}' `, "after ");
         str.push(`${gray(prettyTime(took, "ms"))}`);
-        console.log(str.join(''));
+        console.log(str.join(""));
         return this;
     }
 
@@ -352,7 +353,7 @@ export class Log {
     public echoSparkyTaskHelp(taskName: string, taskHelp: string) {
         log
             .ansi()
-            .write(' ')
+            .write(" ")
             .cyan(taskName)
             .white(taskHelp)
             .echo();
@@ -360,12 +361,12 @@ export class Log {
 
     // --- generalized ---
     public groupHeader(str: string) {
-        log.color('bold.underline').text(`${str}`).echo();
+        log.color("bold.underline").text(`${str}`).echo();
         return this;
     }
     public echoInfo(str: string) {
         const indent = this.indent.level(2);
-        log.preset('info').green(`${indent}→ ${str}`).echo();
+        log.preset("info").green(`${indent}→ ${str}`).echo();
         return this;
     }
     public error(error: Error) {
@@ -374,7 +375,7 @@ export class Log {
         //     log.factory().notify({title: error.message, message: error.stack}).echo()
         // }
 
-        log.tags('error').data(error).echo();
+        log.tags("error").data(error).echo();
         return this;
     }
 
@@ -383,7 +384,7 @@ export class Log {
         if (metadata) {
             log.data(metadata);
         }
-        log.tags('magic').magenta(str).echo();
+        log.tags("magic").magenta(str).echo();
         return this;
     }
 
@@ -405,7 +406,7 @@ export class Log {
         return this;
     }
     public echoError(str: string) {
-        log.red(`  → ERROR ${str}`).echo()
+        log.red(`  → ERROR ${str}`).echo();
     }
     public echoRed(msg) {
         log.red(msg).echo();

--- a/src/core/FuseBox.ts
+++ b/src/core/FuseBox.ts
@@ -383,7 +383,8 @@ export class FuseBox {
                 }
 
                 public addNodeModules() {
-                    return each(self.context.nodeModules, (collection: ModuleCollection) => {
+                    const nodeModules = new Map(Array.from(self.context.nodeModules).sort());
+                    return each(nodeModules, (collection: ModuleCollection) => {
                         if (collection.cached || (collection.info && !collection.info.missing)) {
                             return self.collectionSource.get(collection).then((cnt: string) => {
                                 self.context.log.echoCollection(collection, cnt);

--- a/src/core/FuseBox.ts
+++ b/src/core/FuseBox.ts
@@ -36,34 +36,34 @@ export interface FuseBoxOptions {
      *
      * default: "universal@es5"
      */
-    target?: string,
+    target?: string;
     log?: boolean;
     globals?: { [packageName: string]: /** Variable name */ string };
     plugins?: Array<Plugin | Plugin[]>;
     autoImport?: any;
     natives?: any;
-    warnings?: boolean,
+    warnings?: boolean;
     shim?: any;
     writeBundles?: boolean;
     useTypescriptCompiler?: boolean;
     standalone?: boolean;
     sourceMaps?: boolean | { vendor?: boolean, inlineCSSPath?: string; inline?: boolean, project?: boolean, sourceRoot?: string };
-    hash?: string | Boolean;
-    ignoreModules?: string[],
+    hash?: string | boolean;
+    ignoreModules?: string[];
     customAPIFile?: string;
     output?: string;
     emitHMRDependencies?: boolean;
-    filterFile?: { (file: File): boolean }
+    filterFile?: (file: File) => boolean;
     allowSyntheticDefaultImports?: boolean;
     debug?: boolean;
     files?: any;
     alias?: any;
-    useJsNext?: boolean | string[],
-    stdin?: boolean,
-    ensureTsConfig? : boolean;
+    useJsNext?: boolean | string[];
+    stdin?: boolean;
+    ensureTsConfig?: boolean;
     runAllMatchedPlugins?: boolean;
-    showErrors?: boolean
-    showErrorsInBrowser?: boolean
+    showErrors?: boolean;
+    showErrorsInBrowser?: boolean;
     polyfillNonStandardDefaultUsage?: boolean | string[];
     transformers?: CustomTransformers;
     extensionOverrides?: string[];
@@ -95,8 +95,9 @@ export class FuseBox {
      *
      * @memberOf FuseBox
      */
+    // tslint:disable-next-line:cyclomatic-complexity
     constructor(public opts?: FuseBoxOptions) {
-        printCurrentVersion()
+        printCurrentVersion();
         this.context = new WorkFlowContext();
         this.context.fuse = this;
         this.collectionSource = new CollectionSource(this.context);
@@ -107,21 +108,21 @@ export class FuseBox {
         }
         // setting targets
         opts.target = opts.target || "browser";
-        const [target, languageLevel] = opts.target.toLowerCase().split('@')
-        this.context.target = target
+        const [target, languageLevel] = opts.target.toLowerCase().split("@");
+        this.context.target = target;
         const level = languageLevel && Object.keys(ScriptTarget)
-            .find(t => t.toLowerCase() === languageLevel)
+            .find(t => t.toLowerCase() === languageLevel);
         if (level) {
             this.context.forcedLanguageLevel = ScriptTarget[level];
         }
         this.context.languageLevel = ScriptTarget[level] || ScriptTarget.ES2016;
 
         if (opts.polyfillNonStandardDefaultUsage !== undefined) {
-            this.context.deprecation('polyfillNonStandardDefaultUsage has been depreacted in favour of allowSyntheticDefaultImports')
+            this.context.deprecation("polyfillNonStandardDefaultUsage has been depreacted in favour of allowSyntheticDefaultImports");
             this.producer.allowSyntheticDefaultImports = opts.allowSyntheticDefaultImports;
         }
 
-        if( opts.allowSyntheticDefaultImports !== undefined) {
+        if (opts.allowSyntheticDefaultImports !== undefined) {
             this.producer.allowSyntheticDefaultImports = opts.allowSyntheticDefaultImports;
         }
 
@@ -144,7 +145,7 @@ export class FuseBox {
             this.context.emitHMRDependencies = true;
         }
         if (opts.homeDir) {
-            homeDir = ensureUserPath(opts.homeDir)
+            homeDir = ensureUserPath(opts.homeDir);
         }
         if (opts.debug !== undefined) {
             this.context.debugMode = opts.debug;
@@ -162,7 +163,7 @@ export class FuseBox {
             this.context.showErrors = opts.showErrors;
 
             if (opts.showErrorsInBrowser === undefined) {
-                this.context.showErrorsInBrowser = opts.showErrors
+                this.context.showErrorsInBrowser = opts.showErrors;
             }
         }
 
@@ -185,7 +186,7 @@ export class FuseBox {
             this.context.setSourceMapsProperty(opts.sourceMaps);
         }
 
-        this.context.runAllMatchedPlugins = !!opts.runAllMatchedPlugins
+        this.context.runAllMatchedPlugins = !!opts.runAllMatchedPlugins;
         this.context.plugins = opts.plugins as Plugin[] || [JSONPlugin()];
 
         if (opts.package) {
@@ -193,10 +194,10 @@ export class FuseBox {
                 const packageOptions: any = opts.package;
                 this.context.defaultPackageName = packageOptions.name || "default";
                 this.context.defaultEntryPoint = packageOptions.main;
-            } else if (typeof opts.package === 'string') {
+            } else if (typeof opts.package === "string") {
                 this.context.defaultPackageName = opts.package;
             } else {
-                throw new Error('`package` must be a string or an object of the form {name: string, main: string}');
+                throw new Error("`package` must be a string or an object of the form {name: string, main: string}");
             }
 
         }
@@ -226,7 +227,7 @@ export class FuseBox {
             this.context.addAlias(opts.alias);
         }
 
-        this.context.initAutoImportConfig(opts.natives, opts.autoImport)
+        this.context.initAutoImportConfig(opts.natives, opts.autoImport);
 
 
         if (opts.globals) {
@@ -259,12 +260,12 @@ export class FuseBox {
             this.context.extensionOverrides = new ExtensionOverrides(opts.extensionOverrides);
         }
 
-        const tsConfig = new TypescriptConfig(this.context);;
+        const tsConfig = new TypescriptConfig(this.context);
         tsConfig.setConfigFile(opts.tsConfig);
         this.context.tsConfig = tsConfig;
 
-        if( opts.stdin){
-            process.stdin.on('end', () => { process.exit(0) });
+        if (opts.stdin) {
+            process.stdin.on("end", () => { process.exit(0); });
             process.stdin.resume();
         }
     }
@@ -286,13 +287,13 @@ export class FuseBox {
     }
 
     public copy(): FuseBox {
-        const config = Object.assign({}, this.opts);
-        config.plugins = [].concat(config.plugins || [])
+        const config = {...this.opts};
+        config.plugins = [].concat(config.plugins || []);
         return FuseBox.init(config);
     }
 
     public bundle(name: string, arithmetics?: string): Bundle {
-        let fuse = this.copy();
+        const fuse = this.copy();
         const bundle = new Bundle(name, fuse, this.producer);
 
         bundle.arithmetics = arithmetics;
@@ -300,37 +301,35 @@ export class FuseBox {
         return bundle;
     }
 
-
-
-    public sendPageReload(){
-        if ( this.producer.devServer && this.producer.devServer.socketServer){
+    public sendPageReload() {
+        if (this.producer.devServer && this.producer.devServer.socketServer) {
             const socket = this.producer.devServer.socketServer;
             socket.send("page-reload", []);
         }
     }
 
-    public sendPageHMR(){
-        if ( this.producer.devServer && this.producer.devServer.socketServer){
+    public sendPageHMR() {
+        if (this.producer.devServer && this.producer.devServer.socketServer) {
             const socket = this.producer.devServer.socketServer;
             socket.send("page-hmr", []);
         }
     }
 
     /** Starts the dev server and returns it */
-    public dev(opts?: ServerOptions, fn?: { (server: Server): void }) {
+    public dev(opts?: ServerOptions, fn?: (server: Server) => void) {
         opts = opts || {};
         opts.port = opts.port || 4444;
         this.producer.devServerOptions = opts;
         this.producer.runner.bottom(() => {
-            let server = new Server(this);
+            const server = new Server(this);
             this.producer.devServer = server;
             server.start(opts);
             if (opts.open) {
                 try {
-                    const opn = require('opn');
-                    opn(typeof opts.open === 'string' ? opts.open : `http://localhost:${opts.port}`);
+                    const opn = require("opn");
+                    opn(typeof opts.open === "string" ? opts.open : `http://localhost:${opts.port}`);
                 } catch (e) {
-                    this.context.log.echoRed('If you want to open the browser, please install "opn" package. "npm install opn --save-dev"')
+                    this.context.log.echoRed('If you want to open the browser, please install "opn" package. "npm install opn --save-dev"');
                 }
 
             }
@@ -352,7 +351,7 @@ export class FuseBox {
     }
 
     public process(bundleData: BundleData, bundleReady?: () => any) {
-        let bundleCollection = new ModuleCollection(this.context, this.context.defaultPackageName);
+        const bundleCollection = new ModuleCollection(this.context, this.context.defaultPackageName);
         bundleCollection.pm = new PathMaster(this.context, bundleData.homeDir);
         // swiching on typescript compiler
         if (bundleData.typescriptMode) {
@@ -360,7 +359,7 @@ export class FuseBox {
             bundleCollection.pm.setTypeScriptMode();
         }
 
-        let self = this;
+        const self = this;
         return bundleCollection.collectBundle(bundleData).then(module => {
             if (this.context.emitHMRDependencies) {
                 this.context.emitter.emit("bundle-collected");
@@ -404,7 +403,7 @@ export class FuseBox {
                 }
 
             }).then(result => {
-                let self = this;
+                const self = this;
                 // @NOTE: content is here, but this is not the uglified content
                 // self.context.source.getResult().content.toString()
                 self.context.log.end();
@@ -420,20 +419,20 @@ export class FuseBox {
 
     public addShims() {
         // add all shims
-        let shim = this.context.shim;
+        const shim = this.context.shim;
         if (shim) {
-            for (let name in shim) {
+            for (const name in shim) {
                 if (shim.hasOwnProperty(name)) {
-                    let data = shim[name];
+                    const data = shim[name];
                     if (data.exports) {
                         // creating a fake collection
-                        let shimedCollection
+                        const shimedCollection
                             = ShimCollection.create(this.context, name, data.exports);
                         this.context.addNodeModule(name, shimedCollection);
 
                         if (data.source) {
-                            let source = ensureUserPath(data.source);
-                            let contents = fs.readFileSync(source).toString();
+                            const source = ensureUserPath(data.source);
+                            const contents = fs.readFileSync(source).toString();
                             this.context.source.addContent(contents);
                         }
                     }
@@ -452,7 +451,7 @@ export class FuseBox {
         this.addShims();
         this.triggerStart();
 
-        let parser = Arithmetic.parse(str);
+        const parser = Arithmetic.parse(str);
         let bundle: BundleData;
         return Arithmetic.getFiles(parser, this.virtualFiles, this.context.homeDir).then(data => {
             bundle = data;
@@ -470,7 +469,7 @@ export class FuseBox {
             }
 
             return this.process(data, bundleReady);
-        }).then((contents) => {
+        }).then(contents => {
             bundle.finalize(); // Clean up temp folder if required
             return contents;
         }).catch(e => {
@@ -479,6 +478,6 @@ export class FuseBox {
     }
 }
 
-process.on('unhandledRejection', (reason, promise) => {
+process.on("unhandledRejection", (reason, promise) => {
     console.log(reason.stack);
 });


### PR DESCRIPTION
- sorted bundle sources for easyier checking, that package/file `whatever` is bundled
- fixed all autofixable tslint errors in affected files

before:
```log
Bundle "vendor"

└──  (0 files,  53 Bytes) default
└── fusebox-hot-reload 7.6 kB (1 files)
└── fusebox-websocket 2.9 kB (1 files)
└── events 9.8 kB (1 files)
└── react 50.1 kB (3 files)
└── object-assign 2.2 kB (1 files)
└── fbjs 17.6 kB (16 files)
└── process 4 kB (1 files)
```

after:
```log
Bundle "vendor"

└──  (0 files,  53 Bytes) default
└── events 9.8 kB (1 files)
└── fbjs 17.6 kB (16 files)
└── fusebox-hot-reload 7.6 kB (1 files)
└── fusebox-websocket 2.9 kB (1 files)
└── object-assign 2.2 kB (1 files)
└── process 4 kB (1 files)
└── react 50.1 kB (3 files)
```