### PR TITLE
Fix: Watcher when props.root is undefined

### DIFF
--- a/src/watcher/watcher.ts
+++ b/src/watcher/watcher.ts
@@ -155,7 +155,7 @@ export function createWatcher(ctx: Context) {
       // if no user-roots are specified, use APP_ROOT
       // ensure that SCRIPT_PATH gets watched
       // and remove any redundant paths
-      const rootsToWatch = absRoots.length ? absRoots : [env.APP_ROOT, env.SCRIPT_PATH];
+      const rootsToWatch = absRoots?.length ? absRoots : [env.APP_ROOT, env.SCRIPT_PATH];
       const watchRoots = excludeRedundantFolders(rootsToWatch);
       const watcher = chokidarWatch(watchRoots, finalOptions);
       watcher.on('all', dispatchEvent);


### PR DESCRIPTION
Fixes `TypeError: Cannot read property 'length' of undefined` when fuse-box is started in dev with minimal configuration:
```ts
import { fusebox } from "fuse-box";

const fuse = fusebox({
  entry: "../src/index.ts",
  target: "browser",
  devServer: true,
  webIndex: true,
});

fuse.runDev();
```

