### PR TITLE
fix(Sparky): correct target type of SparkyContext (resolve #1464)

### DIFF
--- a/src/sparky/SparkyContext.ts
+++ b/src/sparky/SparkyContext.ts
@@ -13,14 +13,14 @@ export function getSparkyContext() {
 	return SparkyCurrentContext;
 }
 
-export function SparkyContext(target: () => { [key: string]: any } | (new () => any) | { [key: string]: any }) {
+export function SparkyContext(target: { [key: string]: any } | (new () => any) | (() => { [key: string]: any })) {
 	if (utils.isPlainObject(target)) {
 		SparkyCurrentContext = target;
 	} else if (isClass(target)) {
 		const Class: any = target;
 		SparkyCurrentContext = new Class();
 	} else if (utils.isFunction(target)) {
-		SparkyCurrentContext = target();
+		SparkyCurrentContext = (<Function>target)();
 	}
 	return new SparkyContextClass(SparkyCurrentContext);
 }


### PR DESCRIPTION
The type of `target` should allow for a class, a function returning a plain object, or a plain object.