### PR TITLE
fix: yarn 2 support (can't find fuse-box-hot-reload)

### DIFF
--- a/src/moduleResolver/moduleResolver.ts
+++ b/src/moduleResolver/moduleResolver.ts
@@ -251,6 +251,10 @@ function addExtraDepednencies(props: { bundleContext: IBundleContext; ctx: Conte
       parent: entryModule,
       statement,
     });
+    if (!targetModule) {
+      throw new Error(`Unable to resolve configured dependency module: "${statement}"`);
+    }
+
     // when a plugin injects dependencies it will most likely want to have the reference
     // the easiest way is to store them to the bundle context for later retrieval
     bundleContext.injectedDependencies[statement] = targetModule;

--- a/src/resolver/nodeModuleLookup.ts
+++ b/src/resolver/nodeModuleLookup.ts
@@ -73,6 +73,19 @@ export function findTargetFolder(props: IResolverProps, parsed: IModuleParsed): 
     }
   }
 
+  const isPnp = (process.versions as any).pnp;
+
+  // Support for Yarn v2 PnP
+  if (isPnp) {
+    try {
+      const pnp = require('pnpapi');
+      const folder = pnp.resolveToUnqualified(parsed.name, props.filePath, { considerBuiltins: false });
+      return folder;
+    } catch (e) {
+      // Ignore error here, since it will be handled later
+    }
+  }
+
   const paths = parseAllModulePaths(props.filePath);
 
   for (let i = paths.length - 1; i >= 0; i--) {
@@ -106,20 +119,7 @@ export interface INodeModuleLookup {
 export function nodeModuleLookup(props: IResolverProps, parsed: IModuleParsed): INodeModuleLookup {
   let folder: string;
 
-  const isPnp = (process.versions as any).pnp;
-
-  // Support for Yarn v2 PnP
-  if (isPnp) {
-    try {
-      const pnp = require('pnpapi');
-      folder = pnp.resolveToUnqualified(parsed.name, props.filePath, { considerBuiltins: false });
-    } catch (e) {
-      // Ignore error here, since it will be handled further down
-    }
-  } else {
-    folder = findTargetFolder(props, parsed);
-  }
-
+  folder = findTargetFolder(props, parsed);
   if (!folder) {
     return { error: `Cannot resolve "${parsed.name}"` };
   }


### PR DESCRIPTION
Do custom module loading before yarn 2 pnp module loading.

Also, throw a meaningful error if resolution of an injected module fails (instead of "Cannot read property 'id' of undefined")