### PR TITLE
fix: sparky path executed in sub folders #1582

### DIFF
--- a/src/sparky/sparky_chain.ts
+++ b/src/sparky/sparky_chain.ts
@@ -37,7 +37,7 @@ export function sparkyChain(log: FuseBoxLogAdapter): ISparkyChain {
     }
 
     if (newLocation && newLocationBase) {
-      const root = ensureAbsolutePath(newLocation, env.APP_ROOT);
+      const root = ensureAbsolutePath(newLocation, env.SCRIPT_PATH);
       for (const i in latest) {
         const file = latest[i];
 

--- a/src/sparky/sparky_src.ts
+++ b/src/sparky/sparky_src.ts
@@ -5,7 +5,7 @@ import { env } from '../env';
 
 export async function sparky_src(rule: string) {
   return new Promise((resolve, reject) => {
-    glob(rule, {}, function(err, files) {
+    glob(rule, { cwd: env.SCRIPT_PATH }, function(err, files) {
       if (err) return reject(err);
       files = files.map(file => {
         if (!isAbsolute(file)) {


### PR DESCRIPTION
@nchanged 

Think Ive found the root of my issue.
Need to test more and find a good way to add test to this. I only ran the sparky tests. 

Problem is when its started from package root with something like npm or directly `node ./projects/sample1/fuse.ts`

If I tried to run this nothing happend, because it didnt find it. 
This is why I added option cwd to GLOB.
Changed the ROOT app since files didnt end up relative to script using sparky.

```
// failing, but dont know why
task("copy-src", async context => {
  await src(`./src/**/*.*`)
    .dest('./dist3/ts', `/src/`) 
    .exec();
});
```

If Ive broken something I dont know atm.
But like I started, we need to add more tests before we merge.
Maybe CI finds something when I create the PR too 😂 
Its late, I need sleep now.



