### PR TITLE
Simplify pre option in WebIndexPlugin and add documentation

### DIFF
--- a/docs/plugins/html/WebIndexPlugin.md
+++ b/docs/plugins/html/WebIndexPlugin.md
@@ -10,7 +10,7 @@ Generates a HTML file once a producer's job is completed
 Import from FuseBox
 
 ```js
-const { WebIndexPlugin } = require("fuse-box");
+const { WebIndexPlugin } = require('fuse-box');
 ```
 
 Inject into a chain
@@ -21,21 +21,43 @@ fuse.plugin(
 )
 ```
 
+Include in the `plugins` array property in the `init` configuration
+
+```js
+fuse.init({
+    homeDir: 'src',
+    output: 'build/$name.js',
+    target: 'browser',
+    plugins: [
+      WebIndexPlugin()
+    ]
+});
+```
+
 ## Options
 
-| Name | Meaning |
-| ------------- | ------------- |
-| ` title `   | Sets the title  |
-| ` bundles ` | Provide a list of bundle names (if not set all registered bundles are through) |
-| ` path `   | The relative url bundles are served from. Default is `/`. Empty is set with `.`  |
-| ` template `   | Provide a path to your own template  |
-| ` templateString `   | Provide your own template as a string  |
-| ` target `   | The main filename. Default is `index.html`  |
-| ` resolve `   | `resolve ?: {(output : UserOutput) : string}` Allows to completely override the output  |
-| `pre ` | `{ relType: 'fetch' | 'load' }`  Config object to either preload or prefetch the output javascript bundles in the head of the document |
-| ` appendBundles ` | Append $bundles to provided template |
+> Note: If a `template` and `templateString` option are both specified, then the `template`
+> will take precedent.
+> If no default value is specified below, the option will not be applied.
 
-note: If you specify template and templateString then template will take precedent 
+| Name | Type | Description | Default |
+| -----| ---- | ----------- | -------
+| `appendBundles` | `boolean` | Append the $bundles to provided template | `true` |
+| `async`   | `boolean`| Adds the `async` attribute to the `<script />` tags that link the output javascript bundles | `false` |
+| `author`  | `string` | Set the the `content` attribute of a  `<meta name="author"` tag |
+| `bundles` | `string[]` | Provide a list of bundle names. (if not set all registered bundles are through) |
+| `charset` | `string` | Set the the `charset` attribute of a  `<meta />` tag |
+| `description` | `string` | Set the the `content` attribute of a  `<meta name="description" />` tag |
+| `emitBundles` | `(bundles: string[]) => string` | Function that returns the list of paths to each output bundle |
+| `keywords`| `string` | Set the the `content` attribute of a  `<meta name="keywords" />` tag |
+| `path`    | `string` | The relative url that bundles are served from. Empty is set with `"."`  | `"/"` |
+| `pre`     | `string` | Must be specified using either `'fetch'` or `'load'`. Adds `<link />` tags with `preload` or `prefetch` attributes for each of the output javascript bundles. The tags will be injected into the head of the html document or where specified by the `$pre` macro |
+| `resolve` | `resolve ?: {(output : UserOutput) : string}` | Function that allows to completely override the output |
+| `target`  | `string` | The name of the output `.html` file  | `index.html` |
+| `template`|  `string`| Provide a path to your own template  |
+| `templateString` | `string` | Provide your own template  |
+| `title`   | `string` | Sets the title of the generated HTML document |
+
 
 ### Resolve example
 `resolve` option allows you to completely override the path
@@ -51,10 +73,13 @@ WebIndexPlugin({
 
 A custom template has the following macro available:
 
-| Symbol | Meaning |
+| Macro | Meaning |
 | ------------- | ------------- |
-| ` $title `   | Html Title  |
-| ` $bundles `   | A list of script tags |
-| ` $css `   | A list of styles tags |
-
-github_example: vendor-splitting
+| `$author` | Define where the author meta tags will be injected into the html document |
+| `$bundles`   | A list of script tags |
+| `$charset` | Define where the charset meta tags will be injected into the html document |
+| `$css`   | A list of styles tags |
+| `$description` | Define where the description meta tags will be injected into the html document |
+| `$keywords` | Define where the keywords meta tags will be injected into the html document |
+| `$pre` | Define where the prefetch/preload link tags will be injected into the html document |
+| `$title`   | Html Title  |

--- a/src/plugins/WebIndexPlugin.ts
+++ b/src/plugins/WebIndexPlugin.ts
@@ -1,82 +1,89 @@
-import { } from "../core/File";
-import { Plugin } from "../core/WorkflowContext";
-import { BundleProducer } from "../core/BundleProducer";
-import * as fs from "fs";
-import { ensureAbsolutePath, joinFuseBoxPath } from "../Utils";
-import { UserOutput } from "../core/UserOutput";
-import * as path from "path";
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { } from '../core/File';
+import { Plugin } from '../core/WorkflowContext';
+import { BundleProducer } from '../core/BundleProducer';
+import { UserOutput } from '../core/UserOutput';
+import { ensureAbsolutePath, joinFuseBoxPath } from '../Utils';
 
 export interface IndexPluginOptions {
-    title?: string;
-    charset?: string;
-    description?: string;
-    keywords?: string;
+    appendBundles?: boolean;
+    async?: boolean;
     author?: string;
     bundles?: string[];
+    charset?: string;
+    description?: string;
+    emitBundles?: (bundles: string[]) => string;
+    keywords?: string;
     path?: string;
+    pre?: string;
+    resolve?: { (output: UserOutput): string };
     target?: string;
     template?: string;
     templateString?: string;
-    appendBundles?: boolean;
-    async?: boolean;
-    pre?: { relType: 'fetch' | 'load' };
-    resolve?: { (output: UserOutput): string };
-    emitBundles?: (bundles: string[]) => string;
+    title?: string;
 }
+
+const validPreAttrs = ['fetch', 'load'];
+
 export class WebIndexPluginClass implements Plugin {
     constructor(public opts?: IndexPluginOptions) {
 
     }
 
     private generate(producer: BundleProducer) {
+        const bundles = producer.sortBundles();
         let bundlePaths = [];
-        let bundles = producer.sortBundles();
+
         bundles.forEach((bundle) => {
             let pass = true;
-            if (this.opts.bundles) {
-                if (this.opts.bundles.indexOf(bundle.name) === -1) {
-                    pass = false;
-                }
+
+            if (this.opts.bundles && !this.opts.bundles.includes(bundle.name)) {
+                pass = false;
             }
+
             pass = pass && bundle.webIndexed;
             if (pass) {
                 const output = bundle.context.output;
                 if (output && output.lastPrimaryOutput) {
-                    if( this.opts.resolve){
+                    if (this.opts.resolve) {
                         bundlePaths.push(this.opts.resolve(output))
                     } else {
                         bundlePaths.push(
-                            joinFuseBoxPath(this.opts.path ? this.opts.path : "/", output.folderFromBundleName || "/",
+                            joinFuseBoxPath(this.opts.path ? this.opts.path : '/', output.folderFromBundleName || '/',
                                 output.lastPrimaryOutput.filename)
                         )
                     }
                 }
-
             }
         });
 
-        let html = this.opts.templateString || `<!DOCTYPE html><html>
-<head>
-<title>$title</title>
-$charset
-$description
-$keywords
-$preload
-$author
-$css
-</head>
-<body>
-$bundles
-</body>
-</html>`;
-        if (this.opts.template) {
-            let filePath = ensureAbsolutePath(this.opts.template);
-            html = fs.readFileSync(filePath).toString();
+        let html = this.opts.templateString
+            || `<!doctype html>
+                <html>
+                    <head>
+                        <title>$title</title>
+                        $charset
+                        $description
+                        $keywords
+                        $pre
+                        $author
+                        $css
+                    </head>
+                <body>
+                    $bundles
+                </body>
+                </html>`;
 
-            if (this.opts.appendBundles && html.indexOf('$bundles') === -1) {
-                if (html.indexOf('</body>') !== -1) {
+        if (this.opts.template) {
+            const pathToTemplate = ensureAbsolutePath(this.opts.template);
+            html = fs.readFileSync(pathToTemplate, 'UTF-8');
+
+            if (this.opts.appendBundles && !html.includes('$bundles')) {
+                if (!html.includes('</body>')) {
                     html = html.replace('</body>', '$bundles</body>');
-                } else if (html.indexOf('</head>') !== -1) {
+                } else if (!html.includes('</head>')) {
                     html = html.replace('</head>', '$bundles</head>');
                 } else {
                     html = `${html}$bundles`;
@@ -84,40 +91,43 @@ $bundles
             }
         }
 
-        let jsTags = this.opts.emitBundles
+        const jsTags = this.opts.emitBundles
             ? this.opts.emitBundles(bundlePaths)
             : bundlePaths.map(bundle => `<script ${this.opts.async ? 'async' : ''} type="text/javascript" src="${bundle}"></script>`).join('\n');
 
-        let preloadTags;
-        if (this.opts.pre) {
-            preloadTags = bundlePaths.map(bundle =>
-                `<link rel="pre${this.opts.pre.relType}" as="script" href="${bundle}">`
-            ).join("\n");
+        let preLinkTags;
+        if (this.opts.pre && validPreAttrs.includes[this.opts.pre]) {
+            preLinkTags = bundlePaths.map(bundle =>
+                `<link rel="pre${this.opts.pre}" as="script" href="${bundle}">`
+            ).join('\n');
         }
+
         let cssInjection = [];
-        if ( producer.injectedCSSFiles.size > 0 ){
+        if (producer.injectedCSSFiles.size > 0) {
             producer.injectedCSSFiles.forEach(f => {
-                const resolvedFile = this.opts.path ? path.join(this.opts.path, f) : path.join("/", f);
+                const resolvedFile = this.opts.path ? path.join(this.opts.path, f) : path.join('/', f);
                 cssInjection.push(`<link rel="stylesheet" href="${resolvedFile}"/>`)
             })
         }
 
-        let macro = {
-            css : cssInjection.join('\n'),
-            title: this.opts.title ? this.opts.title : "",
-            charset: this.opts.charset ? `<meta charset="${this.opts.charset}">` : "",
-            description: this.opts.description ? `<meta name="description" content="${this.opts.description}">` : "",
-            keywords: this.opts.keywords ? `<meta name="keywords" content="${this.opts.keywords}">` : "",
-            author: this.opts.author ? `<meta name="author" content="${this.opts.author}">` : "",
+        const macro = {
+            author: this.opts.author ? `<meta name="author" content="${this.opts.author}">` : '',
             bundles: jsTags,
-            preload: this.opts.pre ? preloadTags : "",
+            charset: this.opts.charset ? `<meta charset="${this.opts.charset}">` : '',
+            css : cssInjection.join('\n'),
+            description: this.opts.description ? `<meta name="description" content="${this.opts.description}">` : '',
+            keywords: this.opts.keywords ? `<meta name="keywords" content="${this.opts.keywords}">` : '',
+            pre: this.opts.pre ? preLinkTags : '',
+            title: this.opts.title ? this.opts.title : ''
         }
+
         for (let key in macro) {
             html = html.replace('$' + key, macro[key])
         }
         producer.fuse.context
-            .output.writeToOutputFolder(this.opts.target || "index.html", html);
+            .output.writeToOutputFolder(this.opts.target || 'index.html', html);
     }
+
     producerEnd(producer: BundleProducer) {
         this.generate(producer);
         producer.sharedEvents.on('file-changed', () => {


### PR DESCRIPTION
I know this is a breaking API change, but I figured the feature I established didn't offer an intuitive configuration. Instead of specifying as an object, a string enum is of 'fetch' or 'load' is required. There were also some internal changes including:

*  Use the more expressive `!string.includes()` instead of `string.indexOf() === -1`
* Prefer `const` over `let` where possible
* Unify the use of single quotes for strings
* Sort object properties alphabetically
* Improve spacing consistency

Additionally, the documentation for WebIndexPlugin has been updated to reflect the API changes as well as documenting all the options that the plugin can accept. I did my best to document what I could and would appreciate some reviews of my explanations so that this plugin can be more easily understood by newcomers.