### PR TITLE
fix: invalid transpile output on lower-case dotted JSX element names

### DIFF
--- a/src/compiler/__tests__/__snapshots__/jsx.test.ts.snap
+++ b/src/compiler/__tests__/__snapshots__/jsx.test.ts.snap
@@ -55,6 +55,14 @@ function test() {
 "
 `;
 
+exports[`JSX should handle dotted JSX elements 1`] = `
+"var react_1 = require(\\"react\\");
+function test() {
+  return react_1.default.createElement(animated.div, null, \\"1\\");
+}
+"
+`;
+
 exports[`JSX should have only one spread props 1`] = `
 "function test() {
   return React.createElement(\\"i\\", Object.assign({}, props));

--- a/src/compiler/__tests__/jsx.test.ts
+++ b/src/compiler/__tests__/jsx.test.ts
@@ -152,6 +152,19 @@ describe('JSX', () => {
     expect(result.code).toMatchSnapshot();
   });
 
+  it('should handle dotted JSX elements', () => {
+    const result = testTranspile({
+      code: `
+        import React from "react";
+        function test(){
+          return <animated.div>1</animated.div>
+        }
+          `,
+    });
+
+    expect(result.code).toMatchSnapshot();
+  });
+
   it('should work with JSXSpreadChild', () => {
     const result = testTranspile({
       code: `

--- a/src/compiler/transformers/shared/JSXTransformer.ts
+++ b/src/compiler/transformers/shared/JSXTransformer.ts
@@ -206,6 +206,10 @@ export function JSXTransformer(): ITransformer {
               return { replaceWith: node };
             case 'JSXMemberExpression':
               node.type = 'MemberExpression';
+              // A member expression should never be translated to a literal
+              // So it isn't a JSXIdentifier at this point, it's just an identifier
+              node.object.type = "Identifier";
+              node.property.type = "Identifier";
               // it's important to replace it, since it will be re-visited and picked up by other transformers
               // for example Import transformer
               return { replaceWith: node };


### PR DESCRIPTION
Alpha currently transpiles to invalid javascript on the following:

```JSX
function test() {
    return <animated.div>1</animated.div>
}
```

The issue appears to be that because "animated" is lower case, it gets transformed into a string literal `"animated"` and then `"div"` is appended like `("animated")."div"`.  But this shouldn't be done on identifiers that are already identified as MemberExpressions.

Confirmed that tsc's transpiler outputs:
```JSX
createElement(animated.div, null, "1")
```

This PR adds a test to match the tsc behavior and fixes the issue.