### PR TITLE
docs(website): Add search powered by Algolia

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -2,6 +2,10 @@
 // site configuration options.
 
 const siteConfig = {
+  algolia: {
+    apiKey: "7c4587628ca223f7abcd82db137ad7b4",
+    indexName: "fuse_box",
+  },
   baseUrl: "/",
   colors: {
     primaryColor: "#223351",


### PR DESCRIPTION
Server side configuration is available in Algolia's repository: https://github.com/algolia/docsearch-configs/blob/master/configs/fuse_box.json

@nchanged can you fix up styles for the "powered by" button?