### PR TITLE
feat: Handle resolve urls including protocol

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -146,7 +146,11 @@ export function ensureAbsolutePath(userPath: string) {
 	return userPath;
 }
 export function joinFuseBoxPath(...any): string {
-	return ensureFuseBoxPath(path.join(...any));
+	let includesProtocol = any[0].includes('://');
+	let joinedPath = !includesProtocol
+		? path.join(...any)
+		: any[0].replace(/([^/])$/, '$1/') + path.join(...any.slice(1));
+	return ensureFuseBoxPath(joinedPath);
 }
 export function ensureDir(userPath: string) {
 	if (!path.isAbsolute(userPath)) {

--- a/src/tests/plugins/CopyPlugin.test.ts
+++ b/src/tests/plugins/CopyPlugin.test.ts
@@ -141,4 +141,21 @@ export class CssPluginTest {
 			should(result.projectContents.toString()).findString(`module.exports.default = "/static/92849cf0-hello.txt";`);
 		});
 	}
+
+	"Should copy a file with custom resolver to external domain (hash)"() {
+		return createEnv({
+			project: {
+				hash: true,
+				files: {
+					"index.ts": `require("./hello.txt")`,
+					"hello.txt": "ololo",
+				},
+				plugins: [CopyPlugin({ resolve: "https://example.com/static/", files: [".txt"] })],
+				instructions: "> index.ts",
+			},
+		}).then(result => {
+			result.shouldExistInDist("assets/92849cf0-hello.txt");
+			should(result.projectContents.toString()).findString(`module.exports.default = "https://example.com/static/92849cf0-hello.txt";`);
+		});
+	}
 }


### PR DESCRIPTION
I want to map my static resources to another domain, but I noticed that this currently doesn't work:
```js
CopyPlugin({ resolve: "https://example.com/static/", files: ['.jpg']})
```

This PR makes that possible.

