### PR TITLE
[Proposed] Auto-detect if Package is "User-Owned" or not

### DIFF
--- a/src/moduleResolver/asyncModuleResolver.ts
+++ b/src/moduleResolver/asyncModuleResolver.ts
@@ -66,8 +66,10 @@ export async function asyncModuleResolver(ctx: Context, entryFiles: Array<string
       }
       let pkg = bundleContext.getPackage(resolved.package.meta);
 
+      const pkgType = resolved.package.isUserOwned ? PackageType.USER_PACKAGE : PackageType.EXTERNAL_PACKAGE;
+
       if (!pkg) {
-        pkg = createPackage({ meta: resolved.package.meta, type: PackageType.EXTERNAL_PACKAGE });
+        pkg = createPackage({ meta: resolved.package.meta, type: pkgType });
         bundleContext.setPackage(pkg);
       }
       return { absPath, pkg };

--- a/src/resolver/__tests__/nodeModuleLookup.test.ts
+++ b/src/resolver/__tests__/nodeModuleLookup.test.ts
@@ -151,6 +151,7 @@ describe('folder lookup', () => {
     const result = findTargetFolder({ filePath: target, target: 'a' }, 'd');
     expect(result).toEqual({
       folder: P(PROJECT_NODE_MODULES, `nm-lookup-test-a/node_modules/b/node_modules/d`),
+      isUserOwned: false,
     })
   });
 
@@ -161,6 +162,7 @@ describe('folder lookup', () => {
     const result = findTargetFolder({ filePath: target, target: 'a' }, 'crazy-module');
     expect(result).toEqual({
       folder: P(PROJECT_NODE_MODULES, `nm-lookup-test-a/node_modules/crazy-module`),
+      isUserOwned: false,
     })
   });
 
@@ -171,6 +173,7 @@ describe('folder lookup', () => {
     const result = findTargetFolder({ filePath: target, target: 'a' }, 'nm-lookup-test-b');
     expect(result).toEqual({
       folder: P(PROJECT_NODE_MODULES, `nm-lookup-test-a/node_modules/nm-lookup-test-b`),
+      isUserOwned: false,
     })
   });
 
@@ -179,6 +182,7 @@ describe('folder lookup', () => {
     const result = findTargetFolder({ filePath: target, target: 'a' }, 'nm-lookup-test-b');
     expect(result).toEqual({
       folder: P(PROJECT_NODE_MODULES, `nm-lookup-test-a/node_modules/nm-lookup-test-b`),
+      isUserOwned: false,
     })
   });
 
@@ -187,7 +191,8 @@ describe('folder lookup', () => {
     ensurePackageJson(path.join(PROJECT_NODE_MODULES, 'nm-lookup-test-b'));
     const result = findTargetFolder({ filePath: target, target: 'a' }, 'nm-lookup-test-b');
     expect(result).toEqual({
-      folder: P(__dirname, `node_modules/nm-lookup-test-b`),
+      folder: P(PROJECT_NODE_MODULES, `nm-lookup-test-b`),
+      isUserOwned: false,
     })
   });
 
@@ -202,6 +207,7 @@ describe('folder lookup', () => {
     const result = findTargetFolder({ filePath: target, target: 'a' }, 'c');
     expect(result).toEqual({
       folder: P(PROJECT_NODE_MODULES, `nm-lookup-test-a/node_modules/c`),
+      isUserOwned: false,
     })
   });
 
@@ -250,6 +256,7 @@ describe('folder lookup', () => {
 
       expect(result).toEqual({
         folder: P(PROJECT_NODE_MODULES, `fuse-box-flat-parent/node_modules/fuse-box-resolver-conflict`),
+        isUserOwned: false,
       });
     });
 
@@ -264,6 +271,7 @@ describe('folder lookup', () => {
 
       expect(result).toEqual({
         folder: P(PROJECT_NODE_MODULES, `fuse-box-flat-parent/node_modules/fuse-box-resolver-conflict`),
+        isUserOwned: false,
       });
     });
   });

--- a/src/resolver/resolver.ts
+++ b/src/resolver/resolver.ts
@@ -156,8 +156,8 @@ export function resolveModule(props: IResolverProps): IResolver {
       }
       const pkg = nodeModuleLookup(props, moduleParsed);
 
-      if (pkg.error) {
-        return { error: pkg.error };
+      if ('error' in pkg) {
+        return pkg;
       }
 
       return {


### PR DESCRIPTION
OK, Here is my proposed solution for supporting "user-owned" packages other than the "default" package.

Note: sometimes these are called "local" packages or just "not external" packages, but in the code, "local" and "external" can sometimes mean other things.  So I'm using the term "user-owned" to mean "A package that we expect the user to modify".  This is in contrast to packages that are downloaded from a package registry (things in node_modules) that the user should not modify.  I derived the term from `PackageType.USER_PACKAGE` which is already in the code.

Fuse-box already has a package `type` that can be either `USER_PACKAGE` or `EXTERNAL_PACKAGE`.  The `type` determines how the package is treated by the cache.  But currently only the "default" package is ever set to `USER_PACKAGE`.  And so only the one "default" package is ever considered to be user-owned.

This has been a problem for monorepo setups in particular where the user-owned code is itself split up into packages.  The user will routinely change files _outside of_ the "default" package and wants these things to break cache and to trigger HMR just like changes inside the "default" package do.  But currently they don't because only `package.json` changes break cache if `type` is not `USER_PACKAGE`.

My proposal is basically this: If a package's _true location_ is _outside_ of `node_modules` then treat it as user-owned.  "True location" means: where it _really_ is (after symlinks are dereferenced).

(Yarn 2 Note: There is no node_modules in Yarn 2, so instead we resolving any PnP virtual path and seeing if that is a real directory, and if it is, then we consider that user-owned).

I think this is likely to resolve the problem @starsolaris is trying to solve with PR #1844 for, but does so automatically without requiring manual configuration.  Note: that we could also later support a manual override, but if we did I think it should just override detection of "user/non-user".  But I suspect that this solves @starsolaris's problem without any need to modify config.

This is currently split up into two commits.  It is easiest to review them separately.  The first one just refactors the way `fileLookup()` and `nodeModuleLookup()` return errors.  The feature I am proposing is in the second commit.
