### PR TITLE
Suggested RegEx patterns to ignore

### DIFF
--- a/docs/watcher.md
+++ b/docs/watcher.md
@@ -33,7 +33,7 @@ fusebox({
 *(note: Strings are automatically converted to regular expressions. FuseBox also takes care of windows/\*nix paths for you. For example`./` is converted into `(\/|\\)\.`)*
 
 ## Suggested files to ignore
-* Emacs flycheck temporary files: `/flycheck_/i`. For a specific file, something like `/flycheck_filename.extension/i`
+* Emacs flycheck temporary files: `/flycheck_/i`. For a specific file, something like `/flycheck_filename.extension/i` where "filename.extension" could be, for example, "index.ts".
 
 
 ### Chokidar options

--- a/docs/watcher.md
+++ b/docs/watcher.md
@@ -32,7 +32,7 @@ fusebox({
 
 *(note: Strings are automatically converted to regular expressions. FuseBox also takes care of windows/\*nix paths for you. For example`./` is converted into `(\/|\\)\.`)*
 
-## Suggested files to ignore
+### Suggested files to ignore
 * Emacs flycheck temporary files: `/flycheck_/i`. For a specific file, something like `/flycheck_filename.extension/i` where "filename.extension" could be, for example, "index.ts".
 
 

--- a/docs/watcher.md
+++ b/docs/watcher.md
@@ -32,6 +32,10 @@ fusebox({
 
 *(note: Strings are automatically converted to regular expressions. FuseBox also takes care of windows/\*nix paths for you. For example`./` is converted into `(\/|\\)\.`)*
 
+## Suggested files to ignore
+* Emacs flycheck temporary files: `/flycheck_/i`. For a specific file, something like `/flycheck_filename.extension/i`
+
+
 ### Chokidar options
 
 You can pass chokidar options by using `chokidar` field:


### PR DESCRIPTION
Flycheck will at times create temporary files. This might have the undesired effect of triggering FuseBox watch mechanism. To avoid this, the pattern `/flycheck_/i` could be used.