### PR TITLE
Report diagnostic errors on compilerOptions - #1457

### DIFF
--- a/src/Log.ts
+++ b/src/Log.ts
@@ -469,6 +469,10 @@ export class Log {
 		log.red(msg).echo();
 		return this;
 	}
+	public echoBlue(msg) {
+		log.blue(msg).echo();
+		return this;
+	}
 	public echoBreak() {
 		log.green(`\n  -------------- \n`).echo();
 		return this;

--- a/src/analysis/plugins/LanguageLevel.ts
+++ b/src/analysis/plugins/LanguageLevel.ts
@@ -3,17 +3,17 @@ import { File, ScriptTarget } from "../../core/File";
 export class LanguageLevel {
 	public static onNode(file: File, node: any, parent: any) {
 		if (node.async === true) {
-			file.setLanguageLevel(ScriptTarget.es2017);
+			file.setLanguageLevel(ScriptTarget.ES2017);
 		} else if (node.kind === "const") {
-			file.setLanguageLevel(ScriptTarget.es2015);
+			file.setLanguageLevel(ScriptTarget.ES2017);
 		} else if (node.kind === "let") {
-			file.setLanguageLevel(ScriptTarget.es2015);
+			file.setLanguageLevel(ScriptTarget.ES2015);
 		} else if (node.type === "ArrowFunctionExpression") {
-			file.setLanguageLevel(ScriptTarget.es2015);
+			file.setLanguageLevel(ScriptTarget.ES2015);
 		} else if (node.type === "TemplateLiteral") {
-			file.setLanguageLevel(ScriptTarget.es2015);
+			file.setLanguageLevel(ScriptTarget.ES2015);
 		} else if (node.type === "ClassDeclaration") {
-			file.setLanguageLevel(ScriptTarget.es2015);
+			file.setLanguageLevel(ScriptTarget.ES2015);
 		}
 	}
 	public static onEnd(file: File) {

--- a/src/core/CombinedTargetAndLanguageLevel.ts
+++ b/src/core/CombinedTargetAndLanguageLevel.ts
@@ -16,7 +16,7 @@ export class CombinedTargetAndLanguageLevel {
 		return level ? ScriptTarget[level] : undefined;
 	}
 
-	public getLanguageLevelOrDefault(defaultLanguageLevel: ScriptTarget = ScriptTarget.es2018) {
+	public getLanguageLevelOrDefault(defaultLanguageLevel: ScriptTarget = ScriptTarget.ES2018) {
 		const languageLevel = this.getLanguageLevel();
 		return languageLevel ? languageLevel : defaultLanguageLevel;
 	}

--- a/src/core/File.ts
+++ b/src/core/File.ts
@@ -6,20 +6,13 @@ import { SourceMapGenerator } from "./SourceMapGenerator";
 import { utils, each } from "realm-utils";
 import * as fs from "fs";
 import * as path from "path";
+import * as ts from "typescript"
 import { ensureFuseBoxPath, readFuseBoxModule, isStylesheetExtension, fastHash, joinFuseBoxPath } from "../Utils";
 
 /**
- * Same Target Enumerator used in TypeScript
+ * Same Target Enumerator used in current installed version of TypeScript
  */
-export enum ScriptTarget {
-	ES5 = 1,
-	ES2015 = 2,
-	ES6 = 2,
-	ES2016 = 3,
-	ES7 = 3,
-	ES2017 = 4,
-	ESNext = 5,
-}
+export { ScriptTarget } from "typescript";
 
 /**
  *
@@ -30,7 +23,7 @@ export enum ScriptTarget {
 export class File {
 	public isFuseBoxBundle = false;
 
-	public languageLevel = ScriptTarget.ES5;
+	public languageLevel = ts.ScriptTarget.ES5;
 
 	public es6module = false;
 
@@ -204,7 +197,7 @@ export class File {
 		return file;
 	}
 
-	public setLanguageLevel(level: ScriptTarget) {
+	public setLanguageLevel(level: ts.ScriptTarget) {
 		if (this.languageLevel < level) {
 			this.languageLevel = level;
 		}
@@ -637,20 +630,11 @@ export class File {
 		}
 	}
 
-	public transpileUsingTypescript() {
+	public transpileUsingTypescript(): ts.TranspileOutput | never {
 		try {
-			const ts = require("typescript");
-			try {
-				return ts.transpileModule(this.contents, this.getTranspilationConfig());
-			} catch (e) {
-				this.context.fatal(`${this.info.absPath}: ${e}`);
-				return;
-			}
+			return ts.transpileModule(this.contents, this.getTranspilationConfig())
 		} catch (e) {
-			this.context.fatal(`TypeScript automatic transpilation has failed. Please check that:
-            - You have TypeScript installed
-            - Your tsconfig.json file is not malformed.\nError message: ${e.message}`);
-			return;
+			this.context.fatal(`${this.info.absPath}: ${e}`);
 		}
 	}
 

--- a/src/core/TypescriptConfig.ts
+++ b/src/core/TypescriptConfig.ts
@@ -93,26 +93,6 @@ export class TypescriptConfig {
 			this.logAllDiagnostics(normalizedCompilerOptions.errors);
 		}
 		this.config.compilerOptions = compilerOptions = normalizedCompilerOptions.options;
-		/**
-		 * Explicitely un-set in `transpileModule`:
-		 * https://github.com/Microsoft/TypeScript/blob/865b3e786277233585e1586edba52bf837b61b71/src/services/transpile.ts#L26
-		 * */
-		compilerOptions.isolatedModules = true;
-		compilerOptions.suppressOutputPathCheck = true;
-		compilerOptions.allowNonTsExtensions = true;
-		compilerOptions.noLib = true;
-		compilerOptions.lib = undefined;
-		compilerOptions.types = undefined;
-		compilerOptions.noEmit = undefined;
-		compilerOptions.noEmitOnError = undefined;
-		compilerOptions.paths = undefined;
-		compilerOptions.rootDirs = undefined;
-		compilerOptions.declaration = undefined;
-		compilerOptions.composite = undefined;
-		compilerOptions.declarationDir = undefined;
-		compilerOptions.out = undefined;
-		compilerOptions.outFile = undefined;
-		compilerOptions.noResolve = true;
 	}
 
 	private verifyTsLib() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import { breakCache } from "./CacheBreaker";
+import { ensureTypescriptInstalled } from './Utils'
 
+ensureTypescriptInstalled();
 // kill cache if required beforehand
 breakCache();
 

--- a/src/quantum/plugin/BundleWriter.ts
+++ b/src/quantum/plugin/BundleWriter.ts
@@ -13,7 +13,7 @@ export class BundleWriter {
 
 	private getUglifyJSOptions(bundle: Bundle): any {
 		let opts = this.core.opts.shouldUglify() || {};
-		const userTerser = this.core.context.languageLevel > ScriptTarget.es5 || !!opts.es6;
+		const userTerser = this.core.context.languageLevel > ScriptTarget.ES5 || !!opts.es6;
 		if (typeof opts === "boolean") {
 			opts = {};
 		}

--- a/src/tests/CombinedTargetAndLanguageLevel.test.ts
+++ b/src/tests/CombinedTargetAndLanguageLevel.test.ts
@@ -24,17 +24,17 @@ export class CombinedTargetAndLanguageLevelTest {
 	"Should detect target and language level"() {
 		const combination = new CombinedTargetAndLanguageLevel(`${TARGET_DUMMY}@es5`);
 		should(combination.getTarget()).equal(TARGET_DUMMY);
-		should(combination.getLanguageLevel()).equal(ScriptTarget.es5);
+		should(combination.getLanguageLevel()).equal(ScriptTarget.ES5);
 	}
 
 	"Should default to language level es2016"() {
 		const combination = new CombinedTargetAndLanguageLevel(TARGET_DUMMY);
-		should(combination.getLanguageLevelOrDefault()).equal(ScriptTarget.es2018);
+		should(combination.getLanguageLevelOrDefault()).equal(ScriptTarget.ES2018);
 	}
 
 	"Should detect target and language level (for default variant)"() {
 		const combination = new CombinedTargetAndLanguageLevel(`${TARGET_DUMMY}@es5`);
 		should(combination.getTarget()).equal(TARGET_DUMMY);
-		should(combination.getLanguageLevelOrDefault()).equal(ScriptTarget.es5);
+		should(combination.getLanguageLevelOrDefault()).equal(ScriptTarget.ES5);
 	}
 }

--- a/src/tests/QuantumCSSplitting.test.ts
+++ b/src/tests/QuantumCSSplitting.test.ts
@@ -229,7 +229,7 @@ export class QuantumCSSSplittingTest {
 				env.fileShouldExist("styles.css.map");
 				env.fileShouldExist("chunks/dcbf7349-ea9fe601.css");
 				env.fileShouldExist("chunks/ea9fe601.css.map");
-				env.fileShouldExist("chunks/c3eff8a7-ea9fe601.js");
+				env.fileShouldExist("chunks/b19fd844-ea9fe601.js");
 			},
 		);
 	}

--- a/src/tests/QuantumCSSplitting.test.ts
+++ b/src/tests/QuantumCSSplitting.test.ts
@@ -229,7 +229,7 @@ export class QuantumCSSSplittingTest {
 				env.fileShouldExist("styles.css.map");
 				env.fileShouldExist("chunks/dcbf7349-ea9fe601.css");
 				env.fileShouldExist("chunks/ea9fe601.css.map");
-				env.fileShouldExist("chunks/b19fd844-ea9fe601.js");
+				env.fileShouldExist("chunks/c3eff8a7-ea9fe601.js");
 			},
 		);
 	}


### PR DESCRIPTION
[issues/1457](https://github.com/fuse-box/fuse-box/issues/1457)

- ensure typescript is installed. Checks on `index.js` since it's the earliest when TS is not used
  - ensures minimal version of TS is `3.0`. Okay? :P
- replace `ScriptTarget` enum with `ts.ScriptTarget`
- parse and validate `compilerOptions`
  - only done once before cached
  - format error|warning|message using TS formatter but displayed as standard FuseBox errors/warnings format
  - once parsed, `compilerOptions` is compatible with `ts.CompilerOptions` which replaces strings with equivalent enums' values. For instance, `jsx: "react"` will be `jsx: ts.JsxEmit.React`. This is helpful for not having mixed configuration (string values | number values)
  - explicitly unset/set `compilerOptions` used in `transpileModule` [transpile.ts#L26](https://github.com/Microsoft/TypeScript/blob/865b3e786277233585e1586edba52bf837b61b71/src/services/transpile.ts#L26) **Edit: removed unset, I realized some of the options could be needed in plugins :P**
    - currently has no effect since `transpileModule` does exactly that. However, it'd spend less time trying to fix and parse internally `compilerOptions`. Probably the time spend is insignificant but I also consider that `transpileModule` could be ported to FuseBox since it's a small function and we could ignore the part where it tries to fix `compilerOptions` internally all over again for each file transpiled.
  - displays warnings|messages|errors but only throws on error to prevents transpilation with broken `compilerOptions`. Rather than having the user figuring out why it doesn't work, the diagnostic messages show a good explanation for every broken property in the config

Notes:
- All current tests pass
- I haven't figured out how to write a test to check when `this.context.fatal` throws with `Error: Invalid 'compilerOptions' settings`, so I checked manually on the playground breaking settings. e.g: `{ target: 'asdasd', jsx: 'asdasd' }`