### PR TITLE
fix: Target 'npm' more like 'universal' (nor 'browser' nor 'server')

### DIFF
--- a/src/quantum/plugin/QuantumOptions.ts
+++ b/src/quantum/plugin/QuantumOptions.ts
@@ -339,7 +339,7 @@ export class QuantumOptions {
     }
 
     public isTargetServer() {
-        return this.optsTarget === "server" || this.optsTarget === "electron" || this.optsTarget === "npm";
+        return this.optsTarget === "server" || this.optsTarget === "electron";
     }
 
     public isTargetBrowser() {

--- a/src/quantum/plugin/QuantumOptions.ts
+++ b/src/quantum/plugin/QuantumOptions.ts
@@ -339,7 +339,7 @@ export class QuantumOptions {
     }
 
     public isTargetServer() {
-        return this.optsTarget === "server" || this.optsTarget === "electron";
+        return this.optsTarget === "server" || this.optsTarget === "electron" || this.optsTarget === "npm";
     }
 
     public isTargetBrowser() {

--- a/src/quantum/plugin/modifications/EnvironmentConditionModification.ts
+++ b/src/quantum/plugin/modifications/EnvironmentConditionModification.ts
@@ -9,7 +9,7 @@ export class EnvironmentConditionModification {
 
         return each(file.fuseboxIsEnvConditions, (replacable: ReplaceableBlock) => {
 
-            if (core.opts.isTargetUniveral()) {
+            if (core.opts.isTargetUniveral() || core.opts.isTargetNpm()) {
                 if (replacable.identifier === "isServer") {
                     replacable.setFunctionName(`${core.opts.quantumVariableName}.cs`);
                 }


### PR DESCRIPTION
`npm` target shouldn't be neither "browser" neither "server" as there are browser and server npm packages. It should more be like universal and determine every time if it is in a browser or not. This is especially important for Vue packages to allow SSR

Note: I noticed the problem when my CSS was not included in my browser-targeted npm package as `FuseBox.isBrowser` was `false`.