### PR TITLE
Fix web index

### DIFF
--- a/src/config/PrivateConfig.ts
+++ b/src/config/PrivateConfig.ts
@@ -119,20 +119,20 @@ export class PrivateConfig {
     // define default settings for code splitting
     this.codeSplitting = props.codeSplitting || {};
     this.codeSplitting.useHash = typeof this.codeSplitting.useHash === undefined ? true : this.codeSplitting.useHash;
-    this.codeSplitting.maxPathLength = typeof this.codeSplitting.maxPathLength === 'number' ? this.codeSplitting.maxPathLength : 20;
+    this.codeSplitting.maxPathLength =
+      typeof this.codeSplitting.maxPathLength === 'number' ? this.codeSplitting.maxPathLength : 20;
 
     if (!this.codeSplitting.scriptRoot) {
       if (this.isServer()) {
         this.codeSplitting.scriptRoot = './';
       } else {
-        if (this.webIndex && this.webIndex.publicPath) {
+        if (this.webIndex && typeof this.webIndex.publicPath != 'undefined') {
           this.codeSplitting.scriptRoot = this.webIndex.publicPath;
         } else {
           this.codeSplitting.scriptRoot = '/';
         }
       }
     }
-
 
     this.watch = {
       enabled: !env.isTest,
@@ -204,10 +204,10 @@ export class PrivateConfig {
       return userPublicPath;
     }
     let publicPath = '/';
-    if (this.webIndex && this.webIndex.publicPath) {
+    if (this.webIndex && typeof this.webIndex.publicPath != 'undefined') {
       publicPath = this.webIndex.publicPath;
     }
-    if (this.resources && this.resources.resourcePublicRoot) {
+    if (this.resources && typeof this.resources.resourcePublicRoot != 'undefined') {
       publicPath = joinFuseBoxPath(publicPath, this.resources.resourcePublicRoot);
     }
     return publicPath;

--- a/src/config/PrivateConfig.ts
+++ b/src/config/PrivateConfig.ts
@@ -126,7 +126,7 @@ export class PrivateConfig {
       if (this.isServer()) {
         this.codeSplitting.scriptRoot = './';
       } else {
-        if (this.webIndex && typeof this.webIndex.publicPath != 'undefined') {
+        if (this.webIndex && typeof this.webIndex.publicPath === 'string') {
           this.codeSplitting.scriptRoot = this.webIndex.publicPath;
         } else {
           this.codeSplitting.scriptRoot = '/';

--- a/src/config/PrivateConfig.ts
+++ b/src/config/PrivateConfig.ts
@@ -204,7 +204,7 @@ export class PrivateConfig {
       return userPublicPath;
     }
     let publicPath = '/';
-    if (this.webIndex && typeof this.webIndex.publicPath != 'undefined') {
+    if (this.webIndex && typeof this.webIndex.publicPath === 'string') {
       publicPath = this.webIndex.publicPath;
     }
     if (this.resources && typeof this.resources.resourcePublicRoot != 'undefined') {

--- a/src/config/PrivateConfig.ts
+++ b/src/config/PrivateConfig.ts
@@ -207,7 +207,7 @@ export class PrivateConfig {
     if (this.webIndex && typeof this.webIndex.publicPath === 'string') {
       publicPath = this.webIndex.publicPath;
     }
-    if (this.resources && typeof this.resources.resourcePublicRoot != 'undefined') {
+    if (this.resources && typeof this.resources.resourcePublicRoot === 'string') {
       publicPath = joinFuseBoxPath(publicPath, this.resources.resourcePublicRoot);
     }
     return publicPath;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,9 +1,9 @@
 import * as fs from 'fs';
 import * as fsExtra from 'fs-extra';
-import * as path from 'path';
-import { env } from '../env';
-import * as prettyTime from 'pretty-time';
 import * as offsetLinesModule from 'offset-sourcemap-lines';
+import * as path from 'path';
+import * as prettyTime from 'pretty-time';
+import { env } from '../env';
 const CACHED_PATHS = new Map<string, RegExp>();
 
 export function path2Regex(path: string) {
@@ -33,12 +33,10 @@ export function beautifyBundleName(absPath: string, maxLength?: number) {
     .replace(/(\.\w+)$/g, '')
     .split(/(\/|\\)/g)
     .filter(a => a !== '' && a !== '.' && !a.match(/(\/|\\)/g))
-    .reduce((acc, curr, _idx, arr) => acc
-      ? maxLength && acc.length > maxLength
-        ? arr[arr.length - 1]
-        : `${acc}-${curr}`
-      : curr)
-    .toLowerCase()
+    .reduce((acc, curr, _idx, arr) =>
+      acc ? (maxLength && acc.length > maxLength ? arr[arr.length - 1] : `${acc}-${curr}`) : curr,
+    )
+    .toLowerCase();
 }
 
 export function offsetLines(obj: any, amount: number) {
@@ -210,7 +208,7 @@ export type Concat = {
   sourceMap: string;
 };
 export type ConcatModule = {
-  new(generateSourceMap: boolean, outputFileName: string, seperator: string): Concat;
+  new (generateSourceMap: boolean, outputFileName: string, seperator: string): Concat;
 };
 export const Concat: ConcatModule = require('fuse-concat-with-sourcemaps');
 
@@ -244,9 +242,13 @@ export function ensureFuseBoxPath(input: string) {
 
 export function joinFuseBoxPath(...any): string {
   let includesProtocol = any[0].includes('://');
+  let isRelative = any[0].includes('./');
   let joinedPath = !includesProtocol
     ? path.join(...any)
     : any[0].replace(/([^/])$/, '$1/') + path.join(...any.slice(1));
+  if (isRelative) {
+    joinedPath = './' + joinedPath;
+  }
   return ensureFuseBoxPath(joinedPath);
 }
 

--- a/src/web-index/__tests__/webIndex.test.ts
+++ b/src/web-index/__tests__/webIndex.test.ts
@@ -2,9 +2,9 @@ import { join } from 'path';
 import { BundleType, createBundleSet } from '../../bundle/Bundle';
 import { createContext } from '../../core/Context';
 import { env } from '../../env';
+import { FuseBoxLogAdapter } from '../../fuse-log/FuseBoxLogAdapter';
 import { mockWriteFile } from '../../utils/test_utils';
 import { getEssentialWebIndexParams, IWebIndexConfig, replaceWebIndexStrings } from '../webIndex';
-import { FuseBoxLogAdapter } from '../../fuse-log/FuseBoxLogAdapter';
 const fileMock = mockWriteFile();
 
 const WEBINDEX_DEFAULT_TEMPLATE = `<!DOCTYPE html>
@@ -123,6 +123,18 @@ describe('WebIndex test', () => {
     it('should throw NO error if file not found, but use default template', async () => {
       const opts = getEssentialWebIndexParams({ template: 'foo' }, new FuseBoxLogAdapter({}));
       expect(opts.templateContent).toEqual(WEBINDEX_DEFAULT_TEMPLATE);
+    });
+
+    it('should use an empty publicPath', async () => {
+      await generateCSSBundle({ publicPath: '' });
+      const data = findIndexInMock();
+      expect(data.contents).toContain(`href="styles.css"`);
+    });
+
+    it('should use an specific local publicPath', async () => {
+      await generateCSSBundle({ publicPath: './' });
+      const data = findIndexInMock();
+      expect(data.contents).toContain(`href="./styles.css"`);
     });
   });
 });


### PR DESCRIPTION
- publicPath handles "" and "./" correctly
- webIndex plugins returns of bundles, cssTags, scriptTags is respected and actually used

<img width="579" alt="Bildschirmfoto 2019-09-28 um 01 26 38" src="https://user-images.githubusercontent.com/454817/65807506-1a571b80-e18f-11e9-9180-209e7dfe339c.png">
<img width="568" alt="Bildschirmfoto 2019-09-28 um 01 26 28" src="https://user-images.githubusercontent.com/454817/65807507-1a571b80-e18f-11e9-8c8d-455ad2e6df73.png">

