### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/modules/buffer/index.js
+++ b/modules/buffer/index.js
@@ -765,7 +765,7 @@ function hexWrite(buf, string, offset, length) {
     length = strLen / 2;
   }
   for (var i = 0; i < length; ++i) {
-    var parsed = parseInt(string.substr(2 * i, 2), 16);
+    var parsed = parseInt(string.slice(2 * i, 2 * i + 2), 16);
     if (isNaN(parsed)) return i;
     buf[offset + i] = parsed;
   }

--- a/modules/path/index.js
+++ b/modules/path/index.js
@@ -69,7 +69,7 @@ exports.resolve = function() {
 // posix version
 exports.normalize = function(path) {
   var isAbsolute = exports.isAbsolute(path),
-    trailingSlash = substr(path, -1) === '/';
+    trailingSlash = path.slice(-1) === '/';
 
   // Normalize the path
   path = normalizeArray(
@@ -110,8 +110,8 @@ exports.join = function() {
 // path.relative(from, to)
 // posix version
 exports.relative = function(from, to) {
-  from = exports.resolve(from).substr(1);
-  to = exports.resolve(to).substr(1);
+  from = exports.resolve(from).slice(1);
+  to = exports.resolve(to).slice(1);
 
   function trim(arr) {
     var start = 0;
@@ -165,7 +165,7 @@ exports.dirname = function(path) {
 
   if (dir) {
     // It has a dirname, strip trailing slash
-    dir = dir.substr(0, dir.length - 1);
+    dir = dir.slice(0, -1);
   }
 
   return root + dir;
@@ -174,8 +174,8 @@ exports.dirname = function(path) {
 exports.basename = function(path, ext) {
   var f = splitPath(path)[2];
   // TODO: make this comparison case-insensitive on windows?
-  if (ext && f.substr(-1 * ext.length) === ext) {
-    f = f.substr(0, f.length - ext.length);
+  if (ext && f.slice(-ext.length) === ext) {
+    f = f.slice(0, -ext.length);
   }
   return f;
 };
@@ -192,14 +192,3 @@ function filter(xs, f) {
   }
   return res;
 }
-
-// String.prototype.substr - negative index don't work in IE8
-var substr =
-  'ab'.substr(-1) === 'b'
-    ? function(str, start, len) {
-        return str.substr(start, len);
-      }
-    : function(str, start, len) {
-        if (start < 0) start = str.length + start;
-        return str.substr(start, len);
-      };

--- a/modules/querystring/index.js
+++ b/modules/querystring/index.js
@@ -63,8 +63,8 @@ function decode(qs, sep, eq, options) {
       v;
 
     if (idx >= 0) {
-      kstr = x.substr(0, idx);
-      vstr = x.substr(idx + 1);
+      kstr = x.slice(0, idx);
+      vstr = x.slice(idx + 1);
     } else {
       kstr = x;
       vstr = '';

--- a/modules/url/index.js
+++ b/modules/url/index.js
@@ -146,9 +146,9 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
       if (simplePath[2]) {
         this.search = simplePath[2];
         if (parseQueryString) {
-          this.query = querystring.parse(this.search.substr(1));
+          this.query = querystring.parse(this.search.slice(1));
         } else {
-          this.query = this.search.substr(1);
+          this.query = this.search.slice(1);
         }
       } else if (parseQueryString) {
         this.search = '';
@@ -163,7 +163,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
     proto = proto[0];
     var lowerProto = proto.toLowerCase();
     this.protocol = lowerProto;
-    rest = rest.substr(proto.length);
+    rest = rest.slice(proto.length);
   }
 
   // figure out if it's got a host
@@ -171,9 +171,9 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
   // resolution will treat //foo/bar as host=foo,path=bar because that's
   // how the browser resolves relative URLs.
   if (slashesDenoteHost || proto || rest.match(/^\/\/[^@\/]+@[^@\/]+/)) {
-    var slashes = rest.substr(0, 2) === '//';
+    var slashes = rest.slice(0, 2) === '//';
     if (slashes && !(proto && hostlessProtocol[proto])) {
-      rest = rest.substr(2);
+      rest = rest.slice(2);
       this.slashes = true;
     }
   }
@@ -304,7 +304,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
     // strip [ and ] from the hostname
     // the host field still retains them, though
     if (ipv6Hostname) {
-      this.hostname = this.hostname.substr(1, this.hostname.length - 2);
+      this.hostname = this.hostname.slice(1, -1);
       if (rest[0] !== '/') {
         rest = '/' + rest;
       }
@@ -332,13 +332,13 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
   var hash = rest.indexOf('#');
   if (hash !== -1) {
     // got a fragment string.
-    this.hash = rest.substr(hash);
+    this.hash = rest.slice(hash);
     rest = rest.slice(0, hash);
   }
   var qm = rest.indexOf('?');
   if (qm !== -1) {
-    this.search = rest.substr(qm);
-    this.query = rest.substr(qm + 1);
+    this.search = rest.slice(qm);
+    this.query = rest.slice(qm + 1);
     if (parseQueryString) {
       this.query = querystring.parse(this.query);
     }
@@ -405,7 +405,7 @@ Url.prototype.format = function() {
 
   var search = this.search || (query && '?' + query) || '';
 
-  if (protocol && protocol.substr(-1) !== ':') protocol += ':';
+  if (protocol && protocol.slice(-1) !== ':') protocol += ':';
 
   // only the slashedProtocols get the //.  Not mailto:, xmpp:, etc.
   // unless they had them to begin with.
@@ -652,7 +652,7 @@ Url.prototype.resolveObject = function(relative) {
     srcPath.unshift('');
   }
 
-  if (hasTrailingSlash && srcPath.join('/').substr(-1) !== '/') {
+  if (hasTrailingSlash && srcPath.join('/').slice(-1) !== '/') {
     srcPath.push('');
   }
 
@@ -700,9 +700,9 @@ Url.prototype.parseHost = function() {
   if (port) {
     port = port[0];
     if (port !== ':') {
-      this.port = port.substr(1);
+      this.port = port.slice(1);
     }
-    host = host.substr(0, host.length - port.length);
+    host = host.slice(0, -port.length);
   }
   if (host) this.hostname = host;
 };

--- a/modules/util/index.js
+++ b/modules/util/index.js
@@ -393,7 +393,7 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
 							return "  " + line;
 						})
 						.join("\n")
-						.substr(2);
+						.slice(2);
 				} else {
 					str =
 						"\n" +
@@ -415,7 +415,7 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
 		}
 		name = JSON.stringify("" + key);
 		if (name.match(/^"([a-zA-Z_][a-zA-Z_0-9]*)"$/)) {
-			name = name.substr(1, name.length - 2);
+			name = name.slice(1, -1);
 			name = ctx.stylize(name, "name");
 		} else {
 			name = name

--- a/src/compiler/playground/shit2.js
+++ b/src/compiler/playground/shit2.js
@@ -413,7 +413,7 @@ function formatError(text, obj, injectorErrorName, source) {
   if (source === void 0) {
     source = null;
   }
-  text = text && text.charAt(0) === "\n" && text.charAt(1) == NO_NEW_LINE ? text.substr(2) : text;
+  text = text && text.charAt(0) === "\n" && text.charAt(1) == NO_NEW_LINE ? text.slice(2) : text;
   var context = stringify(obj);
   if (obj instanceof Array) {
     context = obj.map(stringify).join(" -> ");
@@ -12763,12 +12763,12 @@ function i18nStartFirstPass(tView, index, message, subTemplateIndex) {
     if (i & 1) {
       if (value.charAt(0) === "/") {
         if (value.charAt(1) === "#") {
-          var phIndex = parseInt(value.substr(2), 10);
+          var phIndex = parseInt(value.slice(2), 10);
           parentIndex = parentIndexStack[--parentIndexPointer];
           createOpCodes.push(phIndex << 3 | 5);
         }
       } else {
-        var phIndex = parseInt(value.substr(1), 10);
+        var phIndex = parseInt(value.slice(1), 10);
         createOpCodes.push(phIndex << 3 | 0, parentIndex << 17 | 1);
         if (value.charAt(0) === "#") {
           parentIndexStack[++parentIndexPointer] = parentIndex = phIndex;

--- a/src/compilerOptions/typescriptReferences.ts
+++ b/src/compilerOptions/typescriptReferences.ts
@@ -223,7 +223,7 @@ function calculateInOutMap(rootDir: string, outDir: string, input: string): unde
     );
   }
   // strip the root part to get the relative part
-  const relInput = ninput.substr(nroot.length);
+  const relInput = ninput.slice(nroot.length);
   const { ext, stem } = parseTsExtension(relInput);
   const outExt = tsOutExts[ext] || ext;
   return (

--- a/website/versioned_docs/version-3.7.0/plugins/styled-components.md
+++ b/website/versioned_docs/version-3.7.0/plugins/styled-components.md
@@ -73,7 +73,7 @@ StyledComponentsPlugin({
       .replace(/^.*[\\\/]/, "")
       .match(/[a-z]+/gi)
       .map(function(word) {
-        return word.charAt(0).toUpperCase() + word.substr(1).toLowerCase();
+        return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
       })
       .join("")
       .replace("Tsx", "")


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.