### PR TITLE
fix(code-splitting): pass correct config value + other changes

### DIFF
--- a/src/config/PrivateConfig.ts
+++ b/src/config/PrivateConfig.ts
@@ -118,8 +118,8 @@ export class PrivateConfig {
     }
     // define default settings for code splitting
     this.codeSplitting = props.codeSplitting || {};
-    this.codeSplitting.useHash = typeof this.codeSplitting.useHash === undefined ? true : this.codeSplitting.useHash
-    this.codeSplitting.maxPathLength = this.codeSplitting.maxPathLength || 20
+    this.codeSplitting.useHash = typeof this.codeSplitting.useHash === undefined ? true : this.codeSplitting.useHash;
+    this.codeSplitting.maxPathLength = typeof this.codeSplitting.maxPathLength === 'number' ? this.codeSplitting.maxPathLength : 20;
 
     if (!this.codeSplitting.scriptRoot) {
       if (this.isServer()) {

--- a/src/production/stages/codeSplittingStage.ts
+++ b/src/production/stages/codeSplittingStage.ts
@@ -50,7 +50,7 @@ export function codeSplittingStage(props: IProductionFlow) {
 
       const bundle = createBundle({
         ctx: props.ctx,
-        name: `${useHash ? fastHash(root.module.props.absPath) + '-' : ''}${beautifyBundleName(root.module.props.absPath, maxlen)}`,
+        name: `${useHash ? fastHash(root.module.props.absPath) + '-' : ''}${beautifyBundleName(root.module.props.fuseBoxPath, maxlen)}`,
         webIndexed: false,
         type: BundleType.SPLIT_JS,
       });

--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -43,6 +43,21 @@ describe('utils', () => {
       const name = beautifyBundleName('./this/path/is/wild/right/ok.module');
       expect(name).toEqual('this-path-is-wild-right-ok');
     });
+
+    it('should beautifyBundleName 6', () => {
+      const name = beautifyBundleName('./site/not-found/not-found.module');
+      expect(name).toEqual('site-not-found-not-found');
+    });
+
+    it('should beautifyBundleName 6', () => {
+      const name = beautifyBundleName('ngc/browser/site/not-found/not-found.module.js');
+      expect(name).toEqual('ngc-browser-site-not-found-not-found.module');
+    });
+
+    it('should beautifyBundleName 7', () => {
+      const name = beautifyBundleName('./ngc/browser/site/not-found/not-found.module.js');
+      expect(name).toEqual('ngc-browser-site-not-found-not-found.module');
+    });
   });
   describe('parseVersion', () => {
     it('should parse with v', () => {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -31,9 +31,8 @@ export function removeFolder(userPath) {
 export function beautifyBundleName(absPath: string, maxLength?: number) {
   return absPath
     .replace(/(\.\w+)$/g, '')
-    .replace('.', '')
     .split(/(\/|\\)/g)
-    .filter(a => a !== '' && !a.match(/(\/|\\)/g))
+    .filter(a => a !== '' && a !== '.' && !a.match(/(\/|\\)/g))
     .reduce((acc, curr, _idx, arr) => acc
       ? maxLength && acc.length > maxLength
         ? arr[arr.length - 1]


### PR DESCRIPTION
### Improved output

<img width="548" alt="Screen Shot 2019-09-21 at 2 01 28 PM" src="https://user-images.githubusercontent.com/6701211/65378006-5c0c3180-dc78-11e9-971c-0cf6d9d5ef66.png">

Notice `"ngc-browser"`, that is the entry to the project files being compiled. I do think it would be nice to be able to remove "ngc-browser" (or whatever in a given project) by exposing an option in config, or if there is a way to automatically detect this in the fusebox context I am not aware of.
