### PR TITLE
fix: adds stream-browserify as stream polyfill for browser

### DIFF
--- a/modules/stream/index.js
+++ b/modules/stream/index.js
@@ -1,5 +1,5 @@
 if (FuseBox.isServer) {
 	module.exports = global.require("stream");
 } else {
-	module.exports = function() {};
+	module.exports = { Stream: require("stream-browserify") };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fuse-box",
-  "version": "3.7.0-next.1",
+  "version": "3.7.0-next.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10875,6 +10875,15 @@
       "dev": true,
       "requires": {
         "readable-stream": "^2.0.1"
+      }
+    },
+    "stream-browserify": {
+      "version": "2.0.1",
+      "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+      "requires": {
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-combiner": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "request": "^2.79.0",
     "shorthash": "0.0.2",
     "source-map": "^0.7.1",
+    "stream-browserify": "^2.0.1",
     "tslib": "^1.8.0",
     "watch": "^1.0.1",
     "ws": "^1.1.1"


### PR DESCRIPTION
@nchanged - I've made the changes to the stream polyfill (domain is already fixed in #1438 ). I'm currently requiring in `stream-browserify` but let me know if you want this as inline code instead.

I haven't been able to run tests properly as I've ran into issues running `gulp dev` on my machine. Essentially it boils down to this: https://stackoverflow.com/questions/53146394/node-app-fails-to-run-on-mojave-referenceerror-internalbinding-is-not-defined

Ultimately, I would need to upgrade gulp to v4 (and get a new vinyl-fs and new natives).

Guessing this would have breaking changes so I've held off on this. But let me know if you want some PR effort on this.

