### PR TITLE
feat: add warning on not found file

### DIFF
--- a/src/core/File.ts
+++ b/src/core/File.ts
@@ -450,6 +450,8 @@ export class File {
             if (/\.js$/.test(this.info.fuseBoxPath) && this.context.fuse && this.context.fuse.producer) {
                 this.context.fuse.producer.addWarning('unresolved',
                     `Statement "${this.info.fuseBoxPath}" has failed to resolve in module "${this.collection && this.collection.name}"`);
+            } else {
+                this.context.fuse.producer.addWarning('notfound', `File "${this.absPath}" was not found`);
             }
             this.notFound = true;
             return;


### PR DESCRIPTION
Fuse doesn't give any info when an imported css file for example is not found. This PR adds a warning for that case, I think that's the right place to put it