### PR TITLE
Fix some error propagation bugs.

### DIFF
--- a/src/core/Bundle.ts
+++ b/src/core/Bundle.ts
@@ -241,7 +241,7 @@ export class Bundle {
                 }).then(source => {
                 }).catch(e => {
                     console.error(e);
-                    return reject(reject);
+                    return reject(e);
                 });
             return this;
         });

--- a/src/core/FuseBox.ts
+++ b/src/core/FuseBox.ts
@@ -493,6 +493,7 @@ export class FuseBox {
             return contents;
         }).catch(e => {
             console.log(e.stack || e);
+            throw e;
         });
     }
 }


### PR DESCRIPTION
When an error is thrown in plugin, there are bugs making such error not properly propagated to the top level Fusebox.run.  This caused our CI pipeline failed to catch the plugin issue and shipped broken code.

This MR fixes the bugs.