### PR TITLE
Fix/node resolution require packagejson

### DIFF
--- a/src/resolver/nodeModuleLookup.ts
+++ b/src/resolver/nodeModuleLookup.ts
@@ -101,7 +101,7 @@ export function findTargetFolder(props: IResolverProps, parsed: IModuleParsed): 
 
   for (let i = paths.length - 1; i >= 0; i--) {
     const attempted = path.join(paths[i], parsed.name);
-    if (fileExists(attempted)) {
+    if (fileExists(path.join(attempted, "package.json"))) {
       return attempted;
     }
   }
@@ -113,7 +113,7 @@ export function findTargetFolder(props: IResolverProps, parsed: IModuleParsed): 
 
   if (!!localModuleRoot && paths.indexOf(localModuleRoot) === -1) {
     const attempted = path.join(localModuleRoot, parsed.name);
-    if (fileExists(attempted)) {
+    if (fileExists(path.join(attempted, "package.json"))) {
       return attempted;
     }
   }

--- a/src/utils/test_utils.ts
+++ b/src/utils/test_utils.ts
@@ -20,15 +20,15 @@ declare global {
 }
 
 expect.extend({
-  toMatchFilePath(expectedPath, comparedPath) {
+  toMatchFilePath(actualPath, expectedPath) {
+    actualPath = ensureFuseBoxPath(actualPath);
     expectedPath = ensureFuseBoxPath(expectedPath);
-    comparedPath = ensureFuseBoxPath(comparedPath);
 
-    const exp = path2RegexPattern(comparedPath);
-    const isMatched = exp.test(expectedPath);
+    const exp = path2RegexPattern(expectedPath);
+    const isMatched = exp.test(actualPath);
     return {
       pass: isMatched,
-      message: () => `Expected ${exp} to match ${expectedPath}`,
+      message: () => `Expected path matching ${exp}, but got: ${actualPath}`,
     };
   },
 });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -299,8 +299,8 @@ export function isNodeModuleInstalled(name) {
   }
 }
 
-export function ensureFuseBoxPath(input: string) {
-  return input.replace(/\\/g, '/').replace(/\/$/, '');
+export function ensureFuseBoxPath(input: string | undefined) {
+  return input && input.replace(/\\/g, '/').replace(/\/$/, '');
 }
 
 export function joinFuseBoxPath(...any): string {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -179,6 +179,15 @@ export function ensureDir(dir: string) {
   return dir;
 }
 
+export function ensurePackageJson(dir: string) {
+  fsExtra.ensureDir(dir);
+  const pkgJsonPath = pathJoin(dir, "package.json");
+  if (!fileExists(pkgJsonPath)) {
+    const contents = JSON.stringify({ "name": path.basename(dir) }, null, 4);
+    fs.writeFileSync(pkgJsonPath, contents)
+  }
+}
+
 export function fileStat(file: string) {
   return fs.statSync(file);
 }


### PR DESCRIPTION
This resolves the issue with module resolution breaking with deep package folders that lack package.json exist.

This also adds a test which correctly fails without this fix.

This also includes one other fix to improve the error message reporting in unit tests when files don't match, which also handles the `undefined` case.