### PR TITLE
fix: use correct CSS file path

### DIFF
--- a/src/plugins/stylesheet/CSSModules.ts
+++ b/src/plugins/stylesheet/CSSModules.ts
@@ -67,7 +67,7 @@ export class CSSModulesClass implements Plugin {
 					generateScopedName: this.scopedName ? this.scopedName : "_[local]___[hash:base64:5]",
 				}),
 			])
-				.process(file.contents, {})
+				.process(file.contents, { from: file.absPath })
 				.then(result => {
 					file.contents = result.css;
 					if (context.useCache) {


### PR DESCRIPTION
Possible fix for #997.

Not sure which test case I should update, didn't see any covering CSSModules plugin.