### PR TITLE
Make sure dev-imports.js es5 only.

### DIFF
--- a/modules/fuse-box-responsive-api/dev-imports.js
+++ b/modules/fuse-box-responsive-api/dev-imports.js
@@ -2,7 +2,7 @@ var $fsmp$ = (function() {
 	function loadRemoteScript(url) {
 		return Promise.resolve().then(function() {
 			if (FuseBox.isBrowser) {
-				let d = document;
+				var d = document;
 				var head = d.getElementsByTagName("head")[0];
 				var target;
 				if (/\.css$/.test(url)) {


### PR DESCRIPTION
Using a ES6 feature in dev-imports.js breaks uglifyjs.