### PR TITLE
chore: start vscode in debugging mode from selected TS file

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,19 +1,26 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-      {
-        "name": "Debug Jest configParser",
-        "type": "node",
-        "request": "launch",
-        "runtimeArgs": [
-          "--inspect-brk",
-          "${workspaceRoot}/node_modules/jest/bin/jest.js",
-          "--runInBand",
-          "configParser"
-        ],
-        "console": "integratedTerminal",
-        "internalConsoleOptions": "neverOpen",
-        "port": 9229
-      }
-    ]
-  }
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Start current file in debugging mode (ts-node)",
+      "type": "node",
+      "request": "launch",
+      "args": ["${relativeFile}"],
+      "runtimeArgs": ["--nolazy", "-r", "./node_modules/ts-node/register"],
+      "sourceMaps": true,
+      "cwd": "${workspaceRoot}",
+      "protocol": "inspector",
+      "console": "integratedTerminal",
+      "env": { "TS_NODE_TRANSPILE_ONLY": "true", "TS_NODE_IGNORE_DIAGNOSTICS": "true" }
+    },
+    {
+      "name": "Debug Jest configParser",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": ["--inspect-brk", "${workspaceRoot}/node_modules/jest/bin/jest.js", "--runInBand", "configParser"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "port": 9229
+    }
+  ]
+}


### PR DESCRIPTION
This makes it really easy to debug a playground.
Hopefully it will make it easier for someone liek me to help.

How to use:
* set breakpoint somewhere in fuse src you know you project will run
* open playground fuse.ts file, select

![image](https://user-images.githubusercontent.com/2901416/64134234-73c06a80-cddc-11e9-8cab-0fd75066c077.png)




Debugger will now stop at you breakpoint

![image](https://user-images.githubusercontent.com/2901416/64134243-7cb13c00-cddc-11e9-872c-64398967bd8e.png)
