### PR TITLE
fix: correct log messages containing variable == 0 and hmr "module" plural-ification

### DIFF
--- a/src/fuseLog/colors.ts
+++ b/src/fuseLog/colors.ts
@@ -50,7 +50,7 @@ export function codeLog(input: string, vars?: { [key: string]: any }) {
   return findReplace(input, /(<(\/)?([a-z]+)>)|(([@\$])([a-z0-9_]+))/gi, args => {
     const [, , closing, name, , type, variable] = args;
     if (type) {
-      if (type === '$' && vars && vars[variable]) return vars[variable];
+      if (type === '$' && vars && vars[variable] !== undefined) return vars[variable];
       if (type === '@') {
         if (SYMBOLS[variable]) return SYMBOLS[variable];
         else return `@` + variable;

--- a/src/hmr/hmr.ts
+++ b/src/hmr/hmr.ts
@@ -130,7 +130,7 @@ export function createHMR(ctx: Context) {
     const amount = moduleIdsForUpdate.length;
     ctx.log.info('hmr', '<dim>Sending $amount $modules to the client</dim>', {
       amount,
-      modules: amount > 1 ? 'modules' : 'module',
+      modules: amount !== 1 ? 'modules' : 'module',
     });
   }
 


### PR DESCRIPTION
I.e. when HMR is triggered but no modules are sent, it logs this log message:

![image](https://user-images.githubusercontent.com/158330/77069552-ff879600-69be-11ea-96ac-24f65b81f0ef.png)

This PR changes that to this:

![image](https://user-images.githubusercontent.com/158330/77072743-9276ff00-69c4-11ea-9163-58adc1e43ccb.png)
