### PR TITLE
CRITICAL: CSSResourcePlugin parse error

### DIFF
--- a/src/plugins/stylesheet/CSSResourcePlugin.ts
+++ b/src/plugins/stylesheet/CSSResourcePlugin.ts
@@ -136,7 +136,7 @@ export class CSSResourcePluginClass implements Plugin {
                 }
             }
 
-            if (url.startsWith('https:') || url.startsWith('http:') || url.startsWith('//')) {
+            if (url.startsWith('https:') || url.startsWith('http:') || url.startsWith('//') || url.startsWith('#')) {
                 return url
             }
 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/CSS/filter

The url filtering on this plugin isn't very good, it's not taking into account all the possible combinations. Perhaps it's a good idea to consider reworking this.

For now, this will fix my project as I have something that looks like this:

filter: url(#blurMe);

Please merge and release!