### PR TITLE
docs: CSSModules root

### DIFF
--- a/docs/plugins/css/CSSModules.md
+++ b/docs/plugins/css/CSSModules.md
@@ -122,6 +122,14 @@ CSSModules({
 })
 ```
 
+### root
+Set `postcss-modules` root path. _see wef_
+```js
+CSSModules({
+  root: path.resolve(__dirname, 'src')
+})
+```
+
 ## Development mode
 In development, the imported stylesheets are appended to the `<head>` of
 the document by the outputted JavaScript bundle. This allows for the files


### PR DESCRIPTION
Added missing documentation for `root` option on `CSSModules`
