### PR TITLE
feature(plugins): Pass plugin options to corresponding transformer

### DIFF
--- a/src/core/Context.ts
+++ b/src/core/Context.ts
@@ -88,9 +88,11 @@ export class Context {
     this.config.setupEnv();
   }
 
-  public transformerAtPath(path: string | RegExp, transformer: (opts: any) => ITransformer) {
+  public transformerAtPath(path: string | RegExp, transformer: (opts: any) => ITransformer, transformerOptions?: any) {
     if (!this._tranformersAtPaths) this._tranformersAtPaths = [];
-    this._tranformersAtPaths.push({ test: path2RegexPattern(path), transformer });
+    this._tranformersAtPaths.push({
+      test: path2RegexPattern(path), transformer: (opts: any) => transformer({ ...transformerOptions, ...opts })
+    });
   }
 
   public getTransformersAtPath(path: string): Array<(opts: any) => ITransformer> {


### PR DESCRIPTION
This feature adds the functionality to pass plugin options to the transformer:


Simplified example without fallbacks to defaults:

`fuse.ts`
```js
plugins: [
  pluginTest({
    autoInject: true,
    target: /src\/(.*?)\.(js|jsx|ts|tsx)$/
  })
],
```
`plugin_test.ts`
```ts
export function pluginTest(opts?: any) {
    const { target, ...options } = opts;
    return (ctx: Context) => {
        ctx.transformerAtPath(target, TestTransformer, options);
    };
}
```

`TestTransformer.ts`
```ts
export const TestTransformer = (opts?: any): ITransformer => {
  if (opts.autoInject) {
    // do something else?
  }
}
```
