### PR TITLE
Adding filesMapping option to CSSResourcePlugin

### DIFF
--- a/src/plugins/stylesheet/CSSResourcePlugin.ts
+++ b/src/plugins/stylesheet/CSSResourcePlugin.ts
@@ -217,7 +217,7 @@ export class CSSResourcePluginClass implements Plugin {
                     // We also store a string which uniquely identify this array
                     // To avoid watch loop
                     this.copiedFilesID = this.copiedFiles.map(
-                        copiedFile => generateNewFileName( copiedFile.from )
+                        copiedFile => newFileName( copiedFile.from )
                     ).join('+');
                 }
                 return this.resolveFn(newFileName);

--- a/src/plugins/stylesheet/CSSResourcePlugin.ts
+++ b/src/plugins/stylesheet/CSSResourcePlugin.ts
@@ -217,7 +217,7 @@ export class CSSResourcePluginClass implements Plugin {
                     // We also store a string which uniquely identify this array
                     // To avoid watch loop
                     this.copiedFilesID = this.copiedFiles.map(
-                        copiedFile => newFileName( copiedFile.from )
+                        copiedFile => generateNewFileName( copiedFile.from )
                     ).join('+');
                 }
                 return this.resolveFn(newFileName);


### PR DESCRIPTION
This option allow developer to create a manifest of generated resources files. Needed when loading CSS Resources from Javascript.
This fork manages watch loops to allow filesMapping function to create typescript or javascript files in homeDir folder.
filesMapping can also create a JSON file loaded at runtime for example.

Usage :
```
CSSResourcePlugin({

	dist: "resources/",

	// Called when a new set of resources is copied to the resources/ folder
	filesMapping: (files) =>
	{
		// Log copied files
		files.map( fileMapping =>
		{
			console.log(fileMapping.from, "has been copied to", fileMapping.to)
		});
	}
})
```