### PR TITLE
Made error message clearer, and included HTML Template file not found error check.

### DIFF
--- a/src/core/File.ts
+++ b/src/core/File.ts
@@ -451,6 +451,9 @@ export class File {
                 this.context.fuse.producer.addWarning('unresolved',
                     `Statement "${this.info.fuseBoxPath}" has failed to resolve in module "${this.collection && this.collection.name}"`);
             }
+            if (/\.html$/.test(this.info.fuseBoxPath)){
+                this.addError(`HTML Template Reference "${this.info.fuseBoxPath}" has failed to resolve in module "${this.collection && this.collection.name}"`);
+            }
             this.notFound = true;
             return;
         }

--- a/src/core/File.ts
+++ b/src/core/File.ts
@@ -450,9 +450,8 @@ export class File {
             if (/\.js$/.test(this.info.fuseBoxPath) && this.context.fuse && this.context.fuse.producer) {
                 this.context.fuse.producer.addWarning('unresolved',
                     `Statement "${this.info.fuseBoxPath}" has failed to resolve in module "${this.collection && this.collection.name}"`);
-            }
-            if (/\.html$/.test(this.info.fuseBoxPath)){
-                this.addError(`HTML Template Reference "${this.info.fuseBoxPath}" has failed to resolve in module "${this.collection && this.collection.name}"`);
+            } else {
+                this.addError(`Asset reference "${this.info.fuseBoxPath}" has failed to resolve in module "${this.collection && this.collection.name}"`);
             }
             this.notFound = true;
             return;

--- a/src/core/File.ts
+++ b/src/core/File.ts
@@ -622,7 +622,9 @@ export class File {
                 return;
 	    }
         } catch(e){
-            this.context.fatal('You need TypeScript installed to transpile modules automatically');
+            this.context.fatal(`TypeScript automatic transpilation has failed. Please check that:
+            - You have TypeScript installed
+            - Your tsconfig.json file is not malformed.\nError message: ${e.message}`)
             return;
         }
     }

--- a/src/core/File.ts
+++ b/src/core/File.ts
@@ -447,7 +447,7 @@ export class File {
 
         if (!fs.existsSync(this.info.absPath)) {
 
-            if (/\.js$/.test(this.info.fuseBoxPath) && this.context.fuse && this.context.fuse.producer) {
+            if (/\.jsx?$/.test(this.info.fuseBoxPath) && this.context.fuse && this.context.fuse.producer) {
                 this.context.fuse.producer.addWarning('unresolved',
                     `Statement "${this.info.fuseBoxPath}" has failed to resolve in module "${this.collection && this.collection.name}"`);
             } else {


### PR DESCRIPTION
fixes #1204, and also includes an import check for importing HTML files with the ng-template plugin.