### PR TITLE
chore: update fs-extra dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,36 @@
+{
+  "name": "fuse-box",
+  "version": "3.7.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "escodegen": "^1.8.1",
     "express": "^4.14.0",
     "fliplog": "^0.3.13",
-    "fs-extra": "^7.0.0",
+    "fs-extra": "^7.0.1",
     "fuse-concat-with-sourcemaps": "^1.0.5",
     "getopts": "^2.1.1",
     "glob": "^7.1.1",
@@ -56,8 +56,8 @@
     "request": "^2.79.0",
     "shorthash": "0.0.2",
     "source-map": "^0.7.1",
-    "stream-browserify": "^2.0.1",
     "sourcemap-blender": "1.0.5",
+    "stream-browserify": "^2.0.1",
     "tslib": "^1.8.0",
     "watch": "^1.0.1",
     "ws": "^1.1.1"


### PR DESCRIPTION
This update addresses https://github.com/jprichardson/node-fs-extra/commit/ddc1a2f9d42da77342d58f6fd86942a231f5f27f which was introduced into fuse-box when fs-extra was updated in this PR https://github.com/fuse-box/fuse-box/pull/1341/files