### PR TITLE
chore: improve debugger (jest) & rename old debugging mode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Start current file in debugging mode (ts-node)",
+      "name": "Run current file (ts-node)",
       "type": "node",
       "request": "launch",
       "args": ["${relativeFile}"],
@@ -14,13 +14,17 @@
       "env": { "TS_NODE_TRANSPILE_ONLY": "true", "TS_NODE_IGNORE_DIAGNOSTICS": "true" }
     },
     {
-      "name": "Debug Jest configParser",
       "type": "node",
       "request": "launch",
-      "runtimeArgs": ["--inspect-brk", "${workspaceRoot}/node_modules/jest/bin/jest.js", "--runInBand", "configParser"],
+      "name": "Jest Current File (jest)",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["${fileBasenameNoExtension}", "--config", "jest.config.js"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "port": 9229
+      "disableOptimisticBPs": true,
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+      }
     }
   ]
 }


### PR DESCRIPTION
Removed old jest run. It was bad since it only ran 1 test.
With the new one you just select the jest test you want to run.
Also renamed the old debugging with ts-node

![image](https://user-images.githubusercontent.com/2901416/64282180-24ea1080-cf55-11e9-8271-45556adfe586.png)


![image](https://user-images.githubusercontent.com/2901416/64282274-5367eb80-cf55-11e9-9ae8-9484be0c5b0a.png)
