### PR TITLE
fix: watcher can't resume if queue contains a rejecting promise

### DIFF
--- a/src/core/WorkflowContext.ts
+++ b/src/core/WorkflowContext.ts
@@ -324,6 +324,7 @@ export class WorkFlowContext {
 
     public nukeCache() {
         this.resetNodeModules();
+        this.pendingPromises = [];
         if (this.cache) {
             removeFolder(this.cache.cacheFolder);
             this.cache.initialize();


### PR DESCRIPTION
fixes #1335

Nuking the queue together with the cache makes the watcher resume after an error in reproduction http://github.com/sod/fuse-box-watcher-issue

@nchanged 