### PR TITLE
Wait for writes to finish before resolving

### DIFF
--- a/src/core/writer.ts
+++ b/src/core/writer.ts
@@ -96,7 +96,7 @@ export function createWriter(props: IWriterProps): IWriterActions {
         relBrowserPath,
         write: async (cnt?: string) => {
           // piping the contents to webIndex instead
-          writeFile(absPath, cnt ? cnt : contents);
+          await writeFile(absPath, cnt ? cnt : contents);
         },
       };
     },


### PR DESCRIPTION
Added missing 'await' to a returned promise in the async 'write' function.
Without this, sometimes tasks relying on the written file to exist are run before the file is ready; e.g., running the server bundle.