### PR TITLE
fix: 1422 - Hmr does not reload separate css-file changes in a Vue project

### DIFF
--- a/src/plugins/vue/VuePlugin.ts
+++ b/src/plugins/vue/VuePlugin.ts
@@ -128,6 +128,8 @@ export class VueComponentClass implements Plugin {
                 if (!isComponentStyling) {
                   var component = FuseBox.import(fusePath).default;
                   api.reload(component._vueModuleId||component.options._vueModuleId, component);
+                } else {
+                	return false;
                 }
 
                 return true;


### PR DESCRIPTION
hmrUpdate will return false if it hasn't handled the reload, so that other plugins/handlers can handle it