### PR TITLE
docs: Fix simple typo, dependending -> depending

### DIFF
--- a/old_docs/getting-started/installation.md
+++ b/old_docs/getting-started/installation.md
@@ -12,7 +12,7 @@ npm install fuse-box typescript terser uglify-js --save-dev
 ```
 
 You should install `terser` and `uglify-js` too. FuseBox will decide which one
-to use, dependending on a selected target.
+to use, depending on a selected target.
 
 ## Why TypeScript
 

--- a/website/versioned_docs/version-3.5.0/getting-started/installation.md
+++ b/website/versioned_docs/version-3.5.0/getting-started/installation.md
@@ -13,7 +13,7 @@ npm install fuse-box typescript uglify-es uglify-js --save-dev
 ```
 
 You should install `uglify-es` and `uglify-js` too. FuseBox will decide which
-one to use, dependending on a selected target.
+one to use, depending on a selected target.
 
 ## Why TypeScript
 

--- a/website/versioned_docs/version-3.6.0/getting-started/installation.md
+++ b/website/versioned_docs/version-3.6.0/getting-started/installation.md
@@ -13,7 +13,7 @@ npm install fuse-box typescript uglify-es uglify-js --save-dev
 ```
 
 You should install `uglify-es` and `uglify-js` too. FuseBox will decide which
-one to use, dependending on a selected target.
+one to use, depending on a selected target.
 
 ## Why TypeScript
 

--- a/website/versioned_docs/version-3.7.0/getting-started/installation.md
+++ b/website/versioned_docs/version-3.7.0/getting-started/installation.md
@@ -13,7 +13,7 @@ npm install fuse-box typescript terser uglify-js --save-dev
 ```
 
 You should install `terser` and `uglify-js` too. FuseBox will decide which one
-to use, dependending on a selected target.
+to use, depending on a selected target.
 
 ## Why TypeScript
 


### PR DESCRIPTION
There is a small typo in old_docs/getting-started/installation.md, website/versioned_docs/version-3.5.0/getting-started/installation.md, website/versioned_docs/version-3.6.0/getting-started/installation.md, website/versioned_docs/version-3.7.0/getting-started/installation.md.

Should read `depending` rather than `dependending`.

