### PR TITLE
fix: stylus dependency filename change

### DIFF
--- a/src/stylesheet/stylus/stylusRenderer.ts
+++ b/src/stylesheet/stylus/stylusRenderer.ts
@@ -13,7 +13,7 @@ export interface IStylusRenderer {
 }
 export function stylusRender(props: IStylusRenderer): Promise<IStylesheetModuleResponse> {
   const Evaluator = require('stylus/lib/visitor/evaluator');
-  const Literal = require('stylus/lib/nodes/Literal');
+  const Literal = require('stylus/lib/nodes/literal');
   const stylus = require('stylus');
 
   const stylusImport = Evaluator.prototype.visitImport;


### PR DESCRIPTION
## What does it do?

The stylus people changed from `stylus/lib/nodes/Literal.js` to `literal.js`. So one character changed. This PR updates fuse-box stylus renderer to use that file.

Before this PR:

`❌ Cannot find module 'stylus/lib/nodes/Literal'`

After:

<img width="419" alt="Screen Shot 2020-04-19 at 7 47 52 PM" src="https://user-images.githubusercontent.com/1634015/79706479-a7baa400-8276-11ea-9c44-2044bc73ca74.png">

<img width="374" alt="Screen Shot 2020-04-19 at 7 49 28 PM" src="https://user-images.githubusercontent.com/1634015/79706550-dd5f8d00-8276-11ea-9f16-52c9863cc338.png">
