### PR TITLE
fix: typeof require operators should be replaced

### DIFF
--- a/src/compiler/__tests__/__snapshots__/require.statement.interceptor.test.ts.snap
+++ b/src/compiler/__tests__/__snapshots__/require.statement.interceptor.test.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Require statement intercepto it should preview typeof require is defined in the scope 1`] = `
+"function some(require) {
+  console.log(typeof require);
+}
+"
+`;
+
+exports[`Require statement intercepto it should replace typeof require 1`] = `
+"console.log(\\"function\\");
+"
+`;

--- a/src/compiler/__tests__/require.statement.interceptor.test.ts
+++ b/src/compiler/__tests__/require.statement.interceptor.test.ts
@@ -72,4 +72,24 @@ describe('Require statement intercepto', () => {
     });
     expect(result.requireStatementCollection).toHaveLength(0);
   });
+
+  it('it should replace typeof require', () => {
+    const result = testTranspile({
+      code: `
+      console.log(typeof require);
+    `,
+    });
+    expect(result.code).toMatchSnapshot();
+  });
+
+  it('it should preview typeof require is defined in the scope', () => {
+    const result = testTranspile({
+      code: `
+      function some(require){
+        console.log(typeof require);
+      }
+    `,
+    });
+    expect(result.code).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
Replaces

`typeof require` to `function`


@wagerfield If you have other additions here please let me know. 
I remember you mentioned that issues on Slack, so there is the fix to it.
