### PR TITLE
Improve Babel7Plugin and handle JS Babel configuration

### DIFF
--- a/docs/plugins/babel7.md
+++ b/docs/plugins/babel7.md
@@ -20,14 +20,15 @@ npm install @babel/core @babel/preset-env @babel/preset-react --save-dev
 
 | Name          | Type            | Description                                                                     | ?Default                           |
 | ------------- | --------------- | ------------------------------------------------------------------------------- | ---------------------------------- |
-| config        | `Object`        | when using other fuse-box only properties, babel config is passed in as .config |                                    |
-| limit2project | `boolean`       | to use this plugin across an entire project (including other modules like npm)  | `true`                             |
-| extensions    | `Array<string>` | file extensions to allow with fuse-box                                          | `[".jsx"]`                         |
-| test          | `Regex`         | files to match                                                                  | <code>/\\.(j&#124;t)s(x)?$/</code> |
+| configFile    | `String` \| `Boolean` \| `undefined`        | Relative path to `.babelrc` or `babel.config.js` babel config file from FuseBox' `homeDir`. When not set or `undefined`, it will lookup for a config file relatively to `homeDir` and auto-load if any found. To disable auto-load and lookup, set to `false` | `undefined`                                   |
+| config        | `Object`        | Babel config options. Takes priority over configuration loaded from `configFile` | `undefined` |
+| limit2project | `boolean`       | To use this plugin across an entire project (including other modules like npm)  | `true`                             |
+| extensions    | `Array<string>` | File extensions allowed to be transpiled with fuse-box      | `[".js", ".jsx", ".ts", ".tsx"]`                       |
+| test          | `Regex`         | RegExp for matching file extensions. If `extensions` is provided, this property is ignored.                          | <code>/\\.(j&#124;t)s(x)?$/</code> |
 
 ## Examples
 
-### JSX
+### JSX and Source-Maps
 
 ```js
 const { Babel7Plugin } = require("fuse-box");
@@ -44,16 +45,35 @@ plugins: [
 
 ### Shorthand
 
-when only passing in a babel config, there is no need for .config
+when only passing in a babel config, there is no need to specify `config` property
 
 ```js
 plugins: [
   Babel7Plugin({
-    presets: ["es2015"],
+    presets: ["@babel/preset-env"],
   }),
 ];
 ```
 
-note: The Babel7Plugin will merge options from your .babelrc file and any options
-passed into the plugin directly. If an option exists in both, then the options
-object passed into the plugin will take priority.
+### Loading `.babelrc` babel configuration
+
+- assuming `.babelrc` is located in `./config`
+- assuming `fuse.js` is located in `./` with `homeDir: './'`
+```js
+plugins: [
+  Babel7Plugin({ configFile: "./config/.babelrc" })
+]
+```
+
+### Loading project-wide JavaScript babel configuration
+- assuming `babel.config.js` is located in `./config`
+- assuming `fuse.js` is located in `./` with `homeDir: './'`
+```js
+plugins: [
+  Babel7Plugin({ configFile: "./config/babel.config.js" })
+]
+```
+
+## Notes
+- `babel.config.js` must have an object as default export
+- If you want to disable lookup for config files and do only manual configuration, set `configFile: false` and provide configuration options to `config` (e.g: `config: { presets: [...] }`)

--- a/docs/plugins/babel7.md
+++ b/docs/plugins/babel7.md
@@ -24,7 +24,7 @@ npm install @babel/core @babel/preset-env @babel/preset-react --save-dev
 | config        | `Object`        | Babel config options. Takes priority over configuration loaded from `configFile` | `undefined` |
 | limit2project | `boolean`       | To use this plugin across an entire project (including other modules like npm)  | `true`                             |
 | extensions    | `Array<string>` | File extensions allowed to be transpiled with fuse-box      | `[".js", ".jsx", ".ts", ".tsx"]`                       |
-| test          | `Regex`         | RegExp for matching file extensions. If `extensions` is provided, this property is ignored.                          | <code>/\\.(j&#124;t)s(x)?$/</code> |
+| test          | `Regex`         | RegExp for matching file extensions                          | <code>/\\.(j&#124;t)s(x)?$/</code> |
 
 ## Examples
 

--- a/src/tests/plugins/Babel7PluginConfig/plugin-test.js
+++ b/src/tests/plugins/Babel7PluginConfig/plugin-test.js
@@ -1,0 +1,20 @@
+// Helper, check if local plugin is loaded
+module.exports = function testPlugin(api) {
+	api.assertVersion(7);
+	return {
+		name: "plugin-test",
+		visitor: {
+			FunctionDeclaration({ node }) {
+				// Helper, checks whether plugin was called or not successfully
+				node.id.name = "IwasTranspiledWithBabel";
+			},
+			StringLiteral({ node }, state) {
+				// Helper, checks if filename is provided in parser options in Babel7 plugin | Issue #1463
+				if (node.value === "replaceWithFilename") {
+					const { filename } = state.file.opts;
+					node.value = String(filename || '');
+				}
+			}
+		}
+	};
+};


### PR DESCRIPTION
Hey,

- solves the issue mentioned at [issues/1463](https://github.com/fuse-box/fuse-box/issues/1463) that happens when `filename` is not passed when transpiling in the configuration. Some plugins wouldn't work before
- improves defaults or required config that must be always set in order to transpile. e.g: `ast: true, code: true, ...`
- validates configuration with `loadOptions` and `loadPartialOptions` from Babel7 core which ensures a valid configuration is provided on init. e.g: presets and/or plugins are resolvable and fails when extra properties or typos in properties' names
- added handling babel JS config files such as `babel.config.js`
- improve lookup for `.babelrc` or `babel.config.js` files relatively to `homeDir`
- added option `fileConfig` which can be `false | string | undefined`. `false` disables lookup for config files, when `string` locates and loads config file
- added more tests
- updated docs