### PR TITLE
feat: add optional `filterFn` parameter to `Bundle.watch()`

### DIFF
--- a/docs/development/watching.md
+++ b/docs/development/watching.md
@@ -3,8 +3,8 @@ id: watching
 title: Watching
 ---
 
-FuseBox can automatically re-bundle your bundles on file change. FuseBox
-Producer makes sure that only 1 watcher is bound (chokidar).
+FuseBox can automatically re-bundle your bundles on file change. To conserve
+resources, FuseBox Producer ensures that only 1 watcher is bound (via chokidar).
 
 ```js
 const app = fuse
@@ -13,7 +13,10 @@ const app = fuse
   .watch();
 ```
 
-`watch()` accepts a simplified regex (if you want to customise watched folder).
+`watch()` accepts two optional arguments; 1) a simplified regex (if you
+want to customize the watched folder), and 2) a filter function that includes
+any files that return a truthy value.
+
 Let's watch server and client bundle at the same time.
 
 ```js
@@ -25,12 +28,12 @@ fuse
 fuse
   .bundle("server/app")
   .instructions(`> index.ts`)
-  .watch("server/**");
+  .watch("server/**", (path) => !path.match('.*\.temp'));
 ```
 
 In this example whenever a change happen in `homeDir` FuseBox will figure out
-which bundle requires re-triggering. It's implemented in order to save up your
-resources as physically only 1 watcher is defined.
+which bundle requires re-triggering. Additionally, the server bundle will ignore
+any file that ends in `.temp`.
 
 A typical configuration for production builds would look like:
 

--- a/src/core/Bundle.ts
+++ b/src/core/Bundle.ts
@@ -15,6 +15,7 @@ import { EventEmitter } from "../EventEmitter";
 import { ExtensionOverrides } from "./ExtensionOverrides";
 import { QuantumBit } from "../quantum/plugin/QuantumBit";
 
+type WatchFilterFn = (path: string) => boolean
 export interface HMROptions {
 	port?: number;
 	socketURI?: string;
@@ -23,6 +24,7 @@ export interface HMROptions {
 export class Bundle {
 	public context: WorkFlowContext;
 	public watchRule: string;
+	public watchFilterFn?: WatchFilterFn;
 	public arithmetics: string;
 	public process: FuseProcess = new FuseProcess(this);
 	public onDoneCallback: any;
@@ -46,8 +48,14 @@ export class Bundle {
 		this.setup();
 	}
 
-	public watch(rules?: string): Bundle {
-		this.watchRule = rules ? rules : "**";
+	public watch(ruleOrFilterFn?: string | WatchFilterFn, filterFn?: WatchFilterFn): Bundle {
+		if (typeof ruleOrFilterFn === 'function') {
+			this.watchRule = "**";
+			this.watchFilterFn = ruleOrFilterFn;
+		} else {
+			this.watchRule = ruleOrFilterFn || "**";
+			this.watchFilterFn = filterFn;
+		}
 		return this;
 	}
 

--- a/src/core/BundleProducer.ts
+++ b/src/core/BundleProducer.ts
@@ -207,6 +207,7 @@ export class BundleProducer {
 		settings.forEach((expression, bundleName) => {
 			if (expression.test(path)) {
 				const bundle = this.bundles.get(bundleName);
+				if (bundle.watchFilterFn && !bundle.watchFilterFn(path)) { return; }
 
 				const defer = bundle.fuse.context.defer;
 

--- a/src/tests/BundleApi.test.ts
+++ b/src/tests/BundleApi.test.ts
@@ -27,6 +27,25 @@ export class BundleApiTest {
 		fuse.bundle("app").watch("hello/*");
 		const bundle = fuse.producer.bundles.get("app");
 		should(bundle.watchRule).equal("hello/*");
+		should(bundle.watchFilterFn).beUndefined();
+	}
+
+	"Should add add a watch filter"() {
+		const fuse = createFuse();
+		const watchFilter = (path) => false
+		fuse.bundle("app").watch(watchFilter);
+		const bundle = fuse.producer.bundles.get("app");
+		should(bundle.watchRule).equal("**");
+		should(bundle.watchFilterFn).equal(watchFilter);
+	}
+
+	"Should add add a watch rule and filter"() {
+		const fuse = createFuse();
+		const watchFilter = (path) => false
+		fuse.bundle("app").watch("hello/*", watchFilter);
+		const bundle = fuse.producer.bundles.get("app");
+		should(bundle.watchRule).equal("hello/*");
+		should(bundle.watchFilterFn).equal(watchFilter);
 	}
 
 	"Should set globals"() {


### PR DESCRIPTION
`filterFn?` is a function that filters which watch changes trigger a
re-bundle, as an alternative to the pseudo-glob syntax of the
previous `rule` parameter. This is motivated by the need to more
easily exclude files generated by my editor ('flycheck_*`).