### PR TITLE
fix: give ts:main precedence over module in package.json

### DIFF
--- a/src/resolver/__tests__/shared.test.ts
+++ b/src/resolver/__tests__/shared.test.ts
@@ -31,5 +31,34 @@ describe('shared functions', () => {
       const res = getFolderEntryPointFromPackageJSON({ json: {} });
       expect(res).toEqual('index.js');
     });
+
+    it('Precedence test - all types & useLocalField: true - should return "local:main"', () => {
+      const res = getFolderEntryPointFromPackageJSON({
+        useLocalField: true,
+        json: { main: 'main.js', 'ts:main': 'tsmain.ts', 'local:main': 'localmain.js', module: 'module.js' },
+      });
+      expect(res).toEqual('localmain.js');
+    });
+
+    it('Precedence test - all types & useLocalField: false - should return "ts:main"', () => {
+      const res = getFolderEntryPointFromPackageJSON({
+        json: { main: 'main.js', 'ts:main': 'tsmain.ts', 'local:main': 'localmain.js', module: 'module.js' },
+      });
+      expect(res).toEqual('tsmain.ts');
+    });
+
+    it('Precedence test - missing ts:main - should return "module"', () => {
+      const res = getFolderEntryPointFromPackageJSON({
+        json: { main: 'main.js', 'local:main': 'localmain.js', module: 'module.js' },
+      });
+      expect(res).toEqual('module.js');
+    });
+
+    it('Precedence test - missing ts:main or module - should return "main"', () => {
+      const res = getFolderEntryPointFromPackageJSON({
+        json: { main: 'main.js', 'local:main': 'localmain.js' },
+      });
+      expect(res).toEqual('main.js');
+    });
   });
 });

--- a/src/resolver/shared.ts
+++ b/src/resolver/shared.ts
@@ -9,11 +9,11 @@ export function getFolderEntryPointFromPackageJSON(props: {
   if (props.useLocalField && props.json['local:main']) {
     return props.json['local:main'];
   }
-  if (props.json.module) {
-    return props.json.module;
-  }
   if (props.json['ts:main']) {
     return props.json['ts:main'];
+  }
+  if (props.json.module) {
+    return props.json.module;
   }
 
   return props.json.main || 'index.js';


### PR DESCRIPTION
Tried to fix the order.
ts_main should come before module/main but after local:main (alias/paths directories)