### PR TITLE
Swap minimist for getopts

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "ieee754": "^1.1.8",
     "inquirer": "^3.0.6",
     "lego-api": "^1.0.7",
-    "minimist": "^1.2.0",
     "mustache": "^2.3.0",
     "postcss": "^6.0.1",
     "pretty-time": "^0.2.0",
@@ -100,7 +99,8 @@
     "tslib": "^1.8.0",
     "watch": "^1.0.1",
     "ws": "^1.1.1",
-    "yargs": "^9.0.1"
+    "getopts": "^2.1.1",
+    "yargs": "9.0.1"
   },
   "collective": {
     "type": "opencollective",

--- a/src/cli/entry.ts
+++ b/src/cli/entry.ts
@@ -1,5 +1,5 @@
 #! /usr/bin/env node
-const argv = require('minimist')(process.argv.slice(2));
+const argv = require('getopts')(process.argv.slice(2));
 import { Install } from './Install';
 import { Help } from './Help';
 


### PR DESCRIPTION
Hey @nchanged! Here is the PR to swap minimist for [getopts](https://github.com/jorgebucaran/getopts). Getopts is a lighter/faster alternative to minimist. They have the same API, so this is essentially a "drop-in" replacement. 

This is a non-breaking change. See full [benchmarks here](https://github.com/jorgebucaran/getopts/tree/master/bench) if you like.

<pre>
mri × 374,999 ops/sec
yargs × 32,370 ops/sec
<b>getopts × 1,495,165 ops/sec</b>
minimist × 283,031 ops/sec
</pre>

Let me know if this looks good to you. Cheers!