### PR TITLE
fix: hmr, 1 payload per client and cache content

### DIFF
--- a/src/dev-server/devServer.ts
+++ b/src/dev-server/devServer.ts
@@ -16,7 +16,7 @@ import * as proxyMiddleware from 'http-proxy-middleware';
 import { generateFTLJavaScript } from '../FTL/FasterThanLightReload';
 
 export interface IDevServerActions {
-  clientSend: (name: string, payload) => void;
+  clientSend: (name: string, payload, ws_instance?: WebSocket) => void;
   onClientMessage: (fn: (name: string, payload) => void) => void;
 }
 
@@ -137,7 +137,7 @@ export function createDevServer(ctx: Context): IDevServerActions {
   });
 
   return {
-    onClientMessage: (fn: (name: string, payload) => void) => {
+    onClientMessage: (fn: (name: string, payload, ws_instance?: WebSocket) => void) => {
       if (hmrServerMethods) {
         hmrServerMethods.onMessage(fn);
       } else {
@@ -145,9 +145,9 @@ export function createDevServer(ctx: Context): IDevServerActions {
         onMessageCallbacks.push(fn);
       }
     },
-    clientSend: (name: string, payload) => {
+    clientSend: (name: string, payload, ws_instance?: WebSocket) => {
       if (hmrServerMethods) {
-        hmrServerMethods.sendEvent(name, payload);
+        hmrServerMethods.sendEvent(name, payload, ws_instance);
       }
     },
   };

--- a/src/hmr/attach_hmr.ts
+++ b/src/hmr/attach_hmr.ts
@@ -32,63 +32,86 @@ export function attachHMR(ctx: Context) {
   }
 
   const tasks: { [key: string]: IHMRTask } = {};
+  let lastGeneratedHMR = null;
+  let lastPayLoadID = null;
 
-  function sortProjectUpdate(task: IHMRTask, payload: IClientSummary) {
+  function sortProjectUpdate(task: IHMRTask, payload: IClientSummary, ws_instance?: WebSocket) {
     // verify project files first
     const log_pkg = '<bold><yellow>$pkg</yellow></bold>';
 
     const time = measureTime('hmr');
-    const clientProjectFiles = payload.summary['default'];
-    const { packages, modulesForUpdate } = task;
-    const projectPackage = packages.find(pkg => pkg.isDefaultPackage);
-    projectPackage.modules.forEach(module => {
-      // if client doesn't the compiled module
-      if (!clientProjectFiles.includes(module.props.fuseBoxPath)) {
-        ctx.log.print(`<bold><dim>HMR module</dim></bold> $name from ${log_pkg}`, {
-          name: module.props.fuseBoxPath,
-          pkg: 'default',
-        });
-        modulesForUpdate.push(module);
-      }
-    });
-    const packagesForUpdate: Array<Package> = [];
 
-    // check vendor consistency
-    packages.forEach(pkg => {
-      if (pkg.isDefaultPackage) return;
-
-      const name = pkg.getPublicName();
-
-      if (!payload.summary[name]) {
-        // here we need the entire package update
-        ctx.log.print(`<bold><dim>HMR module</dim></bold> ${log_pkg}`, { pkg: name });
-        packagesForUpdate.push(pkg);
-        return;
-      }
-      // check if some files are missing in the package
-      const packageFiles = payload.summary[name];
-      for (const i in pkg.modules) {
-        const module = pkg.modules[i];
-        if (!packageFiles.includes(module.props.fuseBoxPath)) {
-          // making a partial update
-          ctx.log.print(`<bold><dim>HMR module</dim></bold> $name ${log_pkg}`, {
+    // check if its the last payLoadIDm, if so we want to reuse
+    if (payload.id === lastPayLoadID) {
+      ctx.log.print('<dim><bold>HMR content<$id> reused in $time</dim></bold>', { time: time.end(), id: payload.id });
+      devServer.clientSend(
+        'hmr',
+        { packages: lastGeneratedHMR.packages, modules: lastGeneratedHMR.modules },
+        ws_instance,
+      );
+    } else {
+      const clientProjectFiles = payload.summary['default'];
+      const { packages, modulesForUpdate } = task;
+      const projectPackage = packages.find(pkg => pkg.isDefaultPackage);
+      projectPackage.modules.forEach(module => {
+        // if client doesn't the compiled module
+        if (!clientProjectFiles.includes(module.props.fuseBoxPath)) {
+          ctx.log.print(`<bold><dim>HMR module</dim></bold> $name from ${log_pkg}`, {
             name: module.props.fuseBoxPath,
-            pkg: name,
+            pkg: 'default',
           });
           modulesForUpdate.push(module);
         }
-      }
-    });
+      });
+      const packagesForUpdate: Array<Package> = [];
 
-    const generated = generateHMRContent({ packages: packagesForUpdate, modules: modulesForUpdate, ctx: ctx });
-    ctx.log.print('<dim><bold>HMR content generated in $time</dim></bold>', { time: time.end() });
-    devServer.clientSend('hmr', { packages: generated.packages, modules: generated.modules });
+      // check vendor consistency
+      packages.forEach(pkg => {
+        if (pkg.isDefaultPackage) return;
+
+        const name = pkg.getPublicName();
+
+        if (!payload.summary[name]) {
+          // here we need the entire package update
+          ctx.log.print(`<bold><dim>HMR module</dim></bold> ${log_pkg}`, { pkg: name });
+          packagesForUpdate.push(pkg);
+          return;
+        }
+        // check if some files are missing in the package
+        const packageFiles = payload.summary[name];
+        for (const i in pkg.modules) {
+          const module = pkg.modules[i];
+          if (!packageFiles.includes(module.props.fuseBoxPath)) {
+            // making a partial update
+            ctx.log.print(`<bold><dim>HMR module</dim></bold> $name ${log_pkg}`, {
+              name: module.props.fuseBoxPath,
+              pkg: name,
+            });
+            modulesForUpdate.push(module);
+          }
+        }
+      });
+
+      //save lastgenerated, so we can reuse
+      lastGeneratedHMR = generateHMRContent({ packages: packagesForUpdate, modules: modulesForUpdate, ctx: ctx });
+      lastPayLoadID = payload.id;
+
+      ctx.log.print('<dim><bold>HMR content<$id> generated in $time</dim></bold>', {
+        time: time.end(),
+        id: payload.id,
+      });
+      devServer.clientSend(
+        'hmr',
+        { packages: lastGeneratedHMR.packages, modules: lastGeneratedHMR.modules },
+        ws_instance,
+      );
+    }
   }
 
   // here we recieve an update from client - the entire tree of its modules
-  devServer.onClientMessage((event, payload: IClientSummary) => {
+  devServer.onClientMessage((event, payload: IClientSummary, ws_instance?: WebSocket) => {
     if (event === 'summary' && payload.id && tasks[payload.id]) {
-      sortProjectUpdate(tasks[payload.id], payload);
+      sortProjectUpdate(tasks[payload.id], payload, ws_instance);
     }
   });
 


### PR DESCRIPTION
Quickfix for the HMR
This will stop HMR from calling each client multiple times with new content.
Also added simple cache for generated content so we dont regenerate each time

But think we should have maybe some defined events so we easly know how to use it.
Call all clients or just respond to caller.

Atm from what I can see we only have 3 events
- server -> get Summary to all clients 
- clients resond with summary
- the server calls back with new payload

Ive just tested with "monorepo_alt", might be stuff I dont know about that can break this.