### PR TITLE
Fix nested routes bug

### DIFF
--- a/src/quantum/plugin/QuantumSplit.ts
+++ b/src/quantum/plugin/QuantumSplit.ts
@@ -16,7 +16,7 @@ export class QuantumSplitConfig {
         if ( this.resolveOptions && this.resolveOptions.browser ){
             return this.resolveOptions.browser;
         }
-        return "./";
+        return "";
     }
 
     public getServerPath(){


### PR DESCRIPTION
Requesting code-splitted js files at e.g. `http://localhost:4444/foo/bar/baz` didn't work but this PR should fix it.