### PR TITLE
fix($target): fluent api method target() does not split target and la…

### DIFF
--- a/src/core/Bundle.ts
+++ b/src/core/Bundle.ts
@@ -203,9 +203,9 @@ export class Bundle {
 
 	public target(target: string): Bundle {
 		const combination = new CombinedTargetAndLanguageLevel(target);
-		this.context.target = combination.target();
-		this.context.forcedLanguageLevel = combination.languageLevel();
-		this.context.languageLevel = combination.languageLevelOrDefault();
+		this.context.target = combination.getTarget();
+		this.context.forcedLanguageLevel = combination.getLanguageLevel();
+		this.context.languageLevel = combination.getLanguageLevelOrDefault();
 		return this;
 	}
 

--- a/src/core/Bundle.ts
+++ b/src/core/Bundle.ts
@@ -14,6 +14,7 @@ import { PackageAbstraction } from "../quantum/core/PackageAbstraction";
 import { EventEmitter } from "../EventEmitter";
 import { ExtensionOverrides } from "./ExtensionOverrides";
 import { QuantumBit } from "../quantum/plugin/QuantumBit";
+import { CombinedTargetAndLanguageLevel } from './CombinedTargetAndLanguageLevel';
 
 type WatchFilterFn = (path: string) => boolean
 export interface HMROptions {
@@ -201,7 +202,10 @@ export class Bundle {
 	}
 
 	public target(target: string): Bundle {
-		this.context.target = target;
+		const combination = new CombinedTargetAndLanguageLevel(target);
+		this.context.target = combination.target();
+		this.context.forcedLanguageLevel = combination.languageLevel();
+		this.context.languageLevel = combination.languageLevelOrDefault();
 		return this;
 	}
 

--- a/src/core/CombinedTargetAndLanguageLevel.ts
+++ b/src/core/CombinedTargetAndLanguageLevel.ts
@@ -6,19 +6,19 @@ export class CombinedTargetAndLanguageLevel {
 		this.combination = this.combination || "browser";
 	}
 
-	public target(): string {
+	public getTarget(): string {
 		const [target,] = this.splitCombination();
 		return target;
 	}
 
-	public languageLevel(): ScriptTarget {
+	public getLanguageLevel(): ScriptTarget {
 		const [, languageLevel] = this.splitCombination();
 		const level = languageLevel && Object.keys(ScriptTarget).find(t => t.toLowerCase() === languageLevel);
 		return level ? ScriptTarget[level] : undefined;
 	}
 
-	public languageLevelOrDefault(defaultLanguageLevel: ScriptTarget = ScriptTarget.ES2016) {
-		const languageLevel = this.languageLevel();
+	public getLanguageLevelOrDefault(defaultLanguageLevel: ScriptTarget = ScriptTarget.ES2016) {
+		const languageLevel = this.getLanguageLevel();
 		return languageLevel ? languageLevel : defaultLanguageLevel;
 	}
 

--- a/src/core/CombinedTargetAndLanguageLevel.ts
+++ b/src/core/CombinedTargetAndLanguageLevel.ts
@@ -6,23 +6,23 @@ export class CombinedTargetAndLanguageLevel {
 		this.combination = this.combination || "browser";
 	}
 
-	target(): string {
-		const [target,] = this.splittedCombination();
+	public target(): string {
+		const [target,] = this.splitCombination();
 		return target;
 	}
 
-	languageLevel(): ScriptTarget {
-		const [, languageLevel] = this.splittedCombination();
+	public languageLevel(): ScriptTarget {
+		const [, languageLevel] = this.splitCombination();
 		const level = languageLevel && Object.keys(ScriptTarget).find(t => t.toLowerCase() === languageLevel);
 		return level ? ScriptTarget[level] : undefined;
 	}
 
-	languageLevelOrDefault(defaultLanguageLevel: ScriptTarget = ScriptTarget.ES2016) {
+	public languageLevelOrDefault(defaultLanguageLevel: ScriptTarget = ScriptTarget.ES2016) {
 		const languageLevel = this.languageLevel();
 		return languageLevel ? languageLevel : defaultLanguageLevel;
 	}
 
-	private splittedCombination() {
+	private splitCombination() {
 		return this.combination.toLowerCase().split("@");
 	}
 }

--- a/src/core/CombinedTargetAndLanguageLevel.ts
+++ b/src/core/CombinedTargetAndLanguageLevel.ts
@@ -1,0 +1,28 @@
+import { ScriptTarget } from './File';
+
+export class CombinedTargetAndLanguageLevel {
+
+	constructor(private combination: string) {
+		this.combination = this.combination || "browser";
+	}
+
+	target(): string {
+		const [target,] = this.splittedCombination();
+		return target;
+	}
+
+	languageLevel(): ScriptTarget {
+		const [, languageLevel] = this.splittedCombination();
+		const level = languageLevel && Object.keys(ScriptTarget).find(t => t.toLowerCase() === languageLevel);
+		return level ? ScriptTarget[level] : undefined;
+	}
+
+	languageLevelOrDefault(defaultLanguageLevel: ScriptTarget = ScriptTarget.ES2016) {
+		const languageLevel = this.languageLevel();
+		return languageLevel ? languageLevel : defaultLanguageLevel;
+	}
+
+	private splittedCombination() {
+		return this.combination.toLowerCase().split("@");
+	}
+}

--- a/src/core/FuseBox.ts
+++ b/src/core/FuseBox.ts
@@ -14,7 +14,7 @@ import { ModuleCollection } from "./ModuleCollection";
 import { UserOutput } from "./UserOutput";
 import { BundleProducer } from "./BundleProducer";
 import { Bundle } from "./Bundle";
-import { File, ScriptTarget } from "./File";
+import { File } from "./File";
 import { ExtensionOverrides } from "./ExtensionOverrides";
 import { TypescriptConfig } from "./TypescriptConfig";
 import { CombinedTargetAndLanguageLevel } from './CombinedTargetAndLanguageLevel';

--- a/src/core/FuseBox.ts
+++ b/src/core/FuseBox.ts
@@ -17,6 +17,7 @@ import { Bundle } from "./Bundle";
 import { File, ScriptTarget } from "./File";
 import { ExtensionOverrides } from "./ExtensionOverrides";
 import { TypescriptConfig } from "./TypescriptConfig";
+import { CombinedTargetAndLanguageLevel } from './CombinedTargetAndLanguageLevel';
 
 const appRoot = require("app-root-path");
 
@@ -115,14 +116,10 @@ export class FuseBox {
 		}
 
 		// setting targets
-		opts.target = opts.target || "browser";
-		const [target, languageLevel] = opts.target.toLowerCase().split("@");
-		this.context.target = target;
-		const level = languageLevel && Object.keys(ScriptTarget).find(t => t.toLowerCase() === languageLevel);
-		if (level) {
-			this.context.forcedLanguageLevel = ScriptTarget[level];
-		}
-		this.context.languageLevel = ScriptTarget[level] || ScriptTarget.ES2016;
+		const combination = new CombinedTargetAndLanguageLevel(opts.target);
+		this.context.target = combination.target();
+		this.context.forcedLanguageLevel = combination.languageLevel();
+		this.context.languageLevel = combination.languageLevelOrDefault();
 
 		if (opts.polyfillNonStandardDefaultUsage !== undefined) {
 			this.context.deprecation(

--- a/src/core/FuseBox.ts
+++ b/src/core/FuseBox.ts
@@ -117,9 +117,9 @@ export class FuseBox {
 
 		// setting targets
 		const combination = new CombinedTargetAndLanguageLevel(opts.target);
-		this.context.target = combination.target();
-		this.context.forcedLanguageLevel = combination.languageLevel();
-		this.context.languageLevel = combination.languageLevelOrDefault();
+		this.context.target = combination.getTarget();
+		this.context.forcedLanguageLevel = combination.getLanguageLevel();
+		this.context.languageLevel = combination.getLanguageLevelOrDefault();
 
 		if (opts.polyfillNonStandardDefaultUsage !== undefined) {
 			this.context.deprecation(

--- a/src/tests/CombinedTargetAndLanguageLevel.test.ts
+++ b/src/tests/CombinedTargetAndLanguageLevel.test.ts
@@ -9,33 +9,33 @@ export class CombinedTargetAndLanguageLevelTest {
 
 	"Should default to browser target"() {
 		const combination = new CombinedTargetAndLanguageLevel(null);
-		should(combination.target()).equal(TARGET_BROWSER);
+		should(combination.getTarget()).equal(TARGET_BROWSER);
 	}
 
 	"Should detect target without language level"() {
 		const combination = new CombinedTargetAndLanguageLevel(TARGET_DUMMY);
-		should(combination.target()).equal(TARGET_DUMMY);
+		should(combination.getTarget()).equal(TARGET_DUMMY);
 	}
 
 	"Should provide undefined for missing language level"() {
 		const combination = new CombinedTargetAndLanguageLevel(TARGET_DUMMY);
-		should(combination.languageLevel()).beUndefined();
+		should(combination.getLanguageLevel()).beUndefined();
 	}
 
 	"Should detect target and language level"() {
 		const combination = new CombinedTargetAndLanguageLevel(`${TARGET_DUMMY}@es5`);
-		should(combination.target()).equal(TARGET_DUMMY);
-		should(combination.languageLevel()).equal(ScriptTarget.ES5);
+		should(combination.getTarget()).equal(TARGET_DUMMY);
+		should(combination.getLanguageLevel()).equal(ScriptTarget.ES5);
 	}
 
 	"Should default to language level es2016"() {
 		const combination = new CombinedTargetAndLanguageLevel(TARGET_DUMMY);
-		should(combination.languageLevelOrDefault()).equal(ScriptTarget.ES2016);
+		should(combination.getLanguageLevelOrDefault()).equal(ScriptTarget.ES2016);
 	}
 
 	"Should detect target and language level (for default variant)"() {
 		const combination = new CombinedTargetAndLanguageLevel(`${TARGET_DUMMY}@es5`);
-		should(combination.target()).equal(TARGET_DUMMY);
-		should(combination.languageLevelOrDefault()).equal(ScriptTarget.ES5);
+		should(combination.getTarget()).equal(TARGET_DUMMY);
+		should(combination.getLanguageLevelOrDefault()).equal(ScriptTarget.ES5);
 	}
 }

--- a/src/tests/CombinedTargetAndLanguageLevel.test.ts
+++ b/src/tests/CombinedTargetAndLanguageLevel.test.ts
@@ -1,0 +1,41 @@
+import { should } from "fuse-test-runner";
+import { CombinedTargetAndLanguageLevel } from '../core/CombinedTargetAndLanguageLevel';
+import { ScriptTarget } from '../core/File';
+
+const TARGET_BROWSER = "browser";
+const TARGET_DUMMY = "asd";
+
+export class CombinedTargetAndLanguageLevelTest {
+
+	"Should default to browser target"() {
+		const combination = new CombinedTargetAndLanguageLevel(null);
+		should(combination.target()).equal(TARGET_BROWSER);
+	}
+
+	"Should detect target without language level"() {
+		const combination = new CombinedTargetAndLanguageLevel(TARGET_DUMMY);
+		should(combination.target()).equal(TARGET_DUMMY);
+	}
+
+	"Should provide undefined for missing language level"() {
+		const combination = new CombinedTargetAndLanguageLevel(TARGET_DUMMY);
+		should(combination.languageLevel()).beUndefined();
+	}
+
+	"Should detect target and language level"() {
+		const combination = new CombinedTargetAndLanguageLevel(`${TARGET_DUMMY}@es5`);
+		should(combination.target()).equal(TARGET_DUMMY);
+		should(combination.languageLevel()).equal(ScriptTarget.ES5);
+	}
+
+	"Should default to language level es2016"() {
+		const combination = new CombinedTargetAndLanguageLevel(TARGET_DUMMY);
+		should(combination.languageLevelOrDefault()).equal(ScriptTarget.ES2016);
+	}
+
+	"Should detect target and language level (for default variant)"() {
+		const combination = new CombinedTargetAndLanguageLevel(`${TARGET_DUMMY}@es5`);
+		should(combination.target()).equal(TARGET_DUMMY);
+		should(combination.languageLevelOrDefault()).equal(ScriptTarget.ES5);
+	}
+}


### PR DESCRIPTION
…nguage level

A target can be specified by init() or using the fluent api method target(). The first one splitts
target and language level for further processing. The later one does not split them. This leads to
warnings for packages requireing a browser target.

1376