### PR TITLE
fix: css module order bug

### DIFF
--- a/src/bundleRuntime/bundleSource.ts
+++ b/src/bundleRuntime/bundleSource.ts
@@ -43,13 +43,10 @@ export function createBundleSource(props: IBundleSourceProps): BundleSource {
     return modules.map((module) => {
       let depNos = [];
       getDepOrderNo(module, depNos);
-      return { module, depNos }
+      return { module, depNos: depNos.reverse() }
     }).sort((a, b) => {
-      const aDepNos = a.depNos.reverse();
-      const bDepNos = b.depNos.reverse();
-
-      for (let i = 0; i < Math.min(aDepNos.length, bDepNos.length); i++) {
-        const diff = aDepNos[i] - bDepNos[i];
+      for (let i = 0; i < Math.min(a.depNos.length, b.depNos.length); i++) {
+        const diff = a.depNos[i] - b.depNos[i];
         if (diff != 0) return diff;
       }
       return 0;

--- a/src/moduleResolver/asyncModuleResolver.ts
+++ b/src/moduleResolver/asyncModuleResolver.ts
@@ -141,9 +141,15 @@ export async function asyncModuleResolver(ctx: Context, entryFiles: Array<string
           statement: props.statement,
         });
         if (resolved.absPath) {
+          // keep module id order same with resolving order for right css module resolving
+          const idx = module.dependencies.length + 1;
+          module.dependencies.push(-idx);
           const target = await initModule({ absPath: resolved.absPath, pkg: resolved.pkg });
-          const parentDeps = module.dependencies;
-          if (!parentDeps.includes(target.id)) parentDeps.push(target.id);
+          if (!module.dependencies.includes(target.id)) {
+            module.dependencies = module.dependencies.map(d => d === -idx ? target.id : d);
+          } else {
+            module.dependencies = module.dependencies.filter(d => d !== -idx);
+          }
           return { module: target };
         }
         return resolved;


### PR DESCRIPTION
css module resolving order is so important.
so i made module id same with resolving order and when building css, reordering css modules by module id.