### PR TITLE
feat(CustomTransformers): Implemented support for user-provided TS transformers

### DIFF
--- a/playground/custom_transformer/fuse.ts
+++ b/playground/custom_transformer/fuse.ts
@@ -1,0 +1,97 @@
+import { fusebox } from '../../src/core/fusebox';
+import * as ts from 'typescript';
+
+const isProd = process.argv.indexOf('--prod') > -1;
+
+function transformNode(node) {
+
+  // @ts-ignore
+  if (ts.isPropertyAccessExpression(node) && node.expression) {
+    // @ts-ignore
+    if (node.expression.expression && node.expression.expression.getText() && node.expression.expression.getText() === 'process' &&
+      // @ts-ignore
+      node.expression.name && node.expression.name.getText() && node.expression.name.getText() === 'env') {
+
+      // @ts-ignore
+      const envVarName = node.name.getText();
+      const envVarValue = process.env[envVarName];
+
+      return ts.createStringLiteral(envVarValue || '');
+    }
+  }
+}
+
+function exampleProdBeforeTransformer<T extends ts.Node>(): ts.TransformerFactory<T> {
+  return (context) => {
+
+    console.log();
+    console.log('===> custom prod mode, before stage transformer called');
+    console.log();
+
+    const visit: ts.Visitor = (node) => {
+
+      const transformedNode = transformNode(node);
+
+      if (transformedNode) {
+        return transformedNode;
+      }
+      return ts.visitEachChild(node, (child) => visit(child), context);
+    };
+    return (node) => ts.visitNode(node, visit);
+  }
+}
+
+function exampleDevAfterTransformer<T extends ts.Node>(): ts.TransformerFactory<T> {
+  return (context) => {
+
+    console.log();
+    console.log('===> custom dev mode, after stage transformer called');
+    console.log();
+
+    const visit: ts.Visitor = (node) => {
+
+      const transformedNode = transformNode(node);
+
+      if (transformedNode) {
+        return transformedNode;
+      }
+      return ts.visitEachChild(node, (child) => visit(child), context);
+    };
+    return (node) => ts.visitNode(node, visit);
+  }
+}
+
+const fuse = fusebox({
+  target: 'browser',
+  entry: 'src/index.ts',
+  modules: ['modules'],
+  logging: {
+    level: 'succinct',
+  },
+  webIndex: {
+    template: 'src/index.html',
+  },
+  sourceMap: true,
+  customTransformers: isProd ? {
+    before: [
+      exampleProdBeforeTransformer()
+    ]
+  } : {
+    after: [
+      exampleDevAfterTransformer()
+    ]
+  },
+  devServer: true,
+  watch: true,
+  cache: false,
+});
+
+if (isProd) {
+  fuse.runProd({
+    screwIE: true,
+  });
+} else {
+  fuse.runDev();
+}
+// if (process.argv[2] === 'dev') {
+// } else {

--- a/playground/custom_transformer/src/index.html
+++ b/playground/custom_transformer/src/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title></title>
+  </head>
+
+  <body>
+    <div style="width: 100%; height:500px; border:1px solid red;" id="root"></div>
+    $bundles
+  </body>
+</html>

--- a/playground/custom_transformer/src/index.ts
+++ b/playground/custom_transformer/src/index.ts
@@ -1,0 +1,1 @@
+console.log('I am custom transformed and my home directory is: ', process.env.HOME);

--- a/src/config/IPublicConfig.ts
+++ b/src/config/IPublicConfig.ts
@@ -12,6 +12,8 @@ import { IStyleSheetProps } from './IStylesheetProps';
 import { IWebWorkerConfig } from './IWebWorkerConfig';
 import { ICacheProps, IHMRExternalProps, ITarget } from './PrivateConfig';
 import { IPluginLinkOptions } from '../plugins/core/plugin_link';
+import { CustomTransformers } from 'typescript';
+
 export interface IPublicConfig {
   root?: string;
   target?: ITarget;
@@ -51,6 +53,7 @@ export interface IPublicConfig {
   stylesheet?: IStyleSheetProps;
   cache?: boolean | ICacheProps;
   tsConfig?: string | IRawCompilerOptions;
+  customTransformers?: CustomTransformers;
   entry?: string | Array<string>;
   allowSyntheticDefaultImports?: boolean;
   webIndex?: IWebIndexConfig | boolean;

--- a/src/config/PrivateConfig.ts
+++ b/src/config/PrivateConfig.ts
@@ -17,6 +17,7 @@ import { IPublicConfig } from './IPublicConfig';
 import { IResourceConfig } from './IResourceConfig';
 import { IStyleSheetProps } from './IStylesheetProps';
 import { IWebWorkerConfig } from './IWebWorkerConfig';
+import { CustomTransformers } from 'typescript';
 
 export interface IHMRExternalProps {
   reloadEntryOnStylesheet?: boolean;
@@ -67,6 +68,7 @@ export class PrivateConfig {
   env?: { [key: string]: string };
   cache?: ICacheProps;
   tsConfig?: string | IRawCompilerOptions;
+  customTransformers?: CustomTransformers;
   entries?: Array<string>;
   allowSyntheticDefaultImports?: boolean;
   webIndex?: IWebIndexConfig;

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -36,6 +36,14 @@ export function createConfig(props: IPublicConfig): PrivateConfig {
     }
   }
 
+  config.customTransformers = {
+    // make sure the data structure is basically correct (iterable for merges)
+    after: [],
+    before: [],
+    afterDeclarations: [],
+    ...props.customTransformers
+  };
+
   if (props.target) {
     config.target = props.target;
   }

--- a/src/core/Context.ts
+++ b/src/core/Context.ts
@@ -19,6 +19,7 @@ import { ContextTaskManager, createContextTaskManager } from './ContextTaskManag
 import { Package } from './Package';
 import { createWeakModuleReferences, WeakModuleReferences } from './WeakModuleReferences';
 import { createWriter, IWriterActions } from './writer';
+import { CustomTransformers } from 'typescript';
 
 export class Context {
   public assembleContext: IAssembleContext;
@@ -26,6 +27,7 @@ export class Context {
   public interceptor: MainInterceptor;
   public ict: MainInterceptor;
   public tsConfig: TypescriptConfig;
+  public customTransformers: CustomTransformers;
   public log: ILogger;
   public webIndex: IWebIndexInterface;
   public taskManager: ContextTaskManager;
@@ -46,6 +48,7 @@ export class Context {
     this.assembleContext = assembleContext(this);
     this.ict = createInterceptor();
     this.webWorkers = {};
+    this.customTransformers = config.customTransformers;
 
     this.webIndex = createWebIndex(this);
     attachEssentials(this);

--- a/src/interfaces/TypescriptInterfaces.ts
+++ b/src/interfaces/TypescriptInterfaces.ts
@@ -7,6 +7,7 @@ export interface TypescriptConfig {
   diagnostics?: Array<any>; // all errors come here
   jsonCompilerOptions?: IRawCompilerOptions;
   compilerOptions?: ts.CompilerOptions;
+  transpileOptions?: ts.TranspileOptions;
 }
 
 export type ITypescriptTarget = 'ES3' | 'ES5' | 'ES6' | 'ES2015' | 'ES2016' | 'ES2017' | 'ESNext';

--- a/src/plugins/core/plugin_typescript.ts
+++ b/src/plugins/core/plugin_typescript.ts
@@ -73,6 +73,7 @@ export function pluginTypescript() {
           input: module.contents,
           webWorkers: analysis.workers,
           compilerOptions: compilerOptions,
+          transformers: ctx.customTransformers,
           replacements: !analysis.report.statementsReplaced && analysis.replaceable,
         });
         module.contents = data.outputText;

--- a/src/production/stages/transpileStage.ts
+++ b/src/production/stages/transpileStage.ts
@@ -95,7 +95,22 @@ function transpileProductionModule(props: ITranspileStageProps, prodModule: Prod
   const result = ts.transpileModule(text, {
     fileName: prodModule.module.props.absPath,
     compilerOptions: compilerOptions,
-    transformers: { after: [moduleTransformer(props, prodModule)] },
+
+    transformers: {
+
+      // merge in any custom transformers (user-provided)
+      ...ctx.customTransformers,
+
+      // 2nd-level merge in transformers
+      after: [
+
+        // make sure core transformers are applied and executed first
+        moduleTransformer(props, prodModule),
+
+        // user-provided transformers
+        ...ctx.customTransformers.after,
+      ]
+    },
   });
 
   prodModule.transpiledSourceMap = requireSourceMaps
@@ -106,7 +121,7 @@ function transpileProductionModule(props: ITranspileStageProps, prodModule: Prod
 }
 
 export function transpileStage(props: IProductionFlow) {
-  const { productionContext, ctx, packages } = props;
+  const { productionContext } = props;
 
   const log = props.ctx.log;
 


### PR DESCRIPTION
As discussed on gitter, this PR implements the changes required to freely configure user-provided custom `before`, `after`, `afterDeclaration` stage TypeScript compiler transformation functions. 

The implementation respects the differences of the development and production pipeline and comes with a playground-test to end2end-test it's functionality. 

Core-provided transformers take precedence and so their transformations can be altered by user-provided transformers if needed. This gives ultimate freedom for TypeScript-based projects.

<img width="603" alt="Bildschirmfoto 2019-08-22 um 03 22 34" src="https://user-images.githubusercontent.com/454817/63479578-21ec1c00-c48f-11e9-8863-29d432f9376f.png">

<img width="656" alt="Bildschirmfoto 2019-08-22 um 03 22 20" src="https://user-images.githubusercontent.com/454817/63479579-2284b280-c48f-11e9-958e-d5fcc2f5c639.png">