### PR TITLE
fix: improved detection of language level for transpilation

### DIFF
--- a/src/analysis/plugins/LanguageLevel.ts
+++ b/src/analysis/plugins/LanguageLevel.ts
@@ -12,10 +12,15 @@ export class LanguageLevel {
 			file.setLanguageLevel(ScriptTarget.ES2015);
 		} else if (node.type === "TemplateLiteral") {
 			file.setLanguageLevel(ScriptTarget.ES2015);
+		} else if (node.type === "ClassDeclaration") {
+			file.setLanguageLevel(ScriptTarget.ES2015);
 		}
 	}
 	public static onEnd(file: File) {
-		const target = file.context.languageLevel;
+		// In case no target is explicitly specified in fuse.js, file.context.languageLevel defaults to ScriptTarget.ES2016
+		// and no transpilation will be done, regardless of what is specified in tsConfig. This must be wrong?
+		// I believe something like this is necessary.
+		const target = ScriptTarget[file.context.tsConfig.getConfig().compilerOptions.target as string]
 		if (file.languageLevel > target) {
 			file.analysis.requiresTranspilation = true;
 		}


### PR DESCRIPTION
First tried to just add the new if statement to identify usage of classes. But no transpilation was done even though my tsConfig target was ES5. Turned out the tsConfig target is ignored. The only thing that matters is explicit targets set in your fuse.js. If you don't set an explicit target, ES2016 is assumed, not your tsConfig target.

I've attempted to solve it by comparing against the tsConfig target instead of the context target. Don't know if it's the correct way to go about it.