### PR TITLE
fix: do not fall back to node_modules in a PnP environment, and don't hide PnP errors

### DIFF
--- a/src/resolver/nodeModuleLookup.ts
+++ b/src/resolver/nodeModuleLookup.ts
@@ -94,7 +94,12 @@ export function findTargetFolder(props: IResolverProps, parsed: IModuleParsed): 
       return folder;
     } catch (e) {
       // Ignore error here, since it will be handled later
+      // Don't ignore these errors, because PnP returns very useful errors and
+      console.error(e);
     }
+    // If this is PnP and PnP says it doesn't exist,
+    // don't continue trying the rest of the node_modules stuff
+    return;
   }
 
   const paths = parseExistingModulePaths(props.filePath);


### PR DESCRIPTION
In a PnP environment you don't want to fall back on node_modules search logic.  If PnP says that a dependency can't be resolved, then it shouldn't be resolved.  PnP is designed to really own module resolution.

PnP is intentionally stricter about loading dependencies.  For example, it won't allow a module in one package to import another package unless the first one has declared the second as a dependency.  Being able to "find" that dependency doesn't matter.  If the environment is PnP and PnP says it can't be resolved, then it shouldn't be resolved.