### PR TITLE
Fix IE11 compatibility with runtime core

### DIFF
--- a/src/bundleRuntime/bundleRuntimeCore.ts
+++ b/src/bundleRuntime/bundleRuntimeCore.ts
@@ -42,7 +42,9 @@ function getCodeSplittingFunction(target: ITarget) {
         document.head.appendChild(script);
         script.onload = function() {
           if (modules[id]) {
-            conf.fns.map(x => x(f.r(id)));
+            conf.fns.map(function(x) {
+              return x(f.r(id));
+            });
           } else reject('Resolve error of module ' + id + ' at path ' + conf.p);
           conf.fns = void 0;
         };


### PR DESCRIPTION
Fixes this issue on IE11 as arrow functions is invalid syntax for ES5 builds:

![image](https://user-images.githubusercontent.com/16621507/82661016-e657cb80-9c33-11ea-968a-895a1b04751d.png)