### PR TITLE
Vendor mapping bundles

### DIFF
--- a/src/bundle/__tests__/bundleRouter.test.ts
+++ b/src/bundle/__tests__/bundleRouter.test.ts
@@ -1,0 +1,207 @@
+import { createIntegrationTest, createTestWorkspace } from '../../testUtils/integrationTest';
+import { ITestBrowserResponse } from '../../testUtils/browserEnv/testBrowserEnv';
+import * as path from 'path';
+import { EnvironmentType } from '../../config/EnvironmentType';
+
+describe('Bundle router test', () => {
+  describe('When no bundle configuration is provided', () => {
+    let test;
+    beforeAll(() => {
+      test = async (workspace): Promise<ITestBrowserResponse> => {
+        const test = createIntegrationTest({
+          config: {
+            cache: { enabled: true, strategy: 'fs' },
+            entry: path.join(workspace.sourceDir, 'index.ts'),
+            target: 'browser',
+          },
+          envType: EnvironmentType.PRODUCTION,
+          workspace,
+        });
+
+        const response = await test.runProd();
+        return await response.runBrowser();
+      };
+    });
+    afterAll(() => {
+      test = null;
+    });
+    describe('And does not include mappings', () => {
+      it('should create a single app bundle', async done => {
+        const workspace = createTestWorkspace({
+          files: {
+            'foo.ts': 'export const foo = "foo"',
+            'index.ts': `
+              import * as foo from "./foo"
+              (() => import("@scope/package"))();
+              import 'package';
+              const data = { foo }
+              export { data }`,
+          },
+          modules: {
+            '@scope/package': {
+              'component.ts': 'export const packageName = "@scoped/package"',
+              'index.ts': 'export * from "./component"',
+              'package.json': JSON.stringify({
+                main: 'index.ts',
+                name: '@scope/package',
+                version: '1.0.0',
+              }),
+            },
+            package: {
+              'component.ts': 'export const packageName = "package"',
+              'index.ts': 'export * from "./component"',
+              'package.json': JSON.stringify({
+                main: 'index.ts',
+                name: 'package',
+                version: '1.0.0',
+              }),
+            },
+          },
+        });
+        const result = await test(workspace);
+        expect(result.runResponse.bundles.length).toEqual(1);
+        const appBundle = result.runResponse.bundles.find(b => b.relativePath == 'app.js');
+        expect(appBundle).toBeDefined();
+        expect(appBundle.bundle.contents.indexOf('packageName = "@scoped/package";')).toBeGreaterThan(-1);
+        expect(appBundle.bundle.contents.indexOf('packageName = "package";')).toBeGreaterThan(-1);
+
+        done();
+      });
+    });
+  });
+  describe('When bundle configuration is provided', () => {
+    let test;
+    beforeAll(() => {
+      test = async (workspace, runProps): Promise<ITestBrowserResponse> => {
+        const test = createIntegrationTest({
+          config: {
+            cache: { enabled: true, strategy: 'fs' },
+            entry: path.join(workspace.sourceDir, 'index.ts'),
+            target: 'browser',
+          },
+          envType: EnvironmentType.PRODUCTION,
+          workspace,
+          runProps,
+        });
+
+        const response = await test.runProd();
+        return await response.runBrowser();
+      };
+    });
+    afterAll(() => {
+      test = null;
+    });
+    describe('And does not include mappings', () => {
+      it('should create an app and vendor bundle', async done => {
+        const workspace = createTestWorkspace({
+          files: {
+            'foo.ts': 'export const foo = "foo"',
+            'index.ts': `
+              import * as foo from "./foo"
+              (() => import("@scope/package"))();
+              import 'package';
+              const data = { foo }
+              export { data }`,
+          },
+          modules: {
+            '@scope/package': {
+              'component.ts': 'export const packageName = "@scoped/package"',
+              'index.ts': 'export * from "./component"',
+              'package.json': JSON.stringify({
+                main: 'index.ts',
+                name: '@scope/package',
+                version: '1.0.0',
+              }),
+            },
+            package: {
+              'component.ts': 'export const packageName = "package"',
+              'index.ts': 'export * from "./component"',
+              'package.json': JSON.stringify({
+                main: 'index.ts',
+                name: 'package',
+                version: '1.0.0',
+              }),
+            },
+          },
+        });
+        const result = await test(workspace, {
+          bundles: {
+            app: './app.js',
+            vendor: './vendor.js',
+          },
+        });
+        expect(result.runResponse.bundles.length).toEqual(2);
+        expect(result.runResponse.bundles.find(b => b.relativePath == 'app.js')).toBeDefined();
+        const vendorBundle = result.runResponse.bundles.find(b => b.relativePath == 'vendor.js');
+        expect(vendorBundle).toBeDefined();
+        expect(vendorBundle.bundle.contents.indexOf('packageName = "@scoped/package";')).toBeGreaterThan(-1);
+        expect(vendorBundle.bundle.contents.indexOf('packageName = "package";')).toBeGreaterThan(-1);
+        done();
+      });
+    });
+    describe('And includes mappings', () => {
+      it('should create an app and vendor bundle and as many vendor bundles as mappings are defined', async done => {
+        const workspace = createTestWorkspace({
+          files: {
+            'foo.ts': 'export const foo = "foo"',
+            'index.ts': `
+              import * as foo from "./foo"
+              (() => import("@scope/package"))();
+              import 'package';
+              import 'vendor';
+              const data = { foo }
+              export { data }`,
+          },
+          modules: {
+            '@scope/package': {
+              'component.ts': 'export const packageName = "@scoped/package"',
+              'index.ts': 'export * from "./component"',
+              'package.json': JSON.stringify({
+                main: 'index.ts',
+                name: '@scope/package',
+                version: '1.0.0',
+              }),
+            },
+            package: {
+              'component.ts': 'export const packageName = "package"',
+              'index.ts': 'export * from "./component"',
+              'package.json': JSON.stringify({
+                main: 'index.ts',
+                name: 'package',
+                version: '1.0.0',
+              }),
+            },
+            vendor: {
+              'component.ts': 'export const packageName = "vendor"',
+              'index.ts': 'export * from "./component"',
+              'package.json': JSON.stringify({
+                main: 'index.ts',
+                name: 'vendor',
+                version: '1.0.0',
+              }),
+            },
+          },
+        });
+        const result = await test(workspace, {
+          bundles: {
+            app: './app.js',
+            mapping: [
+              { matching: '@scope*', target: './vendor.scoped.js' },
+              { matching: 'package', target: './vendor.module.js' },
+            ],
+            vendor: './vendor.js',
+          },
+        });
+        expect(result.runResponse.bundles.length).toEqual(4);
+        expect(result.runResponse.bundles.find(b => b.relativePath == 'app.js')).toBeDefined();
+        const scopedBundle = result.runResponse.bundles.find(b => b.relativePath == 'vendor.scoped.js');
+        expect(scopedBundle).toBeDefined();
+        expect(scopedBundle.bundle.contents.indexOf('packageName = "@scoped/package";')).toBeGreaterThan(-1);
+        expect(result.runResponse.bundles.find(b => b.relativePath == 'vendor.module.js')).toBeDefined();
+        expect(result.runResponse.bundles.find(b => b.relativePath == 'vendor.js')).toBeDefined();
+
+        done();
+      });
+    });
+  });
+});

--- a/src/bundle/bundle.ts
+++ b/src/bundle/bundle.ts
@@ -28,6 +28,7 @@ export interface Bundle {
   generateHMRUpdate?: () => string;
   prepare: () => IWriterConfig;
   write: () => Promise<IBundleWriteResponse>;
+  path?: string;
 }
 
 export enum BundleType {
@@ -131,9 +132,9 @@ export function createBundle(props: IBundleProps): Bundle {
         const terserOpts: any = {
           sourceMap: source.containsMaps
             ? {
-                content: self.data.sourceMap,
-                includeSources: true,
-              }
+              content: self.data.sourceMap,
+              includeSources: true,
+            }
             : undefined,
         };
         ctx.log.info('minify', self.config.absPath);

--- a/src/bundle/bundleRouter.ts
+++ b/src/bundle/bundleRouter.ts
@@ -3,6 +3,7 @@ import { bundleRuntimeCore, ICodeSplittingMap } from '../bundleRuntime/bundleRun
 import { Context } from '../core/context';
 import { IBundleContext } from '../moduleResolver/bundleContext';
 import { IModule } from '../moduleResolver/module';
+import { PackageType } from '../moduleResolver/package';
 import { ISplitEntry } from '../production/module/SplitEntries';
 import { beautifyBundleName, writeFile } from '../utils/utils';
 import { Bundle, BundleType, createBundle, IBundleWriteResponse } from './bundle';
@@ -124,7 +125,7 @@ export function createBundleRouter(props: IBundleRouteProps): IBundleRouter {
           }
           if (!cssBundle) createCSSBundle();
           cssBundle.source.modules.push(module);
-        } else if (hasVendorConfig) {
+        } else if (module.pkg.type === PackageType.EXTERNAL_PACKAGE && hasVendorConfig) {
           let isMappedBundle = false;
           if (hasMappings) {
             for (const mapping of mappings) {

--- a/src/bundle/bundleRouter.ts
+++ b/src/bundle/bundleRouter.ts
@@ -3,7 +3,6 @@ import { bundleRuntimeCore, ICodeSplittingMap } from '../bundleRuntime/bundleRun
 import { Context } from '../core/context';
 import { IBundleContext } from '../moduleResolver/bundleContext';
 import { IModule } from '../moduleResolver/module';
-import { PackageType } from '../moduleResolver/package';
 import { ISplitEntry } from '../production/module/SplitEntries';
 import { beautifyBundleName, writeFile } from '../utils/utils';
 import { Bundle, BundleType, createBundle, IBundleWriteResponse } from './bundle';

--- a/src/bundle/bundleRouter.ts
+++ b/src/bundle/bundleRouter.ts
@@ -28,7 +28,7 @@ export function createBundleRouter(props: IBundleRouteProps): IBundleRouter {
   const outputConfig = ctx.outputConfig;
   const hasVendorConfig = !!outputConfig.vendor;
   const hasMappings = !!outputConfig.mapping;
-  const mappings = outputConfig.mapping.map(m => ({ ...m, regexp: RegExp(m.matching) }))
+  const mappings = outputConfig.mapping.map(m => ({ ...m, regexp: RegExp(m.matching) }));
   const bundles: Array<Bundle> = [];
   const splitFileNames: Array<string> = [];
   const codeSplittingMap: ICodeSplittingMap = {
@@ -79,8 +79,7 @@ export function createBundleRouter(props: IBundleRouteProps): IBundleRouter {
 
   function createSubVendorBundle(module, mapping) {
     const bundle = bundles.find(b => b.path === mapping.target.path);
-    if (bundle)
-      bundle.source.modules.push(module);
+    if (bundle) bundle.source.modules.push(module);
     else {
       const bundle = createBundle({
         bundleConfig: mapping.target,
@@ -126,7 +125,7 @@ export function createBundleRouter(props: IBundleRouteProps): IBundleRouter {
           }
           if (!cssBundle) createCSSBundle();
           cssBundle.source.modules.push(module);
-        } else if (module.pkg.type === PackageType.EXTERNAL_PACKAGE && hasVendorConfig) {
+        } else if (hasVendorConfig) {
           let isMappedBundle = false;
           if (hasMappings) {
             for (const mapping of mappings) {

--- a/src/bundle/bundleRouter.ts
+++ b/src/bundle/bundleRouter.ts
@@ -28,7 +28,7 @@ export function createBundleRouter(props: IBundleRouteProps): IBundleRouter {
   const outputConfig = ctx.outputConfig;
   const hasVendorConfig = !!outputConfig.vendor;
   const hasMappings = !!outputConfig.mapping;
-  const mappings = outputConfig.mapping.map(m => ({ ...m, regexp: RegExp(m.matching) }));
+  const mappings = hasMappings && outputConfig.mapping.map(m => ({ ...m, regexp: RegExp(m.matching) }));
   const bundles: Array<Bundle> = [];
   const splitFileNames: Array<string> = [];
   const codeSplittingMap: ICodeSplittingMap = {

--- a/src/testUtils/integrationTest.ts
+++ b/src/testUtils/integrationTest.ts
@@ -14,6 +14,7 @@ import { bundleProd } from '../production/bundleProd';
 import { ensureDir, fastHash, fileExists, listDirectory, path2RegexPattern, readFile } from '../utils/utils';
 import { createTestBrowserEnv, ITestBrowserResponse } from './browserEnv/testBrowserEnv';
 import { createTestServerEnv, ITestServerResponse } from './serverEnv/testServerEnv';
+import { IRunProps } from '../config/IRunProps';
 
 const MODULES_PATH = 'node_modules';
 
@@ -198,8 +199,10 @@ export function createIntegrationTest(props: {
   config?: IPublicConfig;
   envType: EnvironmentType;
   workspace: ITestWorkspace;
+  runProps?: IRunProps;
 }) {
   const customConfig: IPublicConfig = props.config || {};
+  const runProps: IRunProps = props.runProps || {};
   const { workspace } = props;
 
   const config: IPublicConfig = {
@@ -222,7 +225,7 @@ export function createIntegrationTest(props: {
   const ctx = createContext({
     envType: props.envType,
     publicConfig: config,
-    runProps: { bundles: { app: 'app.js', distRoot: workspace.distRoot }, uglify: false },
+    runProps: { bundles: { app: 'app.js', distRoot: workspace.distRoot }, uglify: false, ...runProps },
     scriptRoot: workspace.rootDir,
   });
 


### PR DESCRIPTION
Since configuration is already accepting vendor bundles code-splitting, I've prepared a first approach where different vendor bundles are created matching the mapping patterns specified in configuration.

```typescript
bundles: {
    app: './app.$hash.js',
    mapping: [
      { matching: '@webcomponents*', target: './vendor.webcomponents.$hash.js' },
      { matching: '@material*', target: './vendor.material.$hash.js' },
    ],
    vendor: './vendor.$hash.js',
  },
```

With this configuration, we should expect that all `@webcomponents` and all `@material` dependencies be splitted in a `vendor.webcomponents.js` and `vendor.material.js` bundles. 

In `index.html` it should append the following too: 

```html
<script type="text/javascript" src="app.$hash.js"></script>
<script type="text/javascript" src="vendor.webcomponents.$hash.js"></script>
<script type="text/javascript" src="vendor.material.$hash.js"></script>
<script type="text/javascript" src="vendor.$hash.js"></script>
```