### PR TITLE
fix: empty reactionStack bug

### DIFF
--- a/src/watcher/watcher.ts
+++ b/src/watcher/watcher.ts
@@ -100,7 +100,7 @@ export function createWatcher(ctx: Context) {
   const awaitProps = { cancelled: false };
 
   function acceptEvents() {
-    ict.sync('watcher_reaction', { reactionStack });
+    ict.sync('watcher_reaction', { reactionStack: reactionStack.slice(0) });
     reactionStack = [];
   }
 


### PR DESCRIPTION
sometimes reaction is fired after reactionStack is empty. so clone stack for reaction.