### PR TITLE
fix(resolver): local modules now find root

### DIFF
--- a/src/resolver/__tests__/nodeModuleLookup.test.ts
+++ b/src/resolver/__tests__/nodeModuleLookup.test.ts
@@ -83,7 +83,7 @@ describe('NodeModule lookup', () => {
   const filePath = path.join(cases, 'src2/index.ts');
   it('should fail to look up a module', () => {
     const res = nodeModuleLookup({ filePath: filePath, target: '__foo' }, { name: '__foo' });
-    expect(res).toEqual({ error: 'Cannot resolve "__foo"' });
+    expect(res && res.error).toContain('Cannot resolve "__foo"');
   });
 
   it('should fail to look up a module without package.json', () => {

--- a/src/resolver/nodeModuleLookup.ts
+++ b/src/resolver/nodeModuleLookup.ts
@@ -62,6 +62,7 @@ export function parseAllModulePaths(fileAbsPath: string) {
   }
 }
 
+const CACHED_LOCAL_MODULES: { [key: string]: string | null } = {};
 export function findTargetFolder(props: IResolverProps, parsed: IModuleParsed): string {
   // handle custom modules here
   if (props.modules) {
@@ -81,7 +82,10 @@ export function findTargetFolder(props: IResolverProps, parsed: IModuleParsed): 
     }
   }
 
-  const localModuleRoot = findUp(props.filePath, "node_modules");
+  let localModuleRoot = CACHED_LOCAL_MODULES[props.filePath];
+  if (localModuleRoot === undefined) {
+    localModuleRoot = CACHED_LOCAL_MODULES[props.filePath] = findUp(props.filePath, "node_modules");
+  }
   if (!!localModuleRoot) {
     paths.push(localModuleRoot);
     const attempted = path.join(localModuleRoot, parsed.name);

--- a/src/resolver/resolver.ts
+++ b/src/resolver/resolver.ts
@@ -185,7 +185,7 @@ export function resolveModule(props: IResolverProps): IResolver {
   }
 
   if (!lookupResult.fileExists) {
-    return;
+    return { error: `File does not exist "${lookupResult.absPath}"` };
   }
 
   if (props.packageMeta) {

--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -14,6 +14,8 @@ import {
   beautifyBundleName,
   path2RegexPattern,
 } from '../utils';
+import { findUp } from '../findUp';
+import { join } from 'path';
 
 describe('utils', () => {
   describe('beautifyBundleName', () => {
@@ -178,4 +180,34 @@ describe('utils', () => {
       expect(path2RegexPattern(`\\documents\\`).test('users/documents/bar.ts')).toEqual(true);
     });
   });
+
+  // These tests will fail if this test file is moved.
+  describe('findUp', () => {
+    const currentDir = __dirname;
+    const target = "package.json";
+    const projectRoot = join(currentDir, "../../../");
+    const targetPath = join(projectRoot, target);
+
+    it('findUp - target in start dir', () => {
+      expect(findUp(currentDir, target)).toEqual(targetPath);
+    });
+
+    it('findUp - target in parent of start dir', () => {
+      expect(findUp(currentDir, target)).toEqual(targetPath);
+    });
+
+    it('findUp - target at inclusive boundary', () => {
+      expect(findUp(currentDir, target, {
+        boundary: projectRoot,
+        inclusive: true,
+      })).toEqual(targetPath);
+    });
+
+    it('findUp - target at exclusive boundary', () => {
+      expect(findUp(currentDir, target, {
+        boundary: projectRoot,
+        inclusive: false,
+      })).toEqual(null);
+    });
+  })
 });

--- a/src/utils/findUp.ts
+++ b/src/utils/findUp.ts
@@ -1,0 +1,39 @@
+import { join, dirname } from 'path';
+import { existsSync, statSync } from 'fs';
+
+export const FIND_UP_GLOBAL_CONFIG = {
+  maxStepsBack: 10
+};
+
+export function findUp(start: string, target: string, boundaryArg?: {
+  boundary: string,
+  inclusive: boolean,
+}): string | null {
+  let currentDir = start;
+  try {
+    const stat = statSync(start);
+    currentDir = stat.isDirectory() ? start : dirname(start);
+  } catch (err) { }
+
+  let lastTry = false;
+  let backSteps = 0;
+  while (backSteps++ <= FIND_UP_GLOBAL_CONFIG.maxStepsBack) {
+    if (boundaryArg && boundaryArg.boundary.includes(currentDir)) {
+      if (boundaryArg.inclusive && lastTry === false) {
+        lastTry = true;
+      } else {
+        return null;
+      }
+    }
+
+    const targetTestPath = join(currentDir, target);
+    if (existsSync(targetTestPath)) {
+      return targetTestPath;
+    }
+
+    currentDir = join(currentDir, "../");
+  }
+
+  console.error(`Too many back steps, starting from "${start}"`);
+  return null;
+}


### PR DESCRIPTION
All that work, but it ended up being a tiny change.  Also, an insanely difficult bug.

The change is simple, when searching all node_module paths, also check for `node_modules` upwards.

