### PR TITLE
Fix: SASS indent syntax support

### DIFF
--- a/src/stylesheet/sassHandler.ts
+++ b/src/stylesheet/sassHandler.ts
@@ -80,6 +80,7 @@ export async function renderModule(props: IRenderModuleProps): Promise<IStyleshe
     includePaths: [path.dirname(module.absPath)],
     outFile: module.absPath,
     sourceMapContents: requireSourceMap,
+    indentedSyntax: module.extension === ".sass",
     importer: function(url, prev) {
       // gathering imported dependencies in order to let the watcher pickup the right module
 


### PR DESCRIPTION
fix for issue  **.sass files treated as .scss**  (https://github.com/fuse-box/fuse-box/issues/1834)