### PR TITLE
feat: SassPlugin supports both, node-sass and sass (with fibers optional)

### DIFF
--- a/docs/plugins/sass.md
+++ b/docs/plugins/sass.md
@@ -15,6 +15,16 @@ yarn add node-sass --dev
 npm install node-sass --save-dev
 ```
 
+Note: Instead of `node-sass`, you may also use the reference implementation 
+[`sass`](https://github.com/sass/dart-sass) together with its optional
+dependency `fibers`. SassPlugin will use whatever one you installed.
+
+```bash
+yarn add sass fibers --dev
+// OR
+npm install sass fibers --save-dev
+```
+
 ## Usage
 
 check [Sass website](http://sass-lang.com/) for more information. note: The Sass


### PR DESCRIPTION
dart sass (https://github.com/sass/dart-sass) is now stable and has a javascript version published that can be installed via `npm install sass`. Dart sass it the official implementation of sass and new features will be there first. The api is the same, so you can drop in either of both.

It has an optional dependency `fibers` that increases performance.

node-sass is stil faster. But as your fuse-box caching makes transpiling a rare occurance anyway, it would be nice if the SassPlugin could use both, `node-sass` and `sass`, depending on what the user installed.

@nchanged 