### PR TITLE
Babel7Plugin implementation

### DIFF
--- a/docs/plugins/babel7.md
+++ b/docs/plugins/babel7.md
@@ -1,0 +1,59 @@
+---
+id: babel7-plugin
+title: Babel7Plugin
+---
+
+## Description
+
+Transpile code to different dialects of javascript.
+
+## Install
+
+This package depends on the `@babel/core` module.
+
+```bash
+yarn add @babel/core @babel/preset-env @babel/preset-react --dev
+npm install @babel/core @babel/preset-env @babel/preset-react --save-dev
+```
+
+##### Parameters
+
+| Name          | Type            | Description                                                                     | ?Default                           |
+| ------------- | --------------- | ------------------------------------------------------------------------------- | ---------------------------------- |
+| config        | `Object`        | when using other fuse-box only properties, babel config is passed in as .config |                                    |
+| limit2project | `boolean`       | to use this plugin across an entire project (including other modules like npm)  | `true`                             |
+| extensions    | `Array<string>` | file extensions to allow with fuse-box                                          | `[".jsx"]`                         |
+| test          | `Regex`         | files to match                                                                  | <code>/\\.(j&#124;t)s(x)?$/</code> |
+
+## Examples
+
+### JSX
+
+```js
+const { Babel7Plugin } = require("fuse-box");
+
+plugins: [
+  Babel7Plugin({
+    config: {
+      sourceMaps: true,
+      presets: ["@babel/preset-env", "@babel/preset-react"],
+    },
+  }),
+];
+```
+
+### Shorthand
+
+when only passing in a babel config, there is no need for .config
+
+```js
+plugins: [
+  Babel7Plugin({
+    presets: ["es2015"],
+  }),
+];
+```
+
+note: The Babel7Plugin will merge options from your .babelrc file and any options
+passed into the plugin directly. If an option exists in both, then the options
+object passed into the plugin will take priority.

--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
   },
   "description": "Fuse-Box a bundler that does it right",
   "devDependencies": {
+    "@babel/core": "^7.2.2",
+    "@babel/preset-env": "^7.2.3",
     "@types/node": "^6.0.116",
     "@types/styled-components": "^4.1.3",
     "babel-core": "^6.26.3",

--- a/src/plugins/js-transpilers/Babel7Plugin.ts
+++ b/src/plugins/js-transpilers/Babel7Plugin.ts
@@ -1,0 +1,170 @@
+import * as fs from "fs";
+import * as path from "path";
+import { File } from "../../core/File";
+import { string2RegExp } from "../../Utils";
+import { WorkFlowContext } from "../../core/WorkflowContext";
+import { Plugin } from "../../core/WorkflowContext";
+
+let babel7Core;
+
+/**
+ * @export
+ * @class FuseBoxBabel7Plugin
+ * @implements {Plugin}
+ */
+export class Babel7PluginClass implements Plugin {
+	/**
+	 * We can add tsx and ts here as well
+	 * Because Babel won't capture it just being a Plugin
+	 * Typescript files are handled before any external plugin is executed
+	 */
+	public extensions: Array<string> = [".jsx"];
+	public test: RegExp = /\.(j|t)s(x)?$/;
+	public context: WorkFlowContext;
+	private limit2project: boolean = true;
+
+	private config?: any = {};
+	private configPrinted = false;
+	private configLoaded = false;
+
+	constructor(opts: any = { ast: true }) {
+		// if it is an object containing only a babel config
+		if (
+			opts.config === undefined &&
+			opts.test === undefined &&
+			opts.limit2project === undefined &&
+			opts.extensions === undefined &&
+			Object.keys(opts).length
+		) {
+			this.config = opts;
+			return;
+		}
+
+		if (opts.config) {
+			this.config = Object.assign({ ast: true }, opts.config);
+		}
+		if (opts.extensions !== undefined) {
+			this.extensions = opts.extensions;
+			if (opts.test === undefined) {
+				this.test = string2RegExp(opts.extensions.join("|"));
+			}
+		}
+		if (opts.test !== undefined) {
+			this.test = opts.test;
+		}
+		if (opts.limit2project !== undefined) {
+			this.limit2project = opts.limit2project;
+		}
+	}
+
+	/**
+	 * @see this.init
+	 */
+	private handleBabelRc() {
+		if (this.configLoaded) return;
+
+		let babelRcConfig;
+		let babelRcPath = path.join(this.context.appRoot, `.babelrc`);
+
+		if (fs.existsSync(babelRcPath)) {
+			babelRcConfig = fs.readFileSync(babelRcPath).toString();
+
+			if (babelRcConfig) {
+				babelRcConfig = Object.assign({}, JSON.parse(babelRcConfig), this.config);
+			}
+		}
+
+		if (babelRcConfig) {
+			this.config = babelRcConfig;
+		}
+
+		this.configLoaded = true;
+	}
+
+	/**
+	 * @param {WorkFlowContext} context
+	 */
+	public init(context: WorkFlowContext) {
+		this.context = context;
+		if (Array.isArray(this.extensions)) {
+			this.extensions.forEach(ext => context.allowExtension(ext));
+		}
+		this.handleBabelRc();
+	}
+
+	/**
+	 * @param {File} file
+	 */
+	public transform(file: File) {
+		file.wasTranspiled = true;
+		if (!babel7Core) {
+			babel7Core = require("@babel/core");
+		}
+		if (this.configPrinted === false && this.context.doLog === true) {
+			file.context.debug("Babel7Plugin", `\n\tConfiguration: ${JSON.stringify(this.config)}`);
+			this.configPrinted = true;
+		}
+
+		if (this.context.useCache) {
+			if (file.loadFromCache()) {
+				return;
+			}
+		}
+
+		// contents might not be loaded if using a custom file extension
+		file.loadContents();
+
+		// whether we should transform the contents
+		// @TODO needs improvement for the regex matching of what to include
+		//       with globs & regex
+		if (this.limit2project === false || file.collection.name === file.context.defaultPackageName) {
+			let result;
+			try {
+				result = babel7Core.transformSync(file.contents, Object.assign({ ast: true }, this.config));
+			} catch (e) {
+				file.analysis.skip();
+				console.error(e);
+				return;
+			}
+
+			// By default we would want to limit the babel
+			// And use acorn instead (it's faster)
+			if (result.ast) {
+				file.analysis.loadAst(result.ast);
+				let sourceMaps = result.map;
+
+				// escodegen does not really like babel
+				// so a custom function handles transformation here if needed
+				// This happens only when the code is required regeneration
+				// for example with aliases -> in any cases this will stay untouched
+				file.context.setCodeGenerator(ast => {
+					const result = babel7Core.transformFromAstSync(ast);
+					sourceMaps = result.map;
+					return result.code;
+				});
+
+				file.contents = result.code;
+				file.analysis.analyze();
+
+				if (sourceMaps) {
+					sourceMaps.file = file.info.fuseBoxPath;
+					sourceMaps.sources = [file.context.sourceMapsRoot + "/" + file.info.fuseBoxPath];
+					if (!file.context.inlineSourceMaps) {
+						delete sourceMaps.sourcesContent;
+					}
+
+					file.sourceMap = JSON.stringify(sourceMaps);
+				}
+
+				if (this.context.useCache) {
+					this.context.emitJavascriptHotReload(file);
+					this.context.cache.writeStaticCache(file, file.sourceMap);
+				}
+			}
+		}
+	}
+}
+
+export const Babel7Plugin = (opts: any = {}) => {
+	return new Babel7PluginClass(opts);
+};

--- a/src/plugins/js-transpilers/Babel7Plugin.ts
+++ b/src/plugins/js-transpilers/Babel7Plugin.ts
@@ -98,7 +98,15 @@ export class Babel7PluginClass implements Plugin {
 	public transform(file: File) {
 		file.wasTranspiled = true;
 		if (!babel7Core) {
-			babel7Core = require("@babel/core");
+			try {
+				babel7Core = require("@babel/core");
+			} catch (error) {
+				if (error.code === "MODULE_NOT_FOUND") {
+					const message = "Babel7Plugin - requires @babel/core to be installed";
+					throw new Error(message);
+				}
+				throw error;
+			}
 		}
 		if (this.configPrinted === false && this.context.doLog === true) {
 			file.context.debug("Babel7Plugin", `\n\tConfiguration: ${JSON.stringify(this.config)}`);

--- a/src/tests/plugins/Babel7Plugin.test.ts
+++ b/src/tests/plugins/Babel7Plugin.test.ts
@@ -1,0 +1,62 @@
+import { createEnv } from "./../stubs/TestEnvironment";
+import { FuseTestEnv } from "../stubs/FuseTestEnv";
+import { should } from "fuse-test-runner";
+import { Babel7Plugin } from "../../plugins/js-transpilers/Babel7Plugin";
+
+export class Babel7PluginTest {
+	"Should bundle wxyz with Babel using extensions"() {
+		return createEnv({
+			project: {
+				files: {
+					"index.wxyz": `export {default as canada} from './moose/eh/igloo.wxyz'`,
+					"moose/eh/igloo.wxyz": "export default { result: 'igloo'}",
+				},
+				instructions: "index.wxyz",
+				plugins: [Babel7Plugin({ extensions: [".wxyz"], config: { presets: ["@babel/preset-env"] } })],
+			},
+		}).then(result => {
+			const out = result.project.FuseBox.import("./index.wxyz");
+			should(out).deepEqual({ canada: { result: "igloo" } });
+		});
+	}
+
+	"Should allow extension overrides"() {
+		return FuseTestEnv.create({
+			project: {
+				extensionOverrides: [".foo.js"],
+				plugins: [Babel7Plugin({ config: { presets: ["@babel/preset-env"] } })],
+				files: {
+					"index.js": `export {getMessage} from './hello'`,
+					"hello.js": `export function getMessage() { return 'I should not be included'; }`,
+					"hello.foo.js": `export function getMessage() { return 'I should be included'; }`,
+				},
+			},
+		})
+			.simple("> index.js")
+			.then(env =>
+				env.browser(window => {
+					should(window.FuseBox.import("./index").getMessage()).equal("I should be included");
+				}),
+			);
+	}
+
+	"Should allow extension overrides with custom extensions"() {
+		return FuseTestEnv.create({
+			project: {
+				extensionOverrides: [".foo.wxyz"],
+				plugins: [Babel7Plugin({ extensions: [".wxyz"], config: { presets: ["@babel/preset-env"] } })],
+				files: {
+					"index.wxyz": `export {getMessage} from './hello.wxyz'`,
+					"hello.wxyz": `export function getMessage() { return 'I should not be included'; }`,
+					"hello.foo.wxyz": `export function getMessage() { return 'I should be included'; }`,
+				},
+			},
+		})
+			.simple("> index.wxyz")
+			.then(env =>
+				env.browser(window => {
+					should(window.FuseBox.import("./index.wxyz").getMessage()).equal("I should be included");
+				}),
+			);
+	}
+}

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -39,6 +39,7 @@
   "plugins": {
     "Plugins": [
       "plugins/babel-plugin",
+      "plugins/babel7-plugin",
       "plugins/coffee-plugin",
       "plugins/consolidate-plugin",
       "plugins/copy-plugin",


### PR DESCRIPTION
Hello there,

I've ported babel plugin to use babel7 core module. The discussion can be found [here](https://github.com/fuse-box/fuse-box/issues/1364)

I've mentioned that I wanted to make babel auto polyfill work together with this plugin. However, to keep this simple, I've only ported the previous plugin to make it work with babel7.

Notes:
- `ast: true` is provided and merged explicitly with the config because on babel7 this property defaults to `false`. To sum up, to keep it consistent with the previous babel plugin.
- Technically there is no need for this plugin to handle loading `.babelrc` since `configFile` or `babelrc` props can be passed as part of the config [(see #configfile)](https://babeljs.io/docs/en/options#configfile) and let babel core handle it. However, this is up for discussion since `babelrc` will look for `.babelrc` relatively to the filename (fuse.js) and not relatively to `homeDir`. It wasn't an issue with the previous babel plugin but on babel7 there is also `babel.config.js` which is a JS file that cannot be loaded as we currently do (in previous plugin and this plugin). However, it can be loaded through `configFile` prop config.