### PR TITLE
feat: devServer fallback

### DIFF
--- a/docs/development/dev-server.md
+++ b/docs/development/dev-server.md
@@ -31,6 +31,17 @@ fuse.dev({
 })
 ```
 
+## Fallback
+
+If you develop a SPA app you can set a fallback. All 404's will return the fallback file you specify. The file path is relative to your served root.
+
+```js
+fuse.dev({
+    root: 'public/build',
+    fallback: 'index.html'
+})
+```
+
 ## Port
 By default you will get `express` application running and a `socket` server (if [HMR](#hot-module-reload) is enabled) bound to port `4444`. To change the port provide `port` option.
 

--- a/src/devServer/HTTPServer.ts
+++ b/src/devServer/HTTPServer.ts
@@ -12,6 +12,9 @@ export interface HTTPServerOptions {
     /** Provide https server options to enable https */
     https?: https.ServerOptions;
 
+    /** 404 fallback */
+    fallback?: string;
+
     /**
      * If specfied this is the folder served from express.static
      * It can be an absolute path or relative to `appRootPath`
@@ -100,6 +103,11 @@ Development server running ${opts.https ? 'https' : 'http'}://localhost:${port} 
                 this.fuse.context.log.echoWarning("Make sure you are not using dev server for production!")
                 this.app.use(this.fuse.context.sourceMapsRoot, express.static(this.fuse.context.homeDir));
             }
+        }
+        if (this.opts.fallback) {
+            this.app.use('*', (req, res) => {
+                res.sendFile(this.opts.fallback)
+            })
         }
     }
 }

--- a/src/devServer/Server.ts
+++ b/src/devServer/Server.ts
@@ -5,6 +5,7 @@ import { FuseBox } from "../core/FuseBox";
 import { utils } from "realm-utils";
 import * as process from "process";
 import * as https from 'https';
+import * as path from 'path';
 
 export type HotReloadEmitter = (server: Server, sourceChangedInfo: any) => any;
 
@@ -21,6 +22,9 @@ export interface ServerOptions {
 
     /** If not specified it uses regular http */
     https?: https.ServerOptions;
+
+    /** 404 fallback */
+    fallback?: string;
 
     /**
      * - If false nothing is served.
@@ -67,6 +71,7 @@ export class Server {
             ? (utils.isString(opts.root) ? ensureUserPath(opts.root as string) : false) : rootDir;
         const port = opts.port || 4444;
         const https = opts.https
+        const fallback = root && opts.fallback && path.join(root, opts.fallback)
         if (opts.hmr !== false && this.fuse.context.useCache === true) {
 
             setTimeout(() => {
@@ -85,7 +90,7 @@ export class Server {
             if (opts.httpServer === false) {
                 this.socketServer = SocketServer.startSocketServer(port, this.fuse);
             } else {
-                this.socketServer = this.httpServer.launch({ root, port, https }, opts);
+                this.socketServer = this.httpServer.launch({ root, port, https, fallback }, opts);
             }
         });
         return this;

--- a/src/tests/BundleApi.test.ts
+++ b/src/tests/BundleApi.test.ts
@@ -111,6 +111,12 @@ export class BundleApiTest {
         should(fuse.producer.devServerOptions).deepEqual({ port: 4444, https: { cert: "cert", key: "key" } })
     }
 
+    "Should setup devServer with fallback param"() {
+        const fuse = createFuse();
+        fuse.dev({ fallback: "index.html" });
+        should(fuse.producer.devServerOptions).deepEqual({ port: 4444, fallback: "index.html" })
+    }
+
     "Should inject 1 plugin"() {
         const fuse = createFuse();
         const bundle = fuse.bundle("app").plugin("first");


### PR DESCRIPTION
If you develop a SPA app you can set a fallback. All 404's will return the fallback file you specify. The file path is relative to your served root.

```js
fuse.dev({
    root: 'public/build',
    fallback: 'index.html'
})
```