### PR TITLE
Babel7 resolve imports/requires injected by preset-env (polyfills)

### DIFF
--- a/src/plugins/js-transpilers/Babel7Plugin.ts
+++ b/src/plugins/js-transpilers/Babel7Plugin.ts
@@ -4,6 +4,8 @@ import { File } from "../../core/File";
 import { string2RegExp } from "../../Utils";
 import { WorkFlowContext } from "../../core/WorkflowContext";
 import { Plugin } from "../../core/WorkflowContext";
+import { ASTTraverse } from "../../ASTTraverse"
+import { ImportDeclaration } from "../../analysis/plugins/ImportDeclaration";
 
 let babel7Core;
 
@@ -191,6 +193,14 @@ export class Babel7PluginClass implements Plugin {
 			// By default we would want to limit the babel
 			// And use acorn instead (it"s faster)
 			if (result.ast) {
+				// When using @babel/preset-env with, for example, useBuiltIns: 'entry' | 'usage'
+				// It adds `require` statements to core-js or @babel/polyfill
+				// So transverse and resolve import declarations if any found
+				ASTTraverse.traverse(result.ast, {
+					pre: (node, parent, prop, idx) => ImportDeclaration.onNode(file, node, parent),
+				});
+				ImportDeclaration.onEnd(file);
+
 				file.analysis.loadAst(result.ast);
 				let sourceMaps = result.map;
 

--- a/src/tests/plugins/Babel7Plugin.test.ts
+++ b/src/tests/plugins/Babel7Plugin.test.ts
@@ -203,4 +203,36 @@ export class Babel7PluginTest {
 				}),
 			);
 	}
+	"Should resolve injected imports/requires to polyfills from @babel/preset-env"() {
+		return FuseTestEnv.create({
+			project: {
+				files: {
+					"index.js": `
+						export const promise = Promise.resolve('core-js/es6.promise.js added _v')
+					`,
+				},
+				plugins: [
+					Babel7Plugin({
+						config: {
+							presets: [
+								[
+									"@babel/preset-env",
+									{
+										useBuiltIns: "usage",
+										include: ["es6.promise"],
+									},
+								],
+							]
+						}
+					})
+				],
+			},
+		})
+			.simple("> index.js")
+			.then(env =>
+				env.browser(window => {
+					should(window.FuseBox.import("./index.js").promise._v).equal("core-js/es6.promise.js added _v");
+				}),
+			);
+	}
 }


### PR DESCRIPTION
Discussion: [issues/1364](https://github.com/fuse-box/fuse-box/issues/1364)

- resolve imports/requires injected by `@babel/preset-env` to `core-js` polyfills if `useBuiltIns` option is defined to `usage`. This option is still experimental in Babel7. However, if there is any other babel plugin that injects imports/requires, those will be resolved as well
- added test to check if polyfill resolved as expected