### PR TITLE
fix: added direct process to polyfills

### DIFF
--- a/src/compiler/__tests__/__snapshots__/bundle.polyfill.transform.test.ts.snap
+++ b/src/compiler/__tests__/__snapshots__/bundle.polyfill.transform.test.ts.snap
@@ -44,6 +44,12 @@ console.log(https.method);
 "
 `;
 
+exports[`Bundle polyfill transform test polyfills Member reference reference shuold insert process with method reference 1`] = `
+"var process = require(\\"process\\");
+console.log(process.method);
+"
+`;
+
 exports[`Bundle polyfill transform test polyfills Member reference reference shuold insert stream with method reference 1`] = `
 "var stream = require(\\"stream\\");
 console.log(stream.method);
@@ -71,6 +77,12 @@ console.log(http.method());
 exports[`Bundle polyfill transform test polyfills Member reference with a call shuold insert https with method reference with a call 1`] = `
 "var https = require(\\"https\\");
 console.log(https.method());
+"
+`;
+
+exports[`Bundle polyfill transform test polyfills Member reference with a call shuold insert process with method reference with a call 1`] = `
+"var process = require(\\"process\\");
+console.log(process.method());
 "
 `;
 
@@ -131,6 +143,12 @@ console.log(http);
 exports[`Bundle polyfill transform test polyfills Single reference shuold insert https 1`] = `
 "var https = require(\\"https\\");
 console.log(https);
+"
+`;
+
+exports[`Bundle polyfill transform test polyfills Single reference shuold insert process 1`] = `
+"var process = require(\\"process\\");
+console.log(process);
 "
 `;
 

--- a/src/compiler/transformers/bundle/BundlePolyfillTransformer.ts
+++ b/src/compiler/transformers/bundle/BundlePolyfillTransformer.ts
@@ -1,13 +1,12 @@
 import * as path from 'path';
+import { ITarget } from '../../../config/PrivateConfig';
+import { ensureFuseBoxPath } from '../../../utils/utils';
 import { ASTNode } from '../../interfaces/AST';
+import { ImportType } from '../../interfaces/ImportType';
+import { ITransformer } from '../../interfaces/ITransformer';
 import { ITransformerSharedOptions } from '../../interfaces/ITransformerSharedOptions';
-import { GlobalContext } from '../../program/GlobalContext';
 import { createRequireStatement } from '../../Visitor/helpers';
 import { IVisit, IVisitorMod } from '../../Visitor/Visitor';
-import { ImportType } from '../../interfaces/ImportType';
-import { ITarget } from '../../../config/PrivateConfig';
-import { ITransformer } from '../../interfaces/ITransformer';
-import { ensureFuseBoxPath } from '../../../utils/utils';
 
 export interface IBundleEssentialProps {
   target?: ITarget;
@@ -25,6 +24,7 @@ export const PolyfillEssentialConfig = {
   Buffer: 'buffer',
   http: 'http',
   https: 'https',
+  process: 'process',
 };
 
 export function BundlePolyfillTransformer(): ITransformer {


### PR DESCRIPTION
process alone wasn't handled, having process.env.NODE_ENV and other shared methods aren't enough. Sometimes users check process, hence we need to make sure it's never undefined