### PR TITLE
Fix: ISDIR: illegal operation on a directory for sha.js

### DIFF
--- a/src/resolver/__tests__/cases/paths_lookup/src1/some.js/README.md
+++ b/src/resolver/__tests__/cases/paths_lookup/src1/some.js/README.md
@@ -1,0 +1,3 @@
+This reflects the structure and require pattern from `sha.js`
+* https://github.com/crypto-browserify/sha.js/tree/105bfe57c69e13c83fcf7a6ca660dd984cb291bf
+* https://github.com/crypto-browserify/sha.js/blob/105bfe57c69e13c83fcf7a6ca660dd984cb291bf/index.js#L10

--- a/src/resolver/__tests__/cases/paths_lookup/src1/some.js/index.js
+++ b/src/resolver/__tests__/cases/paths_lookup/src1/some.js/index.js
@@ -1,0 +1,3 @@
+const someJs = requie("./some.js");
+
+module.exports = {}

--- a/src/resolver/__tests__/cases/paths_lookup/src1/some.js/some.js
+++ b/src/resolver/__tests__/cases/paths_lookup/src1/some.js/some.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/src/resolver/__tests__/pathsLookup.test.ts
+++ b/src/resolver/__tests__/pathsLookup.test.ts
@@ -6,7 +6,7 @@ const CASE1 = path.join(__dirname, 'cases/paths_lookup/src1');
 describe('Paths lookup', () => {
   describe('Basic lookup based on listing', () => {
     it('Should lookup and resolve baseURL . (tsx)', () => {
-      const result = pathsLookup({ baseURL: CASE1, homeDir: CASE1, target: 'bar/Bar' });
+      const result = pathsLookup({ baseURL: CASE1, homeDir: CASE1, fromPath: CASE1, target: 'bar/Bar' });
 
       expect(result.fileExists).toBe(true);
       expect(result.absPath).toMatch(/Bar\.tsx$/);
@@ -14,25 +14,31 @@ describe('Paths lookup', () => {
     });
 
     it('Should lookup and resolve baseURL . (foo/index.ts)', () => {
-      const result = pathsLookup({ baseURL: CASE1, homeDir: CASE1, target: 'foo' });
+      const result = pathsLookup({ baseURL: CASE1, homeDir: CASE1, fromPath: CASE1, target: 'foo' });
       expect(result.fileExists).toBe(true);
 
       expect(result.absPath).toMatchFilePath('foo/index.ts$');
     });
 
     it('Should lookup and resolve baseURL . (foo/index.ts) with slash', () => {
-      const result = pathsLookup({ baseURL: CASE1, homeDir: CASE1, target: 'foo/' });
+      const result = pathsLookup({ baseURL: CASE1, homeDir: CASE1, fromPath: CASE1, target: 'foo/' });
       expect(result.fileExists).toBe(true);
       expect(result.absPath).toMatchFilePath('foo/index.ts$');
     });
 
+    it('Should lookup and resolve js file in package with name same as file', () => {
+      const result = pathsLookup({ baseURL: CASE1, homeDir: CASE1, fromPath: path.join(CASE1, "some.js/index.js"), target: 'some.js' });
+      expect(result.fileExists).toBe(true);
+      expect(result.absPath).toMatchFilePath('some.js/some.js$');
+    });
+
     it('Should fail to resolve', () => {
-      const result = pathsLookup({ baseURL: CASE1, homeDir: CASE1, target: 'foosome/' });
+      const result = pathsLookup({ baseURL: CASE1, homeDir: CASE1, fromPath: CASE1, target: 'foosome/' });
       expect(result).toBe(undefined);
     });
 
     it('Should result just a file name Moi.ts', () => {
-      const result = pathsLookup({ baseURL: CASE1, homeDir: CASE1, target: 'Moi' });
+      const result = pathsLookup({ baseURL: CASE1, homeDir: CASE1, fromPath: CASE1, target: 'Moi' });
       expect(result.fileExists).toBe(true);
 
       expect(result.absPath).toMatchFilePath('Moi.ts$');
@@ -44,6 +50,7 @@ describe('Paths lookup', () => {
       const result = pathsLookup({
         baseURL: CASE1,
         homeDir: CASE1,
+        fromPath: CASE1,
         paths: {
           '@app/*': ['something/app/*'],
         },
@@ -58,6 +65,7 @@ describe('Paths lookup', () => {
       const result = pathsLookup({
         baseURL: CASE1,
         homeDir: CASE1,
+        fromPath: CASE1,
         paths: {
           '@app/*': ['something/app/*', 'something/other/*'],
         },
@@ -72,6 +80,7 @@ describe('Paths lookup', () => {
       const result = pathsLookup({
         baseURL: CASE1,
         homeDir: CASE1,
+        fromPath: CASE1,
         paths: {
           '@app/*/foo': ['something/*/Foo'],
         },
@@ -86,6 +95,7 @@ describe('Paths lookup', () => {
       const result = pathsLookup({
         baseURL: CASE1,
         homeDir: CASE1,
+        fromPath: CASE1,
         paths: {
           '@app/*': ['foo'],
         },
@@ -100,6 +110,7 @@ describe('Paths lookup', () => {
       const result = pathsLookup({
         baseURL: CASE1,
         homeDir: CASE1,
+        fromPath: CASE1,
         paths: {
           '@app*': ['foo'],
         },
@@ -114,6 +125,7 @@ describe('Paths lookup', () => {
       const result = pathsLookup({
         baseURL: CASE1,
         homeDir: CASE1,
+        fromPath: CASE1,
         paths: {
           path: ['foo'],
         },

--- a/src/resolver/pathsLookup.ts
+++ b/src/resolver/pathsLookup.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as path from 'path';
 import { fileLookup, ILookupResult } from './fileLookup';
 
 export type ITypescriptPaths = { [key: string]: Array<string> };
@@ -8,6 +9,7 @@ interface IPathsLookupProps {
   isDev?: boolean;
   cachePaths?: boolean;
   paths?: ITypescriptPaths;
+  fromPath: string;
   target: string;
 }
 
@@ -82,6 +84,11 @@ function getIndexFiles(props: IPathsLookupProps): DirectoryListing | undefined {
 }
 
 export function pathsLookup(props: IPathsLookupProps): ILookupResult {
+  const fileDir =
+    fs.statSync(props.fromPath).isDirectory()
+      ? props.fromPath
+      : path.dirname(props.fromPath);
+
   // if baseDir is the same as homeDir we can assume aliasing directories
   // and files without the need in specifying "paths"
   // so we check if first
@@ -93,7 +100,7 @@ export function pathsLookup(props: IPathsLookupProps): ILookupResult {
       // check if starts with it only
       const regex = new RegExp(`^${item.nameWithoutExtension}($|\\.|\\/)`);
       if (regex.test(props.target)) {
-        const result = fileLookup({ fileDir: props.baseURL, target: props.target });
+        const result = fileLookup({ fileDir, target: props.target });
         if (result && result.fileExists) {
           return result;
         }
@@ -111,7 +118,7 @@ export function pathsLookup(props: IPathsLookupProps): ILookupResult {
     if (directories) {
       for (const j in directories) {
         const directory = directories[j];
-        const result = fileLookup({ isDev: props.isDev, fileDir: props.baseURL, target: directory });
+        const result = fileLookup({ isDev: props.isDev, fileDir, target: directory });
         if (result && result.fileExists) {
           return result;
         }

--- a/src/resolver/resolver.ts
+++ b/src/resolver/resolver.ts
@@ -136,6 +136,7 @@ export function resolveModule(props: IResolverProps): IResolver {
       cachePaths: props.cache,
       homeDir: props.homeDir,
       paths: props.typescriptPaths.paths,
+      fromPath: props.filePath,
       target: target,
     });
 


### PR DESCRIPTION
When package name ends with `.js` like `sha.js` it shouldn't be considered as a module.