### PR TITLE
fix(tsconfig-loader): tsconfig extends loader wont resolve local module paths

### DIFF
--- a/src/compilerOptions/tryLoadExtendedTsConfig.ts
+++ b/src/compilerOptions/tryLoadExtendedTsConfig.ts
@@ -10,7 +10,7 @@ export const tryLoadExtendedTsConfig = (tsConfigDir: string, tsExtends: string) 
      * a 'node_module'.
      */
     if (extendedConfig.error) {
-        extendedPath = require.resolve(tsExtends, { paths: [process.cwd()] });
+        extendedPath = require.resolve(tsExtends, { paths: [tsConfigDir, process.cwd()] });
         extendedConfig = parseTypescriptConfig(extendedPath);
     }
     return [extendedConfig, extendedPath] as const;


### PR DESCRIPTION
Previously, in a monorepo for example, if tsconfig extended another tsconfig file kept in a workspace's node_module directory, then resolve would fail, since it was inspecting from CWD (root) only.

This update adds the local tsconfig file's path to the resolver, so that local node_modules folders are included.