### PR TITLE
fix: renaming generated files to allow several vue files in a folder

### DIFF
--- a/src/plugins/vue/VuePlugin.ts
+++ b/src/plugins/vue/VuePlugin.ts
@@ -51,7 +51,8 @@ export class VueComponentClass implements Plugin {
 
   private createVirtualFile(file: File, block: any, scopeId: string, pluginChain: Plugin[]): VueBlockFile {
     let extension = block.lang || this.getDefaultExtension(block);
-    let src = `./${block.type}.${extension}`;
+	let name = file.relativePath.split('/').pop();
+	let src = `./${name}.${extension}`;
 
     if (block.src) {
         let srcExtension = path.extname(block.src) || '';


### PR DESCRIPTION
https://github.com/fuse-box/fuse-box/issues/1194

Having two vue files in one folder is making conflicts - in the source map as well as in the style management.
By using the file' name, we have unique names.
Before:
folder/myVue.vue -> folder/script.ts
folder/foobar.vue -> folder/script.ts
After:
folder/myVue.vue -> folder/myVue.vue.ts
folder/foobar.vue -> folder/foobar.vue.ts