### PR TITLE
Add .npmignore to keep everything smaller

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+.github
+docs
+src
+gulpfile.js
+test.js
+logo.*


### PR DESCRIPTION
It’s not smart to include all of this into your npm package.
It’s a good practice to keep the size small.
Also, i'm not sure about `modules/` if it's needed or not, so i haven't touched it.