### PR TITLE
fix: #1206

### DIFF
--- a/src/quantum/plugin/QuantumCore.ts
+++ b/src/quantum/plugin/QuantumCore.ts
@@ -210,13 +210,8 @@ export class QuantumCore {
 	}
 
 	public prepareFiles(bundleAbstraction: BundleAbstraction) {
-		// set ids first
-		let entryId;
-		if (this.producer.entryPackageFile && this.producer.entryPackageName) {
-			entryId = `${this.producer.entryPackageName}/${this.producer.entryPackageFile}`;
-		}
-
 		bundleAbstraction.packageAbstractions.forEach(packageAbstraction => {
+			let entryId = `${this.producer.entryPackageName}/${packageAbstraction.entryFile}`
 			packageAbstraction.fileAbstractions.forEach((fileAbstraction, key: string) => {
 				let fileId = fileAbstraction.getFuseBoxFullPath();
 				const id = this.index;


### PR DESCRIPTION
Hi, this is the fix for #1206, however I'm not sure about how to create a test for this. I did run the tests and none were broken. I'll try to explain the fix here: 

Producer have one `entryPackageName` and one `entryPackageFile`. Me and @Sala were creating multiple bundles from the same `FuseBox.init({...})` instance, with each bundle has its own entry (with the use of `>`). Since the bundles are in the same package (`default`), the later bundle entry overwrite the former one. This PR make the `entryId` ties to `bundleAbstraction` instead of producer, thus allowing entry file per bundle, not package.