### PR TITLE
fix: wait for first bundle completed

### DIFF
--- a/src/core/build.ts
+++ b/src/core/build.ts
@@ -68,7 +68,11 @@ export const createBuild = async (props: IBuildProps): Promise<IRunResponse> => 
     },
   };
 
-  ctx.ict.sync(rebundle ? 'rebundle' : 'complete', response);
+  if (rebundle) {
+    ctx.ict.sync('rebundle', response);
+  } else {
+    await ctx.ict.send('complete', response);
+  }
 
   return response;
 };


### PR DESCRIPTION
sometimes additional process needed after bundle completed. so when build first bundle, wait all the events ends.