### PR TITLE
fix: log.showBundledFiles ignored when log.enabled value missing

### DIFF
--- a/src/core/FuseBox.ts
+++ b/src/core/FuseBox.ts
@@ -228,21 +228,13 @@ export class FuseBox {
             this.context.filterFile = opts.filterFile;
         }
 
-        if (opts.log) {
-            if (typeof opts.log === "boolean") {
-                this.context.doLog = opts.log;
-            }
-
-            if (typeof opts.log === "object" && opts.log.enabled) {
-                this.context.doLog = opts.log.enabled;
-                this.context.log.printLog = opts.log.enabled;
-                this.context.log.showBundledFiles = opts.log.showBundledFiles;
-            }
+        if (typeof opts.log === "boolean") {
+            this.context.log.printLog = opts.log;
         }
 
-        if (opts.log !== undefined) {
-            this.context.doLog = true;
-            this.context.log.printLog = opts.log;
+        if (typeof opts.log === "object") {
+            this.context.log.printLog = opts.log.enabled !== false;
+            this.context.log.showBundledFiles = opts.log.showBundledFiles;
         }
 
         if (opts.hash !== undefined) {


### PR DESCRIPTION
Tried to set `log.showBundledFiles = false`, but it had no effect. Had to look in the source code why. 

`doLog` is always just set back to default, so this PR changes to don't set it at all. And always apply `log.showBundlesFiles`, if found.

Fixes following configs:

```js
FuseBox.init({
    log: {
        showBundledFiles: false, // <- was ignored
    },
});

FuseBox.init({
    log: {
        enabled: false, // <- was ignored
        showBundledFiles: false, // <- was ignored
    },
});
```

Those cases now work plus cases that already worked like:

```js
FuseBox.init({
    log: {
        enabled: true,
        showBundledFiles: false,
    },
});

FuseBox.init({
    log: true,
});

FuseBox.init({
    log: false,
});

FuseBox.init({
    // defaults to true if not set
});
```

@nchanged 