### PR TITLE
Improve tsconfig checking

### DIFF
--- a/src/core/CombinedTargetAndLanguageLevel.ts
+++ b/src/core/CombinedTargetAndLanguageLevel.ts
@@ -1,4 +1,5 @@
 import { ScriptTarget } from "./File";
+import { getScriptLevelNumber } from "./TypescriptConfig";
 
 export class CombinedTargetAndLanguageLevel {
 	constructor(private combination: string) {
@@ -10,10 +11,10 @@ export class CombinedTargetAndLanguageLevel {
 		return target;
 	}
 
-	public getLanguageLevel(): ScriptTarget {
+	public getLanguageLevel(): ScriptTarget & number {
 		const [, languageLevel] = this.splitCombination();
-		const level = languageLevel && Object.keys(ScriptTarget).find(t => t.toLowerCase() === languageLevel);
-		return level ? ScriptTarget[level] : undefined;
+
+		return getScriptLevelNumber(languageLevel);
 	}
 
 	public getLanguageLevelOrDefault(defaultLanguageLevel: ScriptTarget = ScriptTarget.ES2018) {

--- a/src/core/FuseBox.ts
+++ b/src/core/FuseBox.ts
@@ -1,6 +1,5 @@
 import * as fs from "fs";
 import * as process from "process";
-import * as ts from "typescript";
 import { each, utils, chain, Chainable } from "realm-utils";
 import { CustomTransformers } from "typescript";
 import { ensureUserPath, contains, printCurrentVersion } from "./../Utils";
@@ -17,48 +16,15 @@ import { BundleProducer } from "./BundleProducer";
 import { Bundle } from "./Bundle";
 import { File } from "./File";
 import { ExtensionOverrides } from "./ExtensionOverrides";
-import { TypescriptConfig } from "./TypescriptConfig";
+import { TypescriptConfig, rawCompilerOptions } from "./TypescriptConfig";
 import { CombinedTargetAndLanguageLevel } from './CombinedTargetAndLanguageLevel';
 
 const appRoot = require("app-root-path");
 
-/**
- * Typecheck custom tsconfig provided as array.
- * It's Compiler options but replaced enums to equivalent strings keys
- * as it'd be seen in a `tsconfig.json` file
- * Check `typescript.d.ts`:
- * - `CompilerOptionsValue`
- * - `CompilerOptions`
- * e.g:
- * - Instead of `target: 1`, user can input `target: 'ES5'`
- */
-export type tsConfigFileCompilerOptions = {
-	[key in keyof ts.CompilerOptions]:
-	ts.CompilerOptions[key] extends string
-	? ts.CompilerOptions[key]
-	: ts.CompilerOptions[key] extends boolean
-	? ts.CompilerOptions[key]
-	: ts.CompilerOptions[key] extends ts.ScriptTarget
-	? keyof typeof ts.ScriptTarget
-	: ts.CompilerOptions[key] extends ts.JsxEmit
-	? keyof typeof ts.JsxEmit
-	: ts.CompilerOptions[key] extends string[]
-	? string[]
-	: ts.CompilerOptions[key] extends ts.ModuleKind
-	? keyof typeof ts.ModuleKind
-	: ts.CompilerOptions[key] extends ts.ModuleResolutionKind
-	? keyof typeof ts.ModuleResolutionKind
-	: ts.CompilerOptions extends ts.NewLineKind
-	? keyof typeof ts.NewLineKind
-	: ts.CompilerOptions extends ts.MapLike<string[]>
-	? ts.MapLike<string[]>
-	: string | number | boolean | (string | number)[] | string[] | ts.MapLike<string[]> | null | undefined
-}
-
 export interface FuseBoxOptions {
 	homeDir?: string;
 	modulesFolder?: string | string[];
-	tsConfig?: string | tsConfigFileCompilerOptions[];
+	tsConfig?: string | rawCompilerOptions[];
 	package?: string | { name: string; main: string };
 	dynamicImportsEnabled?: boolean;
 	cache?: boolean;
@@ -84,8 +50,8 @@ export interface FuseBoxOptions {
 	useTypescriptCompiler?: boolean;
 	standalone?: boolean;
 	sourceMaps?:
-		| boolean
-		| { vendor?: boolean; inlineCSSPath?: string; inline?: boolean; project?: boolean; sourceRoot?: string };
+	| boolean
+	| { vendor?: boolean; inlineCSSPath?: string; inline?: boolean; project?: boolean; sourceRoot?: string };
 	hash?: string | boolean;
 	ignoreModules?: string[];
 	customAPIFile?: string;

--- a/src/core/TypescriptConfig.ts
+++ b/src/core/TypescriptConfig.ts
@@ -5,9 +5,70 @@ import { ScriptTarget } from "./File";
 import * as fs from "fs";
 import { Config } from "../Config";
 import * as ts from "typescript";
-import { tsConfigFileCompilerOptions } from './FuseBox';
 
 const CACHED: { [path: string]: any } = {};
+
+/**
+ * Typecheck custom tsconfig provided as array.
+ * It's Compiler options but replaced enums to equivalent strings keys
+ * as it'd be seen in a `tsconfig.json` file
+ * Check `typescript.d.ts`:
+ * - `CompilerOptionsValue`
+ * - `CompilerOptions`
+ * e.g:
+ * - Instead of `target: 1`, user can input `target: 'ES5'`
+ */
+export type rawScriptTarget = Exclude<keyof typeof ts.ScriptTarget, "JSON" | "Latest">
+export type rawCompilerOptions = {
+	[key in keyof ts.CompilerOptions]: (
+		key extends "maxNodeModuleJsDepth"
+		? number
+		: ts.CompilerOptions[key] extends ts.ScriptTarget
+		? rawScriptTarget
+		: ts.CompilerOptions[key] extends ts.JsxEmit
+		? "react" | "preserve" | "react-native"
+		: ts.CompilerOptions[key] extends ts.ModuleKind
+		? keyof typeof ts.ModuleKind
+		: ts.CompilerOptions[key] extends ts.ModuleResolutionKind
+		? keyof typeof ts.ModuleResolutionKind
+		: ts.CompilerOptions[key] extends ts.NewLineKind
+		? "CRLF" | "LF"
+		: ts.CompilerOptions[key] extends ts.MapLike<string[]>
+		? ts.MapLike<string[]>
+		: ts.CompilerOptions[key] extends string[]
+		? string[]
+		: ts.CompilerOptions[key] extends string
+		? ts.CompilerOptions[key]
+		: ts.CompilerOptions[key] extends boolean
+		? ts.CompilerOptions[key]
+		: ts.CompilerOptions[key] extends number
+		? number
+		: any
+	)
+}
+
+export function getScriptLevelNumber(level: any): ScriptTarget & number | undefined {
+	if (Number.isNaN(Number(level)) && typeof level === "string") {
+		const key = Object
+			.keys(ScriptTarget)
+			.filter(k => !['json', 'latest'].includes(k.toLowerCase()))
+			.find(t => t.toLowerCase() === level.toLowerCase());
+		return key ? ScriptTarget[key] : undefined;
+	}
+	if (Number(level) in ScriptTarget && ScriptTarget.JSON !== Number(level)) {
+		return Number(level);
+	}
+}
+
+export function getScriptLevelString(level: any): rawScriptTarget | undefined {
+	if (Number(level) in ScriptTarget) {
+		const key = Object
+			.keys(ScriptTarget)
+			.filter(k => !['json', 'latest'].includes(k.toLowerCase()))
+			.find(t => ScriptTarget[t] === Number(level));
+		return key as rawScriptTarget;
+	}
+}
 
 export interface ICategorizedDiagnostics {
 	errors: ReadonlyArray<ts.Diagnostic & { category: ts.DiagnosticCategory.Error }>,
@@ -16,10 +77,36 @@ export interface ICategorizedDiagnostics {
 	suggestions: ReadonlyArray<ts.Diagnostic & { category: ts.DiagnosticCategory.Suggestion }>,
 }
 
+export interface TSParsedConfig {
+	errors: Array<ts.Diagnostic | ts.DiagnosticWithLocation> | ts.SortedReadonlyArray<ts.Diagnostic>,
+	compilerOptions: ts.CompilerOptions,
+	compileOnSave?: boolean,
+	projectReferences?: ReadonlyArray<ts.ProjectReference>,
+	raw?: rawCompilerOptions,
+	typeAcquisition?: ts.TypeAcquisition,
+	wildcardDirectories?: ts.MapLike<ts.WatchDirectoryFlags>,
+}
+
+export const IGNORED_DIAGNOSTICS = new Set([
+	6059, // "'rootDir' is expected to contain all source files. -> FuseBox contains all source files"
+	18002, // "The 'files' list in config file is empty. -> Again, FuseBox ..."
+	18003, // "No inputs were found in config file. -> Again, FuseBox ..."
+]);
+export function makePathDoesNotExistDiagnostic(path: string): ts.Diagnostic {
+	return {
+		code: 5058, // Specified path does not exist
+		category: ts.DiagnosticCategory.Error,
+		messageText: `The specified path does not exist: '${path}'.`,
+		file: undefined,
+		length: undefined,
+		start: undefined,
+	}
+}
+
 export class TypescriptConfig {
 	// the actual typescript config
-	private config: any;
-	private customTsConfig: string | tsConfigFileCompilerOptions[];
+	private config: TSParsedConfig;
+	private customTsConfig: string | rawCompilerOptions[];
 	private configFile: string;
 	private formatDiagnosticsHost: ts.FormatDiagnosticsHost;
 	constructor(public context: WorkFlowContext) {
@@ -35,12 +122,137 @@ export class TypescriptConfig {
 		return this.config;
 	}
 
+	public normalizeDiagnostics(diagnostics: ts.Diagnostic[]): ts.SortedReadonlyArray<ts.Diagnostic> {
+		return ts.sortAndDeduplicateDiagnostics(diagnostics.filter(x => !IGNORED_DIAGNOSTICS.has(x.code)))
+	}
+
+	private findConfigFileBackwards(tsConfigFilePath: string): string {
+		return findFileBackwards(tsConfigFilePath, this.context.appRoot);
+	}
+
+	public readJsonConfigFile(): TSParsedConfig {
+		const config: TSParsedConfig = { compilerOptions: {}, errors: [] };
+
+		this.configFile = (
+			typeof this.customTsConfig === "string"
+				? ensureUserPath(this.customTsConfig)
+				: this.findConfigFileBackwards(path.join(this.context.homeDir, "tsconfig.json"))
+		);
+
+		if (this.configFile) {
+			if (!ts.sys.fileExists(this.configFile)) {
+				config.errors = [makePathDoesNotExistDiagnostic(this.configFile)];
+				return config
+			}
+			const configFileRelPath = this.configFile.replace(this.context.appRoot, "");
+			this.context.log.echoInfo(`Typescript config file:  ${configFileRelPath}`);
+
+			// Note: if tsconfig file contains e.g: `extends: "othertsconfig.json"`
+			// this is handled automatically by `readJsonConfigFile`
+			const JSONSourceFile = ts.readJsonConfigFile(this.configFile, ts.sys.readFile);
+			const parsedJSONFile = ts.parseConfigFileTextToJson(this.configFile, JSONSourceFile.getFullText());
+
+			// Report syntax errors in tsconfig file
+			// Parsed using TS' own JSON parser
+			if (parsedJSONFile.error) {
+				config.errors = [parsedJSONFile.error];
+				return config;
+			}
+
+			// Report errors in tsconfig file (settings / options)
+			// Parse the `JSONSourceFile` as TS config JSON file.
+			// Better than `ts.convertCompilerOptionsFromJson`,
+			// it can map diagnostics to line | column
+			const parsedJSONConfigFile = ts.parseJsonSourceFileConfigFileContent(
+				JSONSourceFile,
+				ts.sys,
+				path.dirname(this.configFile),
+			)
+			if (parsedJSONConfigFile.errors.length) {
+				const errors = this.normalizeDiagnostics(parsedJSONConfigFile.errors);
+				if (errors.length) {
+					config.errors = errors;
+					return config;
+				}
+			}
+
+			Object.assign(
+				config,
+				{
+					compilerOptions: parsedJSONConfigFile.options,
+					compileOnSave: parsedJSONConfigFile.compileOnSave,
+					projectReferences: parsedJSONConfigFile.projectReferences,
+					raw: parsedJSONConfigFile.raw,
+					typeAcquisition: parsedJSONConfigFile.typeAcquisition,
+					wildcardDirectories: parsedJSONConfigFile.wildcardDirectories,
+				},
+			);
+		}
+
+		if (Array.isArray(this.customTsConfig)) {
+			const tsConfigOverrideCompilerOptions = {};
+			this.customTsConfig.forEach(config => {
+				if (
+					typeof config === "object" &&
+					config !== null
+				) {
+					Object.assign(tsConfigOverrideCompilerOptions, config);
+				} else { /** TODO! unknown type */ }
+			});
+
+			const parsedVirtualJSONConfig = ts.convertCompilerOptionsFromJson(
+				tsConfigOverrideCompilerOptions,
+				config.compilerOptions.baseUrl || ".",
+				""
+			);
+			const virtualJSONSourceFile = ts.parseJsonText(
+				"[FuseBoxOptions.tsConfig]",
+				JSON.stringify(this.customTsConfig)
+			);
+
+			const errors = this.normalizeDiagnostics(parsedVirtualJSONConfig.errors)
+			if (errors.length) {
+				const flattenError = errors[0];
+				flattenError.file = virtualJSONSourceFile;
+				flattenError.start = 0;
+				flattenError.length = virtualJSONSourceFile.getFullText().length;
+
+				for (let i = 1; i < errors.length; i++) {
+					const error = errors[i];
+					flattenError.messageText += '\n' + this.formatDiagnostic(error, false);
+				}
+
+				config.errors = [flattenError];
+				return config;
+			}
+		}
+
+		config.compilerOptions.module = ts.ModuleKind.CommonJS;
+
+		if (!("target" in config.compilerOptions)) {
+			config.compilerOptions.target = this.context.languageLevel;
+		}
+
+		if (
+			config.compilerOptions.allowSyntheticDefaultImports !== undefined &&
+			this.context.fuse &&
+			this.context.fuse.producer
+		) {
+			this.context.fuse.producer.allowSyntheticDefaultImports = config.compilerOptions.allowSyntheticDefaultImports;
+		}
+
+		return config
+	}
+
 	private defaultSetup() {
 		const compilerOptions = (this.config.compilerOptions = this.config.compilerOptions || {});
-		if (this.context.useSourceMaps) {
-			compilerOptions.sourceMap = true;
-			compilerOptions.inlineSources = true;
+
+		if (this.configFile && path.basename(this.configFile).startsWith('jsconfig.')) {
+			compilerOptions.allowJs = true
 		}
+		compilerOptions.sourceMap = this.context.useSourceMaps;
+		compilerOptions.inlineSources = this.context.useSourceMaps;
+
 		if (this.context.forcedLanguageLevel) {
 			this.forceCompilerTarget(this.context.forcedLanguageLevel);
 		}
@@ -66,38 +278,38 @@ export class TypescriptConfig {
 	}
 
 	public forceCompilerTarget(level: ScriptTarget) {
-		this.context.log.echoInfo(`Typescript forced script target: ${ScriptTarget[level]}`);
+		this.context.log.echoInfo(`Typescript forced script target: ${getScriptLevelString(level)}`);
 		const compilerOptions = (this.config.compilerOptions = this.config.compilerOptions || {});
-		compilerOptions.target = ScriptTarget[level];
+		compilerOptions.target = level;
 	}
 
-	public setConfigFile(customTsConfig: string | tsConfigFileCompilerOptions[]) {
+	public setConfigFile(customTsConfig: string | rawCompilerOptions[]) {
 		this.customTsConfig = customTsConfig;
 	}
 
 	private initializeConfig() {
-		const compilerOptions = this.config.compilerOptions;
-		compilerOptions.jsx = "react";
-		compilerOptions.importHelpers = true;
-		compilerOptions.emitDecoratorMetadata = true;
-		compilerOptions.experimentalDecorators = true;
-		const targetFile = path.join(this.context.homeDir, "tsconfig.json");
-		this.context.log.echoInfo(`Generating recommended tsconfig.json:  ${targetFile}`);
-		fs.writeFileSync(targetFile, JSON.stringify(this.config, null, 2));
-	}
-
-	private normalizeAndValidateCompilerOptions() {
-		let compilerOptions = this.config.compilerOptions
-		let normalizedCompilerOptions = ts.convertCompilerOptionsFromJson(compilerOptions, compilerOptions.baseUrl);
-
-		if (normalizedCompilerOptions.errors.length) {
-			this.logAllDiagnostics(normalizedCompilerOptions.errors);
+		if (!this.configFile && this.context.ensureTsConfig === true) {
+			Object.assign(this.config.compilerOptions, {
+				jsx: ts.JsxEmit.React,
+				baseUrl: '.',
+				importHelpers: true,
+				emitDecoratorMetadata: true,
+				experimentalDecorators: true,
+			})
+			// Raw compiler options
+			const compilerOptions: rawCompilerOptions = Object.assign({}, this.config.compilerOptions as any, {
+				target: getScriptLevelString(this.config.compilerOptions.target),
+				module: "CommonJS",
+				jsx: "react",
+			});
+			const targetFile = path.join(this.context.homeDir, "tsconfig.json");
+			this.context.log.echoInfo(`Generating recommended tsconfig.json:  ${targetFile}`);
+			fs.writeFileSync(targetFile, JSON.stringify({ compilerOptions }, null, 2));
 		}
-		this.config.compilerOptions = compilerOptions = normalizedCompilerOptions.options;
 	}
 
 	private verifyTsLib() {
-		if (this.config.compilerOptions.importHelpers === true) {
+		if (this.context.ensureTsConfig === true && this.config.compilerOptions.importHelpers === true) {
 			const tslibPath = path.join(Config.NODE_MODULES_DIR, "tslib");
 			if (!fs.existsSync(tslibPath)) {
 				this.context.log.echoWarning(
@@ -143,13 +355,21 @@ export class TypescriptConfig {
 		return { errors, warnings, messages, suggestions };
 	}
 
-	public formatDiagnostic(diagnostic: Readonly<ts.Diagnostic>): string {
-		return ts.formatDiagnosticsWithColorAndContext(
+	public formatDiagnostic(diagnostic: ts.Diagnostic, separator: boolean = true): string {
+		// TODO! make a custom formatter instead
+		diagnostic.messageText = `${diagnostic.messageText}\n`
+		const formatted = ts.formatDiagnosticsWithColorAndContext(
 			[diagnostic],
 			this.formatDiagnosticsHost,
 		)
 			.replace(/error|warning|message/, match => match.toUpperCase())
-			.replace(/\n/, '');
+			.replace(/ - /, '\n')
+			.split('\n')
+			.filter(m => String(m).trim().length)
+			.map((line, i) => i === 0 ? line : separator ? `  │ ${line}` : line)
+			.join('\n')
+
+		return formatted
 	}
 
 	public logDiagnosticsByCategory(diagnostics: ReadonlyArray<ts.Diagnostic>, category: ts.DiagnosticCategory): void {
@@ -184,109 +404,40 @@ export class TypescriptConfig {
 
 	public throwOnDiagnosticErrors(diagnostics: ReadonlyArray<ts.Diagnostic>): never | void {
 		if (diagnostics.length) {
-			this.logDiagnosticsByCategory(diagnostics, ts.DiagnosticCategory.Error)
+			this.logDiagnosticsByCategory(diagnostics, ts.DiagnosticCategory.Error);
 
-			let errorMessage = `  └─ Invalid 'compilerOptions'`
+			let errorMessage = `  └─ Invalid 'compilerOptions'`;
 
-			if (this.configFile) {
-				errorMessage += `\n      - Verify the 'compilerOptions' in your Typescript config file:\n\n        ${this.configFile}\n`
-			}
-			if (Array.isArray(this.customTsConfig)) {
-				errorMessage += `\n      - Verify the 'compilerOptions' that you provided to FuseBox in the 'tsConfig' array property.`
-			}
-
-			this.context.log.echoBoldRed(`${errorMessage}\n`)
-			process.exit(1)
+			this.context.log.echoBoldRed(`${errorMessage}\n`);
+			process.exit(1);
 		}
 	}
 
 	public read() {
-		const cacheKey =
-			(typeof this.customTsConfig === "string" ? this.customTsConfig : this.context.homeDir) +
-			this.context.target +
-			this.context.languageLevel;
+		const cacheKey = (
+			typeof this.customTsConfig === "string"
+				? this.customTsConfig
+				: this.context.homeDir
+		) + this.context.target + this.context.languageLevel;
+
 		if (CACHED[cacheKey]) {
 			this.config = CACHED[cacheKey];
 			return;
-		} else {
-			let tsConfigFilePath;
-			let config: any = {
-				compilerOptions: {},
-			};
-			let configFileFound = false;
-			let tsConfigOverride: any;
-			if (typeof this.customTsConfig === "string") {
-				this.configFile = ensureUserPath(this.customTsConfig);
-			} else {
-				tsConfigFilePath = path.join(this.context.homeDir, "tsconfig.json");
-				let tsconfig = findFileBackwards(tsConfigFilePath, this.context.appRoot);
-				if (tsconfig) {
-					configFileFound = true;
-					this.configFile = tsconfig;
-				}
-			}
-			if (this.configFile) {
-				const configFileRelPath = this.configFile.replace(this.context.appRoot, "");
-				this.context.log.echoInfo(`Typescript config file:  ${configFileRelPath}`);
-				configFileFound = true;
-				const res = readConfigFile(this.configFile, this.context.appRoot);
-				config = res.config;
-				if (res.error) {
-					this.logAllDiagnostics([res.error]);
-				}
-			}
-
-			if (Array.isArray(this.customTsConfig)) {
-				tsConfigOverride = {}
-				this.customTsConfig.forEach(config => Object.assign(tsConfigOverride, config))
-			}
-
-			config.compilerOptions.module = "commonjs";
-			if (!("target" in config.compilerOptions)) {
-				config.compilerOptions.target = ScriptTarget[this.context.languageLevel];
-			}
-			if (tsConfigOverride) {
-				config.compilerOptions = Object.assign(config.compilerOptions, tsConfigOverride);
-			}
-			// allowSyntheticDefaultImports
-			if (config.compilerOptions.allowSyntheticDefaultImports !== undefined) {
-				if (this.context.fuse && this.context.fuse.producer) {
-					this.context.fuse.producer.allowSyntheticDefaultImports = config.compilerOptions.allowSyntheticDefaultImports;
-				}
-			}
-			this.config = config;
-
-			this.defaultSetup();
-			if (!configFileFound && this.context.ensureTsConfig === true) {
-				this.initializeConfig();
-			}
-			if (this.context.ensureTsConfig === true) {
-				this.verifyTsLib();
-			}
-			this.normalizeAndValidateCompilerOptions()
-			this.context.log.echoInfo(`Typescript script target: ${ts.ScriptTarget[config.compilerOptions.target]}`);
-			CACHED[cacheKey] = this.config;
 		}
-	}
-}
 
-function readConfigFile(configFilePath: string, rootDir: string) {
-	const res = ts.readConfigFile(configFilePath, ts.sys.readFile);
-	if (res.error || !res.config || !res.config.extends) return res;
+		const config = this.readJsonConfigFile();
 
-	const extendsFilePath = res.config.extends;
-	const parentRes = readConfigFile(
-		path.isAbsolute(extendsFilePath) ? extendsFilePath : path.join(rootDir, extendsFilePath),
-		rootDir,
-	);
-	if (parentRes.config) {
-		const config = { ...res.config };
-		delete config.extends;
-		res.config = {
-			...parentRes.config,
-			...config,
-			compilerOptions: { ...parentRes.config.compilerOptions, ...config.compilerOptions },
-		};
+		if (config.errors.length) {
+			this.logAllDiagnostics(config.errors);
+			return process.exit(1);
+		}
+
+		this.config = config;
+		this.defaultSetup();
+		this.initializeConfig();
+		this.verifyTsLib();
+
+		this.context.log.echoInfo(`Typescript script target: ${getScriptLevelString(config.compilerOptions.target)}`);
+		CACHED[cacheKey] = this.config;
 	}
-	return res;
 }

--- a/src/core/WorkflowContext.ts
+++ b/src/core/WorkflowContext.ts
@@ -113,8 +113,10 @@ export class WorkFlowContext {
 	public pendingPromises: Promise<any>[] = [];
 
 	public emitHMRDependencies = false;
-	public languageLevel: ScriptTarget;
-	public forcedLanguageLevel: ScriptTarget;
+
+	public languageLevel: ScriptTarget & number;
+
+	public forcedLanguageLevel: ScriptTarget & number;
 
 	public filterFile: { (file: File): boolean };
 

--- a/src/tests/CombinedTargetAndLanguageLevel.test.ts
+++ b/src/tests/CombinedTargetAndLanguageLevel.test.ts
@@ -25,16 +25,25 @@ export class CombinedTargetAndLanguageLevelTest {
 		const combination = new CombinedTargetAndLanguageLevel(`${TARGET_DUMMY}@es5`);
 		should(combination.getTarget()).equal(TARGET_DUMMY);
 		should(combination.getLanguageLevel()).equal(ScriptTarget.ES5);
+		should(combination.getLanguageLevel()).beNumber();
 	}
 
-	"Should default to language level es2016"() {
+	"Should default to language level es2018"() {
 		const combination = new CombinedTargetAndLanguageLevel(TARGET_DUMMY);
 		should(combination.getLanguageLevelOrDefault()).equal(ScriptTarget.ES2018);
+		should(combination.getLanguageLevelOrDefault()).beNumber();
 	}
 
 	"Should detect target and language level (for default variant)"() {
 		const combination = new CombinedTargetAndLanguageLevel(`${TARGET_DUMMY}@es5`);
 		should(combination.getTarget()).equal(TARGET_DUMMY);
 		should(combination.getLanguageLevelOrDefault()).equal(ScriptTarget.ES5);
+		should(combination.getLanguageLevelOrDefault()).beNumber();
+	}
+	"Should detect target and language level (for default variant [number])"() {
+		const combination = new CombinedTargetAndLanguageLevel(`${TARGET_DUMMY}@1`);
+		should(combination.getTarget()).equal(TARGET_DUMMY);
+		should(combination.getLanguageLevelOrDefault()).equal(ScriptTarget.ES5);
+		should(combination.getLanguageLevelOrDefault()).beNumber();
 	}
 }

--- a/src/tests/TypescriptConfig.test.ts
+++ b/src/tests/TypescriptConfig.test.ts
@@ -1,0 +1,370 @@
+import { should } from "fuse-test-runner";
+import * as path from "path";
+import * as fs from "fs";
+import { FuseBox } from "../index";
+import { getScriptLevelNumber, getScriptLevelString } from "../core/TypescriptConfig";
+import * as appRoot from "app-root-path";
+import * as fsExtra from "fs-extra";
+import * as ts from "typescript";
+
+const getTempDir = () => {
+	const name = `test-tsconfig-${new Date().getTime()}`;
+	let tmpFolder = path.join(appRoot.path, ".fusebox", "tests", name);
+	fsExtra.ensureDirSync(tmpFolder);
+	return tmpFolder
+}
+
+export class TypescriptConfigTest {
+	"Should get number language level (level: 'es5' -> 1)"() {
+		should(getScriptLevelNumber('Es5')).equal(ts.ScriptTarget.ES5);
+	}
+	"Should get number language level (level: 1 -> 1)"() {
+		should(getScriptLevelNumber(ts.ScriptTarget.ES5)).equal(ts.ScriptTarget.ES5);
+	}
+	"Should get number language level (level: 'esnext' -> 6)"() {
+		should(getScriptLevelNumber('esnext')).equal(ts.ScriptTarget.ESNext);
+	}
+	"Should get number language level (level: 6 -> 6)"() {
+		should(getScriptLevelNumber(ts.ScriptTarget.ESNext)).equal(ts.ScriptTarget.ESNext);
+	}
+	"Should get number language level (level: 'json' -> undefined)"() {
+		should(getScriptLevelNumber(ts.ScriptTarget.JSON)).equal(undefined);
+	}
+	"Should get number language level (level: unknown -> undefined)"() {
+		should(getScriptLevelNumber('asd')).equal(undefined);
+	}
+	"Should get string language level (level: 1 -> 'ES5')"() {
+		should(getScriptLevelString(ts.ScriptTarget.ES5)).equal('ES5');
+	}
+	"Should get string language level (level: 6 -> 'ESNext')"() {
+		should(getScriptLevelString(ts.ScriptTarget.ESNext)).equal('ESNext');
+	}
+	"Should get string language level (level: 100 [JSON] -> undefined)"() {
+		should(getScriptLevelString(ts.ScriptTarget.JSON)).equal(undefined);
+	}
+
+	"Should generate recommended tsconfig.json file"() {
+		const testDir = getTempDir();
+		const fuse = FuseBox.init({ homeDir: testDir, log: false });
+		const config = JSON.parse(JSON.stringify(fuse.context.tsConfig.getConfig()));
+		const tsconfigFileName = path.resolve(testDir, "tsconfig.json");
+
+		should(fs.existsSync(tsconfigFileName)).beTrue();
+		should(JSON.parse(fs.readFileSync(tsconfigFileName).toString())).deepEqual({
+			compilerOptions: {
+				module: "CommonJS",
+				target: "ES2018",
+				jsx: "react",
+				baseUrl: ".",
+				importHelpers: true,
+				emitDecoratorMetadata: true,
+				experimentalDecorators: true
+			}
+		});
+		should(config).deepEqual({
+			compilerOptions: {
+				module: ts.ModuleKind.CommonJS,
+				target: ts.ScriptTarget.ES2018,
+				jsx: ts.JsxEmit.React,
+				baseUrl: ".",
+				importHelpers: true,
+				emitDecoratorMetadata: true,
+				experimentalDecorators: true
+			},
+			errors: []
+		});
+	}
+	"Should generate recommended tsconfig.json file (with source maps)"() {
+		const testDir = getTempDir();
+		const fuse = FuseBox.init({
+			homeDir: testDir,
+			sourceMaps: true,
+			log: false,
+		});
+		const config = JSON.parse(JSON.stringify(fuse.context.tsConfig.getConfig()));
+		const tsconfigFileName = path.resolve(testDir, "tsconfig.json");
+
+		should(fs.existsSync(tsconfigFileName)).beTrue();
+		should(JSON.parse(fs.readFileSync(tsconfigFileName).toString())).deepEqual({
+			compilerOptions: {
+				module: "CommonJS",
+				target: "ES2018",
+				jsx: "react",
+				baseUrl: ".",
+				importHelpers: true,
+				emitDecoratorMetadata: true,
+				experimentalDecorators: true,
+				sourceMap: true,
+				inlineSources: true,
+			}
+		});
+		should(config).deepEqual({
+			compilerOptions: {
+				module: ts.ModuleKind.CommonJS,
+				target: ts.ScriptTarget.ES2018,
+				jsx: ts.JsxEmit.React,
+				baseUrl: ".",
+				importHelpers: true,
+				emitDecoratorMetadata: true,
+				experimentalDecorators: true,
+				sourceMap: true,
+				inlineSources: true,
+			},
+			errors: []
+		});
+	}
+	"Should generate recommended tsconfig.json file (with forced language level: esnext)"() {
+		const testDir = getTempDir();
+		const fuse = FuseBox.init({
+			target: "browser@esnext",
+			homeDir: testDir,
+			sourceMaps: true,
+			log: false,
+		});
+		const config = JSON.parse(JSON.stringify(fuse.context.tsConfig.getConfig()));
+		const tsconfigFileName = path.resolve(testDir, "tsconfig.json");
+
+		should(fs.existsSync(tsconfigFileName)).beTrue();
+		should(JSON.parse(fs.readFileSync(tsconfigFileName).toString())).deepEqual({
+			compilerOptions: {
+				module: "CommonJS",
+				target: "ESNext",
+				jsx: "react",
+				baseUrl: ".",
+				importHelpers: true,
+				emitDecoratorMetadata: true,
+				experimentalDecorators: true,
+				sourceMap: true,
+				inlineSources: true,
+			}
+		});
+		should(config).deepEqual({
+			compilerOptions: {
+				module: ts.ModuleKind.CommonJS,
+				target: ts.ScriptTarget.ESNext,
+				jsx: ts.JsxEmit.React,
+				baseUrl: ".",
+				importHelpers: true,
+				emitDecoratorMetadata: true,
+				experimentalDecorators: true,
+				sourceMap: true,
+				inlineSources: true,
+			},
+			errors: []
+		});
+	}
+	"Should generate recommended tsconfig.json file (with forced language level: es2015)"() {
+		const testDir = getTempDir();
+		const fuse = FuseBox.init({
+			target: "browser@es2015",
+			homeDir: testDir,
+			sourceMaps: true,
+			log: false,
+		});
+		const config = JSON.parse(JSON.stringify(fuse.context.tsConfig.getConfig()));
+		const tsconfigFileName = path.resolve(testDir, "tsconfig.json");
+
+		should(fs.existsSync(tsconfigFileName)).beTrue();
+		should(JSON.parse(fs.readFileSync(tsconfigFileName).toString())).deepEqual({
+			compilerOptions: {
+				module: "CommonJS",
+				target: "ES2015",
+				jsx: "react",
+				baseUrl: ".",
+				importHelpers: true,
+				emitDecoratorMetadata: true,
+				experimentalDecorators: true,
+				sourceMap: true,
+				inlineSources: true,
+			}
+		});
+		should(config).deepEqual({
+			compilerOptions: {
+				module: ts.ModuleKind.CommonJS,
+				target: ts.ScriptTarget.ES2015,
+				jsx: ts.JsxEmit.React,
+				baseUrl: ".",
+				importHelpers: true,
+				emitDecoratorMetadata: true,
+				experimentalDecorators: true,
+				sourceMap: true,
+				inlineSources: true,
+			},
+			errors: []
+		});
+	}
+	"Should generate recommended tsconfig.json file (with forced language level: 2)"() {
+		const testDir = getTempDir();
+		const fuse = FuseBox.init({
+			target: "browser@2",
+			homeDir: testDir,
+			sourceMaps: true,
+			log: false,
+		});
+		const config = JSON.parse(JSON.stringify(fuse.context.tsConfig.getConfig()));
+		const tsconfigFileName = path.resolve(testDir, "tsconfig.json");
+
+		should(fs.existsSync(tsconfigFileName)).beTrue();
+		should(JSON.parse(fs.readFileSync(tsconfigFileName).toString())).deepEqual({
+			compilerOptions: {
+				module: "CommonJS",
+				target: "ES2015",
+				jsx: "react",
+				baseUrl: ".",
+				importHelpers: true,
+				emitDecoratorMetadata: true,
+				experimentalDecorators: true,
+				sourceMap: true,
+				inlineSources: true,
+			}
+		});
+		should(config).deepEqual({
+			compilerOptions: {
+				module: ts.ModuleKind.CommonJS,
+				target: ts.ScriptTarget.ES2015,
+				jsx: ts.JsxEmit.React,
+				baseUrl: ".",
+				importHelpers: true,
+				emitDecoratorMetadata: true,
+				experimentalDecorators: true,
+				sourceMap: true,
+				inlineSources: true,
+			},
+			errors: []
+		});
+	}
+	"Should load tsconfig file with extends"() {
+		const testDir = getTempDir();
+		const tsconfig1 = JSON.stringify({
+			compilerOptions: {},
+			extends: "./tsconfig2.json"
+		});
+		const tsconfig2 = JSON.stringify({
+			compilerOptions: {
+				target: "es3",
+			}
+		});
+
+		fs.writeFileSync(path.resolve(testDir, "tsconfig1.json"), tsconfig1);
+		fs.writeFileSync(path.resolve(testDir, "tsconfig2.json"), tsconfig2);
+
+		const fuse = FuseBox.init({
+			homeDir: testDir,
+			sourceMaps: true,
+			tsConfig: path.resolve(testDir, "tsconfig1.json"),
+			log: false,
+		});
+		const config = JSON.parse(JSON.stringify(fuse.context.tsConfig.getConfig()));
+
+		delete config.wildcardDirectories;
+
+		should(config).deepEqual({
+			compilerOptions: {
+				target: ts.ScriptTarget.ES3,
+				module: ts.ModuleKind.CommonJS,
+				sourceMap: true,
+				inlineSources: true
+			},
+			errors: [],
+			compileOnSave: false,
+			raw: {
+				compilerOptions: {},
+				extends: "./tsconfig2.json"
+			},
+			typeAcquisition: {
+				enable: false,
+				include: [],
+				exclude: []
+			},
+		});
+	}
+	"Should load jsconfig file (set allowJs to true)"() {
+		const testDir = getTempDir();
+		const jsconfig = JSON.stringify({
+			compilerOptions: {},
+		});
+
+		fs.writeFileSync(path.resolve(testDir, "jsconfig.json"), jsconfig);
+
+		const fuse = FuseBox.init({
+			homeDir: testDir,
+			sourceMaps: true,
+			tsConfig: path.resolve(testDir, "jsconfig.json"),
+			log: false,
+		});
+		const config = JSON.parse(JSON.stringify(fuse.context.tsConfig.getConfig()));
+
+		delete config.wildcardDirectories;
+
+		should(config).deepEqual({
+			compilerOptions: {
+				target: ts.ScriptTarget.ES2018,
+				module: ts.ModuleKind.CommonJS,
+				sourceMap: true,
+				inlineSources: true,
+				allowJs: true,
+			},
+			errors: [],
+			compileOnSave: false,
+			raw: {
+				compilerOptions: {},
+			},
+			typeAcquisition: {
+				enable: false,
+				include: [],
+				exclude: []
+			},
+		});
+	}
+	"Should error when tsconfig doesn't exist"() {
+		const testDir = getTempDir();
+		const fuse = FuseBox.init({
+			homeDir: testDir,
+			sourceMaps: true,
+			ensureTsConfig: false,
+			tsConfig: path.resolve(testDir, "tsconfig.json"),
+			log: false,
+		});
+
+		const config = fuse.context.tsConfig.readJsonConfigFile();
+		should(config.errors.length).equal(1);
+		should(config.errors[0].category).equal(ts.DiagnosticCategory.Error);
+		should(config.errors[0].code).equal(5058 /** The specified path does not exist */);
+	}
+	"Should error when tsconfig contains syntax errors"() {
+		const testDir = getTempDir();
+		const tsconfig = `
+			{
+				compilerOptions: {
+					target: "es5 // comments
+			}
+		`;
+
+		fs.writeFileSync(path.resolve(testDir, "tsconfig.json"), tsconfig);
+
+		const fuse = FuseBox.init({ homeDir: testDir, log: false });
+		const config = fuse.context.tsConfig.readJsonConfigFile();
+		should(config.errors.length).equal(1);
+		should(config.errors[0].category).equal(ts.DiagnosticCategory.Error);
+		should(config.errors[0].code).equal(1002 /** Unterminated string literal */);
+	}
+	"Should error when tsconfig contains invalid options"() {
+		const testDir = getTempDir();
+		const tsconfig = JSON.stringify({
+			compilerOptions: {
+				target: "es3000",
+				jsx: "inferno"
+			}
+		});
+
+		fs.writeFileSync(path.resolve(testDir, "tsconfig.json"), tsconfig);
+
+		const fuse = FuseBox.init({ homeDir: testDir, log: false });
+		const config = fuse.context.tsConfig.readJsonConfigFile();
+		should(config.errors.length).equal(2);
+		should(config.errors[0].category).equal(ts.DiagnosticCategory.Error);
+		should(config.errors[1].category).equal(ts.DiagnosticCategory.Error);
+		should(config.errors[0].messageText).findString('--target');
+		should(config.errors[1].messageText).findString('--jsx');
+	}
+}


### PR DESCRIPTION
- ensure language level is always numeric
- better cast from string|numeric language level to always -> numeric language level
- rename `tsConfigFileCompilerOptions` to `rawCompilerOptions` and improvement on types (e.g: removing `Latest` and `JSON` from `target` which is valid in enum but not as string in raw compiler options)
- refactor of `read`. Same logic/order but simplified the non-pretty if blocks :P
- add support for reading `jsconfig.json` file. Only difference is adding `allowJs: true` to config. Currently not used but may come in handy in plugin writing and it follows standard
- most important, add big test file for `TypescriptConfig`
  - language level casting (number -> string, string -> number)
  - test generated tsconfig. File content must be in `raw` compiler options while `config` must be same but with equivalent numeric enums
  - test diagnostics (tsconfig provided fileName doesn't exist, syntax errors in tsconfig, invalid options in tsconfig) <- this wasn't before in previous PR, now testable :)