### PR TITLE
Correct config.hmr type

### DIFF
--- a/website/versioned_docs/version-4.0.0/development/full-config.md
+++ b/website/versioned_docs/version-4.0.0/development/full-config.md
@@ -237,10 +237,10 @@ resources?: IResourceConfig = {
 ### [**hmr**](./hmr) - Hot module reloading options
 
 ```ts
-hmr?: boolean | IHMRExternalProps = {
-	reloadEntryOnStylesheet?: boolean;
-	hardReloadScripts?: boolean;
-};
+hmr?: boolean | IHMRProps = {
+	enabled?: boolean;
+	plugin?: string;
+}
 ```
 
 <br>


### PR DESCRIPTION
So, this is a quick fix. However, it seems there are quite a few inconsistences in docs.

Here's another if anyone's able to address it:

On docs/development/full-config ...
![Screen Shot 2021-05-14 at 2 55 50 PM](https://user-images.githubusercontent.com/7539871/118316168-7b4a7900-b4c4-11eb-8ec8-f14a9a23930c.png)
... the hmr link points to 

https://fuse-box.org/docs/development/hmr
![Screen Shot 2021-05-14 at 2 56 43 PM](https://user-images.githubusercontent.com/7539871/118316262-9a490b00-b4c4-11eb-8b8c-f1f37fb46290.png)
However, 1) there is no such property `config.watch` according to the `IPublicConfig`, and 2) there's nothing explicitly about HMR on this page.



