### PR TITLE
Remove unused yargs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,8 +99,7 @@
     "tslib": "^1.8.0",
     "watch": "^1.0.1",
     "ws": "^1.1.1",
-    "getopts": "^2.1.1",
-    "yargs": "9.0.1"
+    "getopts": "^2.1.1"
   },
   "collective": {
     "type": "opencollective",


### PR DESCRIPTION
Remove unused package `yargs`.

@nchanged I didn't update the [old docs still mentioning yargs](https://github.com/fuse-box/fuse-box/blob/master/docs/cli_api.md#options), as I am not sure what's the direction you'd want to take. 

**Possibly Related**: https://github.com/fuse-box/fuse-box/issues/1321