### PR TITLE
feat(WebIndexDefaultTpl): Default WebIndex template allows for zero-config setup

### DIFF
--- a/src/web-index/__tests__/webIndex.test.ts
+++ b/src/web-index/__tests__/webIndex.test.ts
@@ -3,7 +3,13 @@ import { BundleType, createBundleSet } from '../../bundle/Bundle';
 import { createContext } from '../../core/Context';
 import { env } from '../../env';
 import { mockWriteFile } from '../../utils/test_utils';
-import { getEssentialWebIndexParams, IWebIndexConfig, replaceWebIndexStrings } from '../webIndex';
+import {
+  getEssentialWebIndexParams,
+  IWebIndexConfig,
+  replaceWebIndexStrings,
+  WEBINDEX_DEFAULT_TEMPLATE,
+} from '../webIndex';
+import { FuseBoxLogAdapter } from '../../fuse-log/FuseBoxLogAdapter';
 const fileMock = mockWriteFile();
 
 const defaultTemplate = `
@@ -116,10 +122,9 @@ describe('WebIndex test', () => {
       expect(data.contents).toContain(`src="/app.js"></script>`);
     });
 
-    it('should throw an error if a file not found', async () => {
-      expect(() => {
-        getEssentialWebIndexParams({ template: 'foo' });
-      }).toThrowError();
+    it('should throw NO error if file not found, but use default template', async () => {
+      const opts = getEssentialWebIndexParams({ template: 'foo' }, new FuseBoxLogAdapter({}));
+      expect(opts.templateContent).toEqual(WEBINDEX_DEFAULT_TEMPLATE);
     });
   });
 });

--- a/src/web-index/__tests__/webIndex.test.ts
+++ b/src/web-index/__tests__/webIndex.test.ts
@@ -12,19 +12,6 @@ import {
 import { FuseBoxLogAdapter } from '../../fuse-log/FuseBoxLogAdapter';
 const fileMock = mockWriteFile();
 
-const defaultTemplate = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <title></title>
-    $css
-  </head>
-  <body>
-    $bundles
-  </body>
-</html>
-
-`;
 describe('WebIndex test', () => {
   describe('replaceWebIndexStrings', () => {
     it('should replace in one line', () => {
@@ -62,7 +49,7 @@ describe('WebIndex test', () => {
   describe('webindex', () => {
     beforeEach(() => {
       fileMock.flush();
-      fileMock.addFile(join(env.FUSE_MODULES, 'web-index-default-template/template.html'), defaultTemplate);
+      fileMock.addFile(join(env.FUSE_MODULES, 'web-index-default-template/template.html'), WEBINDEX_DEFAULT_TEMPLATE);
     });
     afterAll(() => {
       fileMock.unmock();

--- a/src/web-index/webIndex.ts
+++ b/src/web-index/webIndex.ts
@@ -18,16 +18,18 @@ export interface IWebIndexConfig {
 export const WEBINDEX_DEFAULT_TEMPLATE = `<!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title></title>
-    $css
-    $bundles
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title></title>
+  $css
 </head>
 <body>
+  $bundles
 </body>
-</html>`;
+</html>
+
+`;
 
 export interface IWebIndexInterface {
   isDisabled?: boolean;


### PR DESCRIPTION
Fixes issue #1618 -- but I took a bit different approach, open for discussion:

1) I didn't generate the index.html because we'd change the developers code by doing this. Thats always a dangerous thing to do for a build system, especially when we do that automatically -- instead I use a default template on the fly and warn that there is no index template file. So if the developer wants, the file can be created by him but if he doesn't, the project builds anyway. Perfect for zero-config setups and super simple setups.

2) I changed the default template to add some useful headers for modern devices like viewport and edge support, UTF-8 charset etc.