### PR TITLE
fix: match against valid npm namespace + package name

### DIFF
--- a/src/quantum/core/nodes/RequireStatement.ts
+++ b/src/quantum/core/nodes/RequireStatement.ts
@@ -45,8 +45,8 @@ export class RequireStatement {
 
                 if (moduleValue.charAt(0) === '@') {
                     // matching @angular/animations/browser
-                    // where package name is @angular/animations 
-                    let matched = moduleValue.match(/(@[\w_-]+\/[\w_-]+)\/?(.*)/i);
+                    // where package name is @angular/animations
+                    let matched = moduleValue.match(/(@[a-zA-Z0-9][a-zA-Z0-9_\.-]*\/[a-zA-Z0-9][a-zA-Z0-9_-]*)\/?(.*)/i);
                     if (matched) {
                         this.nodeModuleName = matched[1]
                         this.nodeModulePartialRequire = matched[2]

--- a/src/quantum/tests/OptimisedBundle.test.ts
+++ b/src/quantum/tests/OptimisedBundle.test.ts
@@ -102,7 +102,7 @@ export class FlatAPItest {
     }
 
     "Should bundle a partial require on a scoped repository"() {
-        // gets a module from src/tests/stubs/test_modules/fbjs
+        // gets a module from src/tests/stubs/test_modules/@bar
         return createOptimisedBundleEnv({
             stubs: true,
             project: {
@@ -116,5 +116,21 @@ export class FlatAPItest {
 
             should(first).deepEqual({ something: { hello: '@bar/animations/browser' } })
         });
+    }
+
+    "Should bundle a partial require on a scoped (with valid naming) repository"() {
+      // gets a module from src/tests/stubs/test_modules/@bar.foo
+      return createOptimisedBundleEnv({
+          stubs: true,
+          project: {
+              files: {
+                  "index.js": `exports.something = require("@bar.foo/animations/browser")`
+              },
+              instructions: "index.js",
+          },
+      }).then((result) => {
+          const first = result.window.$fsx.r(0);
+          should(first).deepEqual({ something: { hello: '@bar/animations/browser' } })
+      });
     }
 }

--- a/src/tests/stubs/test_modules/@bar.foo/animations/browser/index.js
+++ b/src/tests/stubs/test_modules/@bar.foo/animations/browser/index.js
@@ -1,0 +1,1 @@
+module.exports = { hello: "@bar/animations/browser" }


### PR DESCRIPTION
This fix aims at supporting any [valid npm package name](https://docs.npmjs.com/files/package.json#name) under a namespace.

Fusebox is currently unable to recognize `@deck.gl/core` because of the `.` present in the namespace (and any packages under the `@deck.gl` namespace) as valid `node_modules`.

This in turn makes the build fail since required modules are not referenced in the final output `$fsx.r(<name>)` instead of a valid `$fsx.r(<ID>)`.