### PR TITLE
Fix: Don't throw asset reference error on wildcard imports

### DIFF
--- a/src/core/File.ts
+++ b/src/core/File.ts
@@ -446,12 +446,13 @@ export class File {
         this.context.extensionOverrides && this.context.extensionOverrides.setOverrideFileInfo(this);
 
         if (!fs.existsSync(this.info.absPath)) {
-
-            if (/\.jsx?$/.test(this.info.fuseBoxPath) && this.context.fuse && this.context.fuse.producer) {
-                this.context.fuse.producer.addWarning('unresolved',
-                    `Statement "${this.info.fuseBoxPath}" has failed to resolve in module "${this.collection && this.collection.name}"`);
-            } else {
-                this.addError(`Asset reference "${this.info.fuseBoxPath}" has failed to resolve in module "${this.collection && this.collection.name}"`);
+            if (!/\*/.test(this.info.fuseBoxPath)) {
+                if (/\.js(x)?$/.test(this.info.fuseBoxPath) && this.context.fuse && this.context.fuse.producer) {
+                    this.context.fuse.producer.addWarning('unresolved',
+                        `Statement "${this.info.fuseBoxPath}" has failed to resolve in module "${this.collection && this.collection.name}"`);
+                } else {
+                    this.addError(`Asset reference "${this.info.fuseBoxPath}" has failed to resolve in module "${this.collection && this.collection.name}"`);
+                }
             }
             this.notFound = true;
             return;


### PR DESCRIPTION
Since commit [66f06bb3](https://github.com/fuse-box/fuse-box/commit/66f06bb358bc3673412fd4b37c19c29dbad83505#diff-cb5978b5d218f988ba81132ae01eb62fR454) wildcard imports are broken.
This PR fixes this issue:
I've added a check - if file path includes `*` then don't throw any errors.