### PR TITLE
fix: replace processEnv to env when no processEnv

### DIFF
--- a/src/compilerOptions/compilerOptions.ts
+++ b/src/compilerOptions/compilerOptions.ts
@@ -14,7 +14,9 @@ export function createCompilerOptions(ctx: Context): ICompilerOptions {
   if (!options.jsxFactory) options.jsxFactory = 'React.createElement';
   if (options.esModuleInterop === undefined) options.esModuleInterop = true;
   if (options.esModuleStatement === undefined) options.esModuleStatement = true;
-  options.processEnv = ctx.config.env;
+  if (!options.processEnv) {
+    options.processEnv = ctx.config.env;
+  }
   options.buildTarget = ctx.config.target;
 
   if (!options.jsParser) options.jsParser = {};


### PR DESCRIPTION
compilerOptions.processEnv replaced with env. but sometimes i want to use different env for compiling and running. 
so i changed compilerOptions.processEnv replaced with env when only processEnv not exist.