### PR TITLE
fix wrong test of element exist in array

### DIFF
--- a/src/bundle/bundleRouter.ts
+++ b/src/bundle/bundleRouter.ts
@@ -41,7 +41,7 @@ export function createBundleRouter(props: IBundleRouteProps): IBundleRouter {
   function generateSplitFileName(relativePath: string): string {
     const paths = relativePath.split(path.sep).reverse();
     let fileName = beautifyBundleName(paths.shift());
-    while (splitFileNames[fileName]) {
+    while (splitFileNames.indexOf(fileName) !== -1) {
       fileName = beautifyBundleName(paths.shift() + path.sep + fileName);
     }
     splitFileNames.push(fileName);


### PR DESCRIPTION
hello
splitFileNames is an array so splitFileNames[fileName] will always respond with undefined, use indexOf instead.

My problem was only visible when build on linux, on windows, the relativePath come with "/" as separator, or 'path.sep' is "\" so paths.shift() respond with full path, or in linux 'path.sep' is "/" so paths.shift() respond with "/" and the split works, and becaue of wrong test in the while loop, the function return always the fileName only without path, so that make same name for all my dynamic package (because I remove the hash tag too)
thx