### PR TITLE
check if node.getExpression is exists

### DIFF
--- a/src/production/transformation/conditionUnwrapper.ts
+++ b/src/production/transformation/conditionUnwrapper.ts
@@ -69,6 +69,10 @@ function setResult(result: any, node: IfStatement) {
   }
 }
 function onIfStatement(node: IfStatement, props: LocalContext) {
+  if (typeof node.getExpression === "undefined") {
+    return;
+  }
+
   const expression = node.getExpression();
   const desc = expression.getDescendants();
 


### PR DESCRIPTION
there is problem when .runProd() starting on tslib.es6.js, and other files (even on empty project source files):
```
(node:352) UnhandledPromiseRejectionWarning: TypeError: node.getExpression is not a function
    at onIfStatement (G:\source\git\modules\fb\node_modules\fuse-box\production\transformation\conditionUnwrapper.js:75:29)
    at Identifiers.forEach.id (G:\source\git\modules\fb\node_modules\fuse-box\production\transformation\conditionUnwrapper.js:114:13)
    at Array.forEach (<anonymous>)
    at Object.conditionUnwrapperProduction (G:\source\git\modules\fb\node_modules\fuse-box\production\transformation\conditionUnwrapper.js:112:17)
    at Object.performStaticTransformations (G:\source\git\modules\fb\node_modules\fuse-box\production\transformation\index.js:11:26)
    at staticTransform (G:\source\git\modules\fb\node_modules\fuse-box\production\stages\preparationStage.js:14:26)
    at pkg.modules.forEach.module (G:\source\git\modules\fb\node_modules\fuse-box\production\stages\preparationStage.js:33:13)
    at Array.forEach (<anonymous>)
    at packages.forEach.pkg (G:\source\git\modules\fb\node_modules\fuse-box\production\stages\preparationStage.js:29:21)
    at Array.forEach (<anonymous>)
(node:352) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a p
romise which was not handled with .catch(). (rejection id: 2)
(node:352) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a no
n-zero exit code.
```