### PR TITLE
Awaitable ICT

### DIFF
--- a/docs/development/plugins.md
+++ b/docs/development/plugins.md
@@ -59,12 +59,12 @@ const pluginBar = () => (ctx: Context) => {
 ```
 
 If your plugin is asynchronous and you want to instruct fuse-box to wait until the `Promise` that it returns will
-resolve, you should use `awaitOn`. This will give fuse-box the change to wait until your plugin finished it's work.
+resolve, you should use `waitFor`. This will give fuse-box the change to wait until your plugin finished it's work.
 Please notice that fuse-box will decide if it will await the results or not (depending on the event and context).
 
 ```ts
 const pluginBar = () => (ctx: Context) => {
-  ctx.ict.awaitOn('complete', async props => {
+  ctx.ict.waitFor('complete', async props => {
     console.log('Bundling is completed');
 
     // in async functions, all return values are wrapped in Promises automatically

--- a/docs/development/plugins.md
+++ b/docs/development/plugins.md
@@ -58,6 +58,21 @@ const pluginBar = () => (ctx: Context) => {
 };
 ```
 
+If your plugin is asynchronous and you want to instruct fuse-box to wait until the `Promise` that it returns will
+resolve, you should use `awaitOn`. This will give fuse-box the change to wait until your plugin finished it's work.
+Please notice that fuse-box will decide if it will await the results or not (depending on the event and context).
+
+```ts
+const pluginBar = () => (ctx: Context) => {
+  ctx.ict.awaitOn('complete', async props => {
+    console.log('Bundling is completed');
+
+    // in async functions, all return values are wrapped in Promises automatically
+    return props;
+  });
+};
+```
+
 ## Module plugins
 
 Module plugins are the ones that work with the actual files (javascript or typescript) A very simple plugin that
@@ -125,8 +140,8 @@ There are several types of events related to capturing modules in `ict`
 ctx.ict.on('assemble_module_init', props => {});
 ```
 
-At this point module hasn just been resolved. It won't contain any information (analysis etc.) whatsoever. Never
-perform any async operations here, since it will lead to race conditions. NEVER transform the contents at this point.
+At this point module hasn just been resolved. It won't contain any information (analysis etc.) whatsoever. Never perform
+any async operations here, since it will lead to race conditions. NEVER transform the contents at this point.
 
 **NEVER** transform the contents at **assemble_module_init**
 

--- a/src/interceptor/__tests__/interceptor.test.ts
+++ b/src/interceptor/__tests__/interceptor.test.ts
@@ -70,4 +70,25 @@ describe('Interceptor', () => {
     await icp.resolve();
     expect(responses).toEqual([1, 2]);
   });
+
+  it('should await all interceptors to finish', async () => {
+    const interceptor = createInterceptor();
+
+    interceptor.awaitOn('assemble_module', async (props: { module: Module }) => {
+      const sleep = async (sec: number) => {
+        return new Promise(resolve => setTimeout(resolve, sec * 1000));
+      };
+
+      await sleep(2);
+
+      props.module.contents = 'foo';
+      return props;
+    });
+
+    const timeNow = Date.now();
+    const response = await interceptor.awaitForSync('assemble_module', { module: _module });
+
+    expect(Date.now() - timeNow).toBeGreaterThan(2000);
+    expect(response.module.contents).toEqual('foo');
+  });
 });

--- a/src/interceptor/__tests__/interceptor.test.ts
+++ b/src/interceptor/__tests__/interceptor.test.ts
@@ -74,7 +74,7 @@ describe('Interceptor', () => {
   it('should await all interceptors to finish', async () => {
     const interceptor = createInterceptor();
 
-    interceptor.awaitOn('assemble_module', async (props: { module: Module }) => {
+    interceptor.waitFor('assemble_module', async (props: { module: Module }) => {
       const sleep = async (sec: number) => {
         return new Promise(resolve => setTimeout(resolve, sec * 1000));
       };
@@ -86,7 +86,7 @@ describe('Interceptor', () => {
     });
 
     const timeNow = Date.now();
-    const response = await interceptor.awaitForSync('assemble_module', { module: _module });
+    const response = await interceptor.send('assemble_module', { module: _module });
 
     expect(Date.now() - timeNow).toBeGreaterThan(2000);
     expect(response.module.contents).toEqual('foo');
@@ -100,7 +100,7 @@ describe('Interceptor', () => {
       return props;
     });
 
-    const response = await interceptor.awaitForSync('assemble_module', { module: _module });
+    const response = await interceptor.send('assemble_module', { module: _module });
 
     expect(response.module.contents).toEqual('foo');
   });
@@ -108,7 +108,7 @@ describe('Interceptor', () => {
   it('should NOT be be forward compatible with async callbacks', () => {
     const interceptor = createInterceptor();
 
-    interceptor.awaitOn('assemble_module', async (props: { module: Module }) => {
+    interceptor.waitFor('assemble_module', async (props: { module: Module }) => {
       props.module.contents = 'foo';
       return props;
     });

--- a/src/interceptor/__tests__/interceptor.test.ts
+++ b/src/interceptor/__tests__/interceptor.test.ts
@@ -91,4 +91,31 @@ describe('Interceptor', () => {
     expect(Date.now() - timeNow).toBeGreaterThan(2000);
     expect(response.module.contents).toEqual('foo');
   });
+
+  it('should be backwards compatible with non-async callbacks', async () => {
+    const interceptor = createInterceptor();
+
+    interceptor.on('assemble_module', (props: { module: Module }) => {
+      props.module.contents = 'foo';
+      return props;
+    });
+
+    const response = await interceptor.awaitForSync('assemble_module', { module: _module });
+
+    expect(response.module.contents).toEqual('foo');
+  });
+
+  it('should NOT be be forward compatible with async callbacks', () => {
+    const interceptor = createInterceptor();
+
+    interceptor.awaitOn('assemble_module', async (props: { module: Module }) => {
+      props.module.contents = 'foo';
+      return props;
+    });
+
+    const response = interceptor.sync('assemble_module', { module: _module });
+
+    expect(response).toBeInstanceOf(Promise);
+    expect(response.module).not.toBeDefined();
+  });
 });

--- a/src/interceptor/interceptor.ts
+++ b/src/interceptor/interceptor.ts
@@ -4,8 +4,10 @@ interface TypedInterceptor<T> {
   getPromises: () => Array<any>;
   promise: (fn: () => Promise<any>) => void;
   resolve: () => Promise<any>;
-  on<K extends keyof T>(s: K, props: (props: T[K]) => T[K]);
-  sync<K extends keyof T>(s: K, props: T[K]): T[K];
+  on<K extends keyof T>(key: K, fn: (props: T[K]) => T[K]);
+  sync<K extends keyof T>(key: K, props: T[K]): T[K];
+  awaitForSync<K extends keyof T>(key: K, props: T[K]): Promise<T[K]>;
+  awaitOn<K extends keyof T>(key: K, fn: (props: T[K]) => Promise<T[K]>);
 }
 export type MainInterceptor = TypedInterceptor<InterceptorEvents>;
 export function createInterceptor(): MainInterceptor {
@@ -21,6 +23,11 @@ export function createInterceptor(): MainInterceptor {
     }
     fns.push(fn);
   }
+
+  const on = function(key: any, fn: (props: any) => any) {
+    add(key, fn);
+  };
+
   return {
     getPromises: () => promises,
     promise: function(fn: () => Promise<any>) {
@@ -31,14 +38,29 @@ export function createInterceptor(): MainInterceptor {
       promises = [];
       return res;
     },
-    on: function(key: any, fn: (props: any) => any) {
-      add(key, fn);
-    },
+    on,
     // sync (emit an even which should return an according props
     sync: function(key: string, props: any) {
       if (subscriptions.has(key)) {
         const fns = subscriptions.get(key);
         const responses = fns.map(fn => fn(props));
+        if (responses.length > 0) {
+          // return the latest response
+          return responses[responses.length - 1];
+        }
+      }
+      return props;
+    },
+    awaitOn: on,
+    awaitForSync: async function(key: string, props: any) {
+      if (subscriptions.has(key)) {
+        const fns = subscriptions.get(key);
+        const responses = [];
+
+        for (let i = 0; i < fns.length; i++) {
+          responses.push(await fns[i](props));
+        }
+
         if (responses.length > 0) {
           // return the latest response
           return responses[responses.length - 1];

--- a/src/interceptor/interceptor.ts
+++ b/src/interceptor/interceptor.ts
@@ -6,8 +6,8 @@ interface TypedInterceptor<T> {
   resolve: () => Promise<any>;
   on<K extends keyof T>(key: K, fn: (props: T[K]) => T[K]);
   sync<K extends keyof T>(key: K, props: T[K]): T[K];
-  awaitForSync<K extends keyof T>(key: K, props: T[K]): Promise<T[K]>;
-  awaitOn<K extends keyof T>(key: K, fn: (props: T[K]) => Promise<T[K]>);
+  send<K extends keyof T>(key: K, props: T[K]): Promise<T[K]>;
+  waitFor<K extends keyof T>(key: K, fn: (props: T[K]) => Promise<T[K]>);
 }
 export type MainInterceptor = TypedInterceptor<InterceptorEvents>;
 export function createInterceptor(): MainInterceptor {
@@ -51,14 +51,14 @@ export function createInterceptor(): MainInterceptor {
       }
       return props;
     },
-    awaitOn: on,
-    awaitForSync: async function(key: string, props: any) {
+    waitFor: on,
+    send: async function(key: string, props: any) {
       if (subscriptions.has(key)) {
         const fns = subscriptions.get(key);
         const responses = [];
 
-        for (let i = 0; i < fns.length; i++) {
-          responses.push(await fns[i](props));
+        for (let fn of fns) {
+          responses.push(await fn(props));
         }
 
         if (responses.length > 0) {


### PR DESCRIPTION
This PR adds the functionality to async/await for callbacks registered with an interceptor. 

Based on this implementation, fuse-box can decide internally where it wants to wait for all registered callbacks to finish before it continues it's work.

The new API `awaitForSync` is backward compatible with all callbacks registered using `on` and `awaitOn`.
The old API `sync` can handle callbacks registered by `awaitOn` in theory, but it is likely that the fuse-box internal code will fail because it doesn't expect a Promise as a return value. You really have to use the API wrong to come into this situation. But when we add a list of events to the documentation, we should also document which ones shall be sync and async