### PR TITLE
Fix missing `/resources` in asset paths

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -16,7 +16,8 @@ export function Configuration(ctx: Context): IConfig {
       if (existing) return existing;
       let publicPath = '/';
       if (self.webIndex && self.webIndex.publicPath) publicPath = self.webIndex.publicPath;
-      if (self.resources && self.resources.resourcePublicRoot) return publicPath;
+      if (self.resources && self.resources.resourcePublicRoot) publicPath = self.resources.resourcePublicRoot;
+      return publicPath;
     },
     getResourceConfig: (stylesheet?: IStyleSheetProps) => {
       let resources: IResourceConfig = {};


### PR DESCRIPTION
**Issue:**
Assets (svg,png,jpg) are not able to load on the web page due to an incomplete url. It shows `/0ea3030a.svg` instead of `/resources/0ea3030a.svg`

**Found bug:**
The `resourcePublicRoot` in `src/plugins/core/plugin_link.ts` stays at `'/'` instead of `'/resources'`
It uses ` ctx.config.link.resourcePublicRoot` from `/config/config.ts`

**Code:**
In `src/config/config.ts` at `getPublicRoot()` the right `/resources` can be found in `self.resources. resourcePublicRoot`. It also looked to me that the `return publicPath` was at the wrong place (should be at the bottom, not after the second if).

This fixed it for all my use-cases where the images were broken. Let me know if this is a decent fix.

Config used:
```js
class Context {
  runServer;
  getConfig = () =>
    fusebox({
      target: "browser",
      entry: "../client/index.tsx",
      webIndex: {
        template: "../client/index.html"
      },
      env: {
        CLIENT: process.env.CLIENT,
        NODE_ENV: process.env.NODE_ENV,
      },
      cache: true,
      devServer: this.runServer,
      sourceMap: true,
      plugins: [pluginMDX({ useDefault: true })],
      watcher: {
        enabled: true,
        include: [path.join(process.cwd(), './packages')]
      },

    });
}

const { task } = sparky<Context>(Context);

task("default", async ctx => {
  ctx.runServer = true;
  const fuse = ctx.getConfig();
  await fuse.runDev({
    bundles: {
      distRoot: distDir,
    }
  });
});

task("preview", async ctx => {
  ctx.runServer = true;
  const fuse = ctx.getConfig();
  await fuse.runProd({ uglify: false });
});
task("dist", async ctx => {
  ctx.runServer = false;
  const fuse = ctx.getConfig();
  await fuse.runProd({ uglify: false });
});
```

P.S Loving you lib, works really nicely. A very welcome breath of fresh air after all the hussle with the slowness and complex setup of other packagers.