### PR TITLE
fix: Synthetic default export polyfill does not add __esModule property

### DIFF
--- a/modules/fuse-box-responsive-api/index.js
+++ b/modules/fuse-box-responsive-api/index.js
@@ -13,8 +13,11 @@
 			return;
 		}
 
+		// use hasOwnProperty to avoid triggering usage warnings from libraries like mobx
 		var hasDefaultProperty = input.hasOwnProperty('default');
 		var hasModuleProperty = input.hasOwnProperty('__esModule');
+
+		// to get around frozen input
 		if (Object.isFrozen(input)) {
 			if (!hasDefaultProperty) {
 				input['default'] = input;
@@ -26,6 +29,7 @@
 			return;
 		}
 
+		// free to define properties
 		if (!hasDefaultProperty) {
 			Object.defineProperty(input, 'default', { value: input, writable: true, enumerable: false });
 		}

--- a/modules/fuse-box-responsive-api/index.js
+++ b/modules/fuse-box-responsive-api/index.js
@@ -9,26 +9,30 @@
 	/* @if allowSyntheticDefaultImports */
 	// NOTE: Should match syntheticDefaultExportPolyfill in LoaderAPI.ts
 	function syntheticDefaultExportPolyfill(input) {
-		if (
-			input === null ||
-			["function", "object", "array"].indexOf(typeof input) === -1 ||
-			input.hasOwnProperty("default") // use hasOwnProperty to avoid triggering usage warnings from libraries like mobx
-		) {
+		if (input === null || ['function', 'object', 'array'].indexOf(typeof input) === -1) {
 			return;
 		}
 
-		// to get around frozen input
+		var hasDefaultProperty = input.hasOwnProperty('default');
+		var hasModuleProperty = input.hasOwnProperty('__esModule');
 		if (Object.isFrozen(input)) {
-			input.default = input;
+			if (!hasDefaultProperty) {
+				input['default'] = input;
+			}
+
+			if (!hasModuleProperty) {
+				input['__esModule'] = true;
+			}
 			return;
 		}
 
-		// free to define properties
-		Object.defineProperty(input, "default", {
-			value: input,
-			writable: true,
-			enumerable: false
-		});
+		if (!hasDefaultProperty) {
+			Object.defineProperty(input, 'default', { value: input, writable: true, enumerable: false });
+		}
+
+		if (!hasModuleProperty) {
+			Object.defineProperty(input, '__esModule', { value: true });
+		}
 	}
 	/* @end */
 

--- a/modules/fuse-box-responsive-api/index.js
+++ b/modules/fuse-box-responsive-api/index.js
@@ -9,13 +9,13 @@
 	/* @if allowSyntheticDefaultImports */
 	// NOTE: Should match syntheticDefaultExportPolyfill in LoaderAPI.ts
 	function syntheticDefaultExportPolyfill(input) {
-		if (input === null || ['function', 'object', 'array'].indexOf(typeof input) === -1) {
+		if (input == null || ['function', 'object', 'array'].indexOf(typeof input) === -1) {
 			return;
 		}
 
 		// use hasOwnProperty to avoid triggering usage warnings from libraries like mobx
-		var hasDefaultProperty = input.hasOwnProperty('default');
-		var hasModuleProperty = input.hasOwnProperty('__esModule');
+		var hasDefaultProperty = Object.prototype.hasOwnProperty.call(input, 'default');
+		var hasModuleProperty = Object.prototype.hasOwnProperty.call(input, '__esModule');
 
 		// to get around frozen input
 		if (Object.isFrozen(input)) {

--- a/modules/fuse-loader/index.js
+++ b/modules/fuse-loader/index.js
@@ -303,13 +303,13 @@ function $trigger(name, args) {
 }
 // NOTE: Should match syntheticDefaultExportPolyfill in fuse-box-responsive-api/index.js
 function syntheticDefaultExportPolyfill(input) {
-  if (input === null || ['function', 'object', 'array'].indexOf(typeof input) === -1) {
+  if (input == null || ['function', 'object', 'array'].indexOf(typeof input) === -1) {
     return;
   }
 
   // use hasOwnProperty to avoid triggering usage warnings from libraries like mobx
-  var hasDefaultProperty = input.hasOwnProperty('default');
-  var hasModuleProperty = input.hasOwnProperty('__esModule');
+  var hasDefaultProperty = Object.prototype.hasOwnProperty.call(input, 'default');
+  var hasModuleProperty = Object.prototype.hasOwnProperty.call(input, '__esModule');
 
   // to get around frozen input
   if (Object.isFrozen(input)) {

--- a/modules/fuse-loader/index.js
+++ b/modules/fuse-loader/index.js
@@ -307,8 +307,11 @@ function syntheticDefaultExportPolyfill(input) {
     return;
   }
 
+  // use hasOwnProperty to avoid triggering usage warnings from libraries like mobx
   var hasDefaultProperty = input.hasOwnProperty('default');
   var hasModuleProperty = input.hasOwnProperty('__esModule');
+
+  // to get around frozen input
   if (Object.isFrozen(input)) {
     if (!hasDefaultProperty) {
       input['default'] = input;
@@ -320,6 +323,7 @@ function syntheticDefaultExportPolyfill(input) {
     return;
   }
 
+  // free to define properties
   if (!hasDefaultProperty) {
     Object.defineProperty(input, 'default', { value: input, writable: true, enumerable: false });
   }

--- a/modules/fuse-loader/index.js
+++ b/modules/fuse-loader/index.js
@@ -303,24 +303,30 @@ function $trigger(name, args) {
 }
 // NOTE: Should match syntheticDefaultExportPolyfill in fuse-box-responsive-api/index.js
 function syntheticDefaultExportPolyfill(input) {
-  if (
-    input === null ||
-    ['function', 'object', 'array'].indexOf(typeof input) === -1 ||
-    (input && Object.prototype.hasOwnProperty.call(input, 'default')) // use hasOwnProperty to avoid triggering usage warnings from libraries like mobx
-  ) {
+  if (input === null || ['function', 'object', 'array'].indexOf(typeof input) === -1) {
     return;
   }
-  // to get around frozen input
+
+  var hasDefaultProperty = input.hasOwnProperty('default');
+  var hasModuleProperty = input.hasOwnProperty('__esModule');
   if (Object.isFrozen(input)) {
-    input['default'] = input;
+    if (!hasDefaultProperty) {
+      input['default'] = input;
+    }
+
+    if (!hasModuleProperty) {
+      input['__esModule'] = true;
+    }
     return;
   }
-  // free to define properties
-  Object.defineProperty(input, 'default', {
-    value: input,
-    writable: true,
-    enumerable: false,
-  });
+
+  if (!hasDefaultProperty) {
+    Object.defineProperty(input, 'default', { value: input, writable: true, enumerable: false });
+  }
+
+  if (!hasModuleProperty) {
+    Object.defineProperty(input, '__esModule', { value: true });
+  }
 }
 /**
  * Imports File

--- a/modules/fuse-loader/index.ts
+++ b/modules/fuse-loader/index.ts
@@ -402,26 +402,30 @@ function $trigger(name: string, args: any) {
 
 // NOTE: Should match syntheticDefaultExportPolyfill in fuse-box-responsive-api/index.js
 function syntheticDefaultExportPolyfill(input) {
-  if (
-    input === null ||
-    ['function', 'object', 'array'].indexOf(typeof input) === -1 ||
-    (input && Object.prototype.hasOwnProperty.call(input, 'default')) // use hasOwnProperty to avoid triggering usage warnings from libraries like mobx
-  ) {
+  if (input === null || ['function', 'object', 'array'].indexOf(typeof input) === -1) {
     return;
   }
 
-  // to get around frozen input
+  var hasDefaultProperty = input.hasOwnProperty('default');
+  var hasModuleProperty = input.hasOwnProperty('__esModule');
   if (Object.isFrozen(input)) {
-    input.default = input;
+    if (!hasDefaultProperty) {
+      input['default'] = input;
+    }
+
+    if (!hasModuleProperty) {
+      input['__esModule'] = true;
+    }
     return;
   }
 
-  // free to define properties
-  Object.defineProperty(input, 'default', {
-    value: input,
-    writable: true,
-    enumerable: false,
-  });
+  if (!hasDefaultProperty) {
+    Object.defineProperty(input, 'default', { value: input, writable: true, enumerable: false });
+  }
+
+  if (!hasModuleProperty) {
+    Object.defineProperty(input, '__esModule', { value: true });
+  }
 }
 
 /**

--- a/modules/fuse-loader/index.ts
+++ b/modules/fuse-loader/index.ts
@@ -402,13 +402,13 @@ function $trigger(name: string, args: any) {
 
 // NOTE: Should match syntheticDefaultExportPolyfill in fuse-box-responsive-api/index.js
 function syntheticDefaultExportPolyfill(input) {
-  if (input === null || ['function', 'object', 'array'].indexOf(typeof input) === -1) {
+  if (input == null || ['function', 'object', 'array'].indexOf(typeof input) === -1) {
     return;
   }
 
   // use hasOwnProperty to avoid triggering usage warnings from libraries like mobx
-  var hasDefaultProperty = input.hasOwnProperty('default');
-  var hasModuleProperty = input.hasOwnProperty('__esModule');
+  var hasDefaultProperty = Object.prototype.hasOwnProperty.call(input, 'default');
+  var hasModuleProperty = Object.prototype.hasOwnProperty.call(input, '__esModule');
 
   // to get around frozen input
   if (Object.isFrozen(input)) {

--- a/modules/fuse-loader/index.ts
+++ b/modules/fuse-loader/index.ts
@@ -406,8 +406,11 @@ function syntheticDefaultExportPolyfill(input) {
     return;
   }
 
+  // use hasOwnProperty to avoid triggering usage warnings from libraries like mobx
   var hasDefaultProperty = input.hasOwnProperty('default');
   var hasModuleProperty = input.hasOwnProperty('__esModule');
+
+  // to get around frozen input
   if (Object.isFrozen(input)) {
     if (!hasDefaultProperty) {
       input['default'] = input;
@@ -419,6 +422,7 @@ function syntheticDefaultExportPolyfill(input) {
     return;
   }
 
+  // free to define properties
   if (!hasDefaultProperty) {
     Object.defineProperty(input, 'default', { value: input, writable: true, enumerable: false });
   }


### PR DESCRIPTION
This should fix the issue with the Babel import polyfill (and any similar helper functions)