### PR TITLE
refactor(test.js): Refine test runner and npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,8 +120,7 @@
     "help": "node bin/fsbx --help",
     "lint": "tslint --project ./src",
     "start": "gulp watch",
-    "test": "cross-env FUSE_TEST_TIMEOUT=5000 node ./test.js",
-    "test:once": "cross-env gulp dist && TRAVIS=true ./node_modules/mocha/bin/mocha && node ./test.js"
+    "test": "node test.js"
   },
   "typings": "index.d.ts",
   "version": "3.5.0-next.5"


### PR DESCRIPTION
- test.js script should be easier to understand
- test:once script is removed because it's not needed and there are no mocha tests

I hope I was right that `test:once` is no longer needed, please correct me if I'm wrong, I'll revert the change and add a documentation on what's the purpose of it.