### PR TITLE
Add options passed to less compiler.

### DIFF
--- a/docs/stylesheet.md
+++ b/docs/stylesheet.md
@@ -316,6 +316,24 @@ fusebox({
 });
 ```
 
+### Adding options
+
+You can pass options to the Less compiler
+
+```ts
+fusebox({
+  stylesheet: {
+    less: {
+      options: {
+        modifyVars: { color1: 'red' },
+      },
+    },
+  },
+});
+```
+
+Available options are [listed here](http://lesscss.org/usage/#less-options)
+
 ## Working with Stylus
 
 Install the module first

--- a/src/config/ILessProps.ts
+++ b/src/config/ILessProps.ts
@@ -1,3 +1,4 @@
 export interface ILessProps {
   plugins: Array<any>;
+  options: any;
 }

--- a/src/stylesheet/less/lessHandler.ts
+++ b/src/stylesheet/less/lessHandler.ts
@@ -74,13 +74,18 @@ export async function renderModule(props: { ctx: Context; module: Module; less: 
   );
 
   let pluginList: Array<any> = [Importer];
+  let compilerOptions: any = {};
   if (props.options.less) {
     if (props.options.less.plugins) {
       pluginList = pluginList.concat(props.options.less.plugins);
     }
+    if (props.options.less.options) {
+      compilerOptions = props.options.less.options;
+    }
   }
 
   const data = await renderWithLess(props.less, processed.contents, {
+    ...compilerOptions,
     sourceMap: requireSourceMap && { outputSourceFiles: true },
     filename: module.props.absPath,
     plugins: pluginList,


### PR DESCRIPTION
I would like to pass options to the less compiler such as { modifyVars: { 'accent-color': 'blue' } }.

I propose to add an options object to stylesheet.less that would be passed to less.render().