### PR TITLE
feat: allow specifying watcher root paths

### DIFF
--- a/docs/watcher.md
+++ b/docs/watcher.md
@@ -14,12 +14,25 @@ fusebox({ watcher: true });
 By default the watcher watches the entire application root, but reacts only to the path relative to the first entry
 point.
 
-You can change that by passing `include` property
+You can change what the watcher reacts to by passing an `include` property.
 
 ```ts
 fusebox({
   watcher: {
     include: { "src/" },
+  },
+});
+```
+
+### Overriding the root path
+
+You can override the root that the watcher will watch by setting the `root` property, which can be a path, or an array of paths.
+
+```ts
+const workspace = path.dirname(__dirname)
+fusebox({
+  watcher: {
+    root: workspace, // watch parent folder
   },
 });
 ```

--- a/src/config/IWatcher.ts
+++ b/src/config/IWatcher.ts
@@ -5,4 +5,9 @@ export interface IWatcherPublicConfig {
   enabled?: boolean;
   ignore?: Array<string | RegExp>;
   include?: Array<string | RegExp>;
+  /**
+   * The root folder(s) to watch
+   * Passed to chokidar as paths
+   */
+  root?: string | string[];
 }

--- a/src/watcher/watcher.ts
+++ b/src/watcher/watcher.ts
@@ -44,9 +44,14 @@ export function createWatcher(ctx: Context) {
   let ignorePaths: Array<RegExp> = [];
 
   if (!props.include) {
-    // taking an assumption that the watch directory should be next to the entry point
-    const entryPath = path.dirname(ctx.config.entries[0]);
-    includePaths.push(path2RegexPattern(entryPath));
+    if (props.root) {
+      includePaths = (typeof props.root === "string" ? [props.root] : props.root).map(path2RegexPattern)
+    }
+    else {
+      // taking an assumption that the watch directory should be next to the entry point
+      const entryPath = path.dirname(ctx.config.entries[0]);
+      includePaths.push(path2RegexPattern(entryPath));
+    }
   } else {
     for (const prop of props.include) {
       if (typeof prop === 'string') {
@@ -141,7 +146,8 @@ export function createWatcher(ctx: Context) {
       const userOptions = props.chokidarOptions || {};
       const finalOptions = { ...defaultOpts, ...userOptions };
 
-      var watcher = chokidarWatch(env.APP_ROOT, finalOptions);
+      const root = props.root || [`${env.APP_ROOT}`];
+      const watcher = chokidarWatch(root, finalOptions);
       watcher.on('all', dispatchEvent);
     },
   };


### PR DESCRIPTION
This is a proposed feature to how watcher is configured.

Chokidar lets you specify one to many "root" paths to watch.  Currently fuse-box watches only one root, which is always `env.APP_ROOT`.  This PR leaves that as the default but allows overriding it with a `root` property in `IWatcherPublicConfig`.

Note that in a monorepo environment relying on workspaces, you would specify those workspace folders as roots, and in a future change, I plan to add the ability to auto-detect if in a workspaces environment and add those automatically.  But manual override of roots is a good feature to have anyway.