### PR TITLE
chore: fix a false test failure in ts references for some setups

### DIFF
--- a/src/compilerOptions/__tests__/typescriptReferences.test.ts
+++ b/src/compilerOptions/__tests__/typescriptReferences.test.ts
@@ -62,6 +62,11 @@ describe('test case 3', () => {
 
   it('groups the set of mappings by package', () => {
     const grouped = groupByPackage(expectedMappings);
+    // in case the tester happens to have any packge.json above the fuse-box root,
+    // tsreference will have added groups for those as it should
+    // so we'll just ignore those here
+    for (const dir of ancestorsOf(fuseRoot))
+      grouped.delete(dir);
     const expected = expectedGrouped;
     expect(grouped).toEqual(expected);
   });
@@ -99,3 +104,17 @@ describe('test case 3', () => {
     });
   });
 });
+
+
+function* ancestorsOf(absPath: string) {
+  const start = path.normalize(absPath);
+  for (let dir = parentDir(start); dir !== undefined; dir = parentDir(dir)) {
+    yield dir;
+  }
+}
+
+function parentDir(normalizedPath: string): undefined | string {
+  const parent = path.dirname(normalizedPath);
+  if (parent === normalizedPath) return undefined;
+  return parent;
+}


### PR DESCRIPTION
If a test environment has a package.json above the fuse-box repo root, one of the ts reference tests fails.  This PR fixes the test to ignore those.