### PR TITLE
fix(production): polyfill global

### DIFF
--- a/src/production/transformation/processTransformation.ts
+++ b/src/production/transformation/processTransformation.ts
@@ -21,7 +21,7 @@ function onGlobal(node: Identifier, props: LocalContext) {
     }
     if (!props.globalInserted) {
       props.globalInserted = true;
-      props.insertions.push(`const global = {};`);
+      props.insertions.push(`const global = globalThis || self || window || global;`);
     }
   }
 }

--- a/src/production/transformation/processTransformation.ts
+++ b/src/production/transformation/processTransformation.ts
@@ -21,7 +21,12 @@ function onGlobal(node: Identifier, props: LocalContext) {
     }
     if (!props.globalInserted) {
       props.globalInserted = true;
-      props.insertions.push(`const global = globalThis || self || window || global;`);
+      props.insertions.push(`const global =
+        typeof globalThis !== 'undefined' ? globalThis :
+        typeof self !== 'undefined' ? self :
+        typeof window !== 'undefined' ? window :
+        typeof global !== 'undefined' ? global :
+        {};`);
     }
   }
 }


### PR DESCRIPTION
fix #1654

Uses `globalThis` for modern browsers and [this polyfill](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis#Examples) for those that don't have `globalThis`.