### PR TITLE
Minor documentation change: bundle.output replaced with bundle.context.output

### DIFF
--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -320,7 +320,7 @@ You can retrieve bundle names from a [producer](/page/bundle#producer) like so:
 ```js
 fuse.run().then(producer => {
     producer.bundles.forEach((bundle, name) => {
-       bundle.output.lastPrimaryOutput.filename
+       bundle.context.output.lastPrimaryOutput.filename
     });
 })
 ```


### PR DESCRIPTION
I'm pretty sure there isn't a bundle.output - instead this should be bundle.context.output.