### PR TITLE
Aggregate plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ build
 dist
 node_modules
 npm-debug.log*
+pnpm-debug.log
 coverage/
 sourcemaps.js.map
 yarn.lock

--- a/src/sparky/aggregatePlugins.ts
+++ b/src/sparky/aggregatePlugins.ts
@@ -1,0 +1,3 @@
+export function aggregatePlugins(plugins: any[]): any[] {
+  return plugins.filter((plugin) => plugin !== false)
+}


### PR DESCRIPTION
Why? When building the FuseBox config, the plugins property requires plugins and not booleans. This doesn't pose a problem in JavaScript, but it does in TypeScript.

So, instead of this ...
EG: 
````js
plugins: [
  WebIndexPlugin({
                    cssPath: "css",
                    path: ".",
                    template: "src/index.html",
                }),
                [
                    SassPlugin({
                        importer: true,
                        //                        resources: [{ test: /.*/, file: "resources.scss" }],
                    }),
                    PostCSSPlugin(
                        [
                            Unprefix(),
                            Autoprefixer(),
                            Cssnano(),
                            this.isProduction && Banner({
                                banner: bannerStatement(this.isProduction),
                                important: true,
                            }),
                        ]),
                    CSSResourcePlugin({
                        dist: "dist/css-resources",
                        inline: true,
                    }),
                    CSSPlugin({inject: true}),
                ],
]
````

this ...
````ts
plugins: [
 WebIndexPlugin({
                    cssPath: "css",
                    path: ".",
                    template: "src/index.html",
                }),
                [
                    SassPlugin({
                        importer: true,
                        //                        resources: [{ test: /.*/, file: "resources.scss" }],
                    }),
                    PostCSSPlugin(aggregatePostCSSPlugins(
                        [
                            Unprefix(),
                            Autoprefixer(),
                            Cssnano(),
                            this.isProduction && Banner({
                                banner: bannerStatement(this.isProduction),
                                important: true,
                            }),
                        ])),
                    CSSResourcePlugin({
                        dist: "dist/css-resources",
                        inline: true,
                    }),
                    CSSPlugin({inject: true}),
                ],
]
````

````ts
export function aggregatePlugins(plugins: any[]): any[] {
  return plugins.filter((plugin) => plugin !== false)
}
````

Two questions for you, @nchanged 
1) Did I put the function in the correct place in the code base?
2) Using the `any` type is no good. What is the common type for plugins?

EDIT: @nchanged , i just had a thought. If you think this is good functionality, there is probably no need to expose this function. It should just be the way it works in the background, no?