### PR TITLE
fix: allow providing relative root for watcher

### DIFF
--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -13,6 +13,7 @@ import {
   parseVersion,
   beautifyBundleName,
   path2RegexPattern,
+  excludeRedundantFolders,
 } from '../utils';
 import { findUp } from '../findUp';
 import { join } from 'path';
@@ -209,5 +210,20 @@ describe('utils', () => {
         inclusive: false,
       })).toEqual(null);
     });
+  })
+
+  describe('excludeRedundantFolders - removes redundant root folders', () => {
+    const input: string[] = [
+      `/one/two/three`, // <-- exclude because of /one/two
+      `/one/two`,
+      `/three/four/five/..`,
+      `/three/four/size`, // <-- exclude because of /three/four/five/..
+    ];
+    const actual = excludeRedundantFolders(input);
+    const expected = [
+      '/one/two',
+      '/three/four',
+    ]
+    expect(actual).toEqual(expected);
   })
 });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -293,6 +293,28 @@ export function ensureScriptRoot(userPath: string) {
   return userPath;
 }
 
+/**
+ * Given a list of folders, exclude any that are contained in any others
+ * e.g.:
+ *   - "/one/two"
+ *   - "/one/two/three"  ❌ _exclude: contained by "/one/two"_
+ *   - "/four/five/six"
+ *   - "/four/five/six"  ❌ _exclude: duplicate_
+ * @param folders
+ */
+export function excludeRedundantFolders(folders: string[]): string[] {
+  // normalize and sort, so that all ancestors come before descendants
+  const sorted = folders.map(r => path.normalize(r)).sort();
+  let keep: string[] = []
+  for (const folder of sorted) {
+    // ignore anything if we have already seen it or its ancestor
+    if (keep.some(k => k === folder || folder.startsWith(`${k}${path.sep}`)))
+      continue;
+    keep.push(folder);
+  }
+  return keep;
+}
+
 export function getPathRelativeToConfig(props: { dirName: string; ensureDirExist?: boolean; fileName?: string }) {
   let target = props.fileName ? path.dirname(props.fileName) : props.dirName;
   const fileName = props.fileName && path.basename(props.fileName);


### PR DESCRIPTION
Currently relative root paths don't work in the watcher config.  E.g. the following doesn't work

```javascript
watcher: {
    root: "..",
}
```

This PR adds support for relative paths.