### PR TITLE
feat(PortInUse): Exit gracefully

### DIFF
--- a/src/dev-server/devServer.ts
+++ b/src/dev-server/devServer.ts
@@ -63,16 +63,20 @@ export function createExpressApp(ctx: Context, props: IHTTPServerProps, extra?: 
     res.sendFile(props.fallback);
   });
 
-  return app.listen(props.port, () => {
-    if (extra && extra.openProps) {
-      extra.openProps.target = extra.openProps.target || `http://localhost:${props.port}`;
-      open(extra.openProps.target, extra.openProps);
-    }
+  return app
+    .listen(props.port, () => {
+      if (extra && extra.openProps) {
+        extra.openProps.target = extra.openProps.target || `http://localhost:${props.port}`;
+        open(extra.openProps.target, extra.openProps);
+      }
 
-    ctx.log.info('development', `Development server is running at <bold>http://localhost:$port</bold>`, {
-      port: props.port,
+      ctx.log.info('development', `Development server is running at <bold>http://localhost:$port</bold>`, {
+        port: props.port,
+      });
+    })
+    .on('error', err => {
+      ctx.fatal('An error occurred while trying to start the devServer.', [err.message]);
     });
-  });
 }
 
 export function createDevServer(ctx: Context): IDevServerActions {


### PR DESCRIPTION
<img width="498" alt="Bildschirmfoto 2019-09-08 um 16 47 27" src="https://user-images.githubusercontent.com/454817/64489940-ae9d2500-d258-11e9-9676-794e129c5c89.png">

This fixes #1553 but also in general all types of errors that could occur while devServer startup
